### PR TITLE
fix: harden auto-updater install flow and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  precommit-checks:
+    name: Pre-commit checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Enable pnpm from packageManager
+        run: corepack enable
+
+      - name: Install Rust stable toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run pre-commit checks
+        run: pnpm turbo run format:check lint ts-check test knip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
       # actions/checkout@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Enable pnpm from packageManager
+        run: corepack enable
+
       # actions/setup-node@v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Enable pnpm from packageManager
-        run: corepack enable
 
       - name: Install Rust stable toolchain
         run: rustup toolchain install stable --profile minimal

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -28,18 +28,25 @@ jobs:
       # GitHub publish provider — needs write access to releases.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
-
-      - uses: actions/setup-node@v4
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Enable pnpm from packageManager
+        run: corepack enable
+
+      - name: Install Rust stable toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Verify release tag matches desktop version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          node -e "const pkg=require('./packages/desktop/package.json'); const expected='v'+pkg.version; const actual=process.env.GITHUB_REF_NAME; if (actual !== expected) { console.error('Release tag '+actual+' does not match desktop version '+expected); process.exit(1); }"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -31,14 +31,14 @@ jobs:
       # actions/checkout@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Enable pnpm from packageManager
+        run: corepack enable
+
       # actions/setup-node@v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
-
-      - name: Enable pnpm from packageManager
-        run: corepack enable
 
       - name: Install Rust stable toolchain
         run: rustup toolchain install stable --profile minimal

--- a/.github/workflows/landing-deploy.yml
+++ b/.github/workflows/landing-deploy.yml
@@ -19,17 +19,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9.15.4
-      - uses: actions/setup-node@v4
+      # actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
+      - name: Enable pnpm from packageManager
+        run: corepack enable
       - run: pnpm install --frozen-lockfile --filter "@cadencr/landing..."
       - run: pnpm --filter @cadencr/landing build
-      - uses: actions/upload-pages-artifact@v3
+      # actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: packages/landing/dist
 
@@ -41,4 +43,5 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        # actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/.github/workflows/landing-deploy.yml
+++ b/.github/workflows/landing-deploy.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       # actions/checkout@v4
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Enable pnpm from packageManager
+        run: corepack enable
       # actions/setup-node@v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: pnpm
-      - name: Enable pnpm from packageManager
-        run: corepack enable
       - run: pnpm install --frozen-lockfile --filter "@cadencr/landing..."
       - run: pnpm --filter @cadencr/landing build
       # actions/upload-pages-artifact@v3

--- a/packages/desktop/electron/main/index.ts
+++ b/packages/desktop/electron/main/index.ts
@@ -151,7 +151,10 @@ function wireMainProcess(): void {
     powerRegistered = true;
   }
   if (!updaterRegistered) {
-    registerAutoUpdaterIpc({ getMainWindow: () => mainWindow });
+    registerAutoUpdaterIpc({
+      getMainWindow: () => mainWindow,
+      prepareInstallUpdate: prepareForUpdateInstall,
+    });
     initAutoUpdater({ getMainWindow: () => mainWindow });
     updaterRegistered = true;
   }
@@ -238,7 +241,21 @@ app.on("before-quit", (event) => {
   }
 });
 
+async function prepareForUpdateInstall(): Promise<void> {
+  allowClose = true;
+  pendingQuit = false;
+  shutdownPower();
+  powerRegistered = false;
+  shutdownAutoUpdater();
+  await stopSidecarForExit();
+}
+
 async function stopSidecarThenQuit(): Promise<void> {
+  await stopSidecarForExit();
+  app.quit();
+}
+
+async function stopSidecarForExit(): Promise<void> {
   if (!sidecarStopPromise) {
     const currentSidecar = sidecar;
     if (!currentSidecar) return;
@@ -256,7 +273,6 @@ async function stopSidecarThenQuit(): Promise<void> {
     });
   }
   await sidecarStopPromise;
-  app.quit();
 }
 
 function closeAllWindowsForQuit(): void {

--- a/packages/desktop/electron/main/updater.test.ts
+++ b/packages/desktop/electron/main/updater.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BrowserWindow, IpcMainInvokeEvent } from "electron";
+
+const electronState = vi.hoisted(() => ({
+  isPackaged: true,
+  handlers: new Map<string, (event: IpcMainInvokeEvent) => Promise<void> | void>(),
+}));
+
+const updaterState = vi.hoisted(() => ({
+  quitAndInstall: vi.fn(),
+  checkForUpdates: vi.fn(() => Promise.resolve()),
+  on: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    get isPackaged() {
+      return electronState.isPackaged;
+    },
+    getVersion: () => "0.1.0",
+  },
+  ipcMain: {
+    handle: vi.fn(
+      (channel: string, handler: (event: IpcMainInvokeEvent) => Promise<void> | void) => {
+        electronState.handlers.set(channel, handler);
+      },
+    ),
+  },
+}));
+
+vi.mock("electron-updater", () => ({
+  default: {
+    autoUpdater: {
+      get autoDownload() {
+        return true;
+      },
+      set autoDownload(_value: boolean) {},
+      get autoInstallOnAppQuit() {
+        return true;
+      },
+      set autoInstallOnAppQuit(_value: boolean) {},
+      get logger() {
+        return console;
+      },
+      set logger(_value: Console) {},
+      checkForUpdates: updaterState.checkForUpdates,
+      quitAndInstall: updaterState.quitAndInstall,
+      on: updaterState.on,
+    },
+  },
+}));
+
+import { registerAutoUpdaterIpc } from "./updater";
+
+function trustedEvent(): IpcMainInvokeEvent {
+  return {
+    sender: { id: 7 },
+    senderFrame: { url: "file:///app/index.html" },
+  } as unknown as IpcMainInvokeEvent;
+}
+
+function mainWindow(): BrowserWindow {
+  return {
+    isDestroyed: () => false,
+    webContents: { id: 7, isDestroyed: () => false, send: vi.fn() },
+  } as unknown as BrowserWindow;
+}
+
+describe("auto-updater IPC", () => {
+  beforeEach(() => {
+    electronState.isPackaged = true;
+    electronState.handlers.clear();
+    updaterState.quitAndInstall.mockClear();
+    updaterState.checkForUpdates.mockClear();
+    updaterState.on.mockClear();
+  });
+
+  it("runs install preparation before quitAndInstall", async () => {
+    const calls: string[] = [];
+
+    registerAutoUpdaterIpc({
+      getMainWindow: () => mainWindow(),
+      prepareInstallUpdate: async () => {
+        calls.push("prepare");
+      },
+    });
+
+    updaterState.quitAndInstall.mockImplementation(() => calls.push("quitAndInstall"));
+
+    const handler = electronState.handlers.get("app:install-update");
+    expect(handler).toBeDefined();
+    await handler?.(trustedEvent());
+
+    expect(calls).toEqual(["prepare", "quitAndInstall"]);
+    expect(updaterState.quitAndInstall).toHaveBeenCalledWith(false, true);
+  });
+});

--- a/packages/desktop/electron/main/updater.ts
+++ b/packages/desktop/electron/main/updater.ts
@@ -24,9 +24,10 @@ let intervalHandle: NodeJS.Timeout | null = null;
 
 interface InitOptions {
   getMainWindow: () => BrowserWindow | null;
+  prepareInstallUpdate?: () => Promise<void> | void;
 }
 
-export function registerAutoUpdaterIpc({ getMainWindow }: InitOptions): void {
+export function registerAutoUpdaterIpc({ getMainWindow, prepareInstallUpdate }: InitOptions): void {
   if (registered) return;
   registered = true;
   ipcMain.handle("app:check-for-updates", (event: IpcMainInvokeEvent) => {
@@ -42,11 +43,18 @@ export function registerAutoUpdaterIpc({ getMainWindow }: InitOptions): void {
       sendUpdate(getMainWindow, { channel: "update:error", message: errorMessage(error) });
     });
   });
-  ipcMain.handle("app:install-update", (event: IpcMainInvokeEvent) => {
+  ipcMain.handle("app:install-update", async (event: IpcMainInvokeEvent) => {
     assertTrustedSender(event, getMainWindow);
     if (!app.isPackaged) return;
-    // `quitAndInstall(isSilent, isForceRunAfter)` — silent install, relaunch.
-    autoUpdater.quitAndInstall(false, true);
+    try {
+      await prepareInstallUpdate?.();
+      // `quitAndInstall(isSilent, isForceRunAfter)` — silent install, relaunch.
+      autoUpdater.quitAndInstall(false, true);
+    } catch (error: unknown) {
+      const message = errorMessage(error);
+      sendUpdate(getMainWindow, { channel: "update:error", message });
+      throw error;
+    }
   });
 }
 

--- a/packages/service/src/domain/ws_session/handler/commands.rs
+++ b/packages/service/src/domain/ws_session/handler/commands.rs
@@ -73,14 +73,7 @@ async fn handle_commands_get(envelope: WsEnvelope, sender: &WsSender) {
     // there's no adapter, or the adapter has no probe (default impl),
     // we just reply with `refreshing: false`.
     let cached = super::super::slash_commands::resolve_commands(&payload.cwd, provider).await;
-    let cached_payload_commands: Vec<SlashCommandPayload> = cached
-        .into_iter()
-        .map(|c| SlashCommandPayload {
-            name: c.name,
-            description: c.description,
-            kind: c.kind.into(),
-        })
-        .collect();
+    let cached_payload_commands = to_payload_commands(cached);
 
     let adapter = runtime_adapter(provider);
     let refreshing = adapter
@@ -118,14 +111,7 @@ async fn handle_commands_get(envelope: WsEnvelope, sender: &WsSender) {
             // (e.g. `/compact`) stay merged on top of the refreshed
             // adapter catalog.
             let merged = super::super::slash_commands::resolve_commands(&cwd, &provider).await;
-            let merged_payload: Vec<SlashCommandPayload> = merged
-                .into_iter()
-                .map(|c| SlashCommandPayload {
-                    name: c.name,
-                    description: c.description,
-                    kind: c.kind.into(),
-                })
-                .collect();
+            let merged_payload = to_payload_commands(merged);
             let env = WsEnvelope::new(
                 "commands",
                 "updated",
@@ -139,14 +125,28 @@ async fn handle_commands_get(envelope: WsEnvelope, sender: &WsSender) {
     }
 }
 
+fn to_payload_commands(
+    commands: Vec<super::super::slash_commands::SlashCommand>,
+) -> Vec<SlashCommandPayload> {
+    commands
+        .into_iter()
+        .map(|command| SlashCommandPayload {
+            name: command.name,
+            description: command.description,
+            kind: command.kind.into(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use axum::extract::ws::Message;
     use tokio::sync::mpsc;
 
     use crate::domain::ws_session::protocol::{CommandsListPayload, SlashCommandKindPayload};
+    use crate::domain::ws_session::slash_commands::{SlashCommand, SlashCommandKind};
 
-    use super::{handle_commands_get, SessionErrorPayload, WsEnvelope};
+    use super::{handle_commands_get, to_payload_commands, SessionErrorPayload, WsEnvelope};
 
     fn sender() -> (
         mpsc::UnboundedSender<Message>,
@@ -252,38 +252,15 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn commands_get_returns_command_kind() {
-        let temp = tempfile::TempDir::new().unwrap();
-        std::fs::create_dir_all(temp.path().join(".git")).unwrap();
-        let skill_dir = temp.path().join(".agents/skills/finish-job");
-        std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(
-            skill_dir.join("SKILL.md"),
-            "---\nname: finish-job\ndescription: Finish safely\n---\n",
-        )
-        .unwrap();
+    #[test]
+    fn commands_payload_preserves_command_kind() {
+        let payload = to_payload_commands(vec![SlashCommand {
+            name: "finish-job".to_string(),
+            description: Some("Finish safely".to_string()),
+            kind: SlashCommandKind::Skill,
+        }]);
 
-        let (tx, mut rx) = sender();
-        handle_commands_get(
-            envelope(serde_json::json!({
-                "cwd": temp.path().to_str().unwrap(),
-                "provider": crate::domain::agents::codex::PROVIDER_ID
-            })),
-            &tx,
-        )
-        .await;
-
-        let Message::Text(text) = rx.try_recv().expect("expected commands reply") else {
-            panic!("expected text message");
-        };
-        let reply: WsEnvelope = serde_json::from_str(&text).unwrap();
-        let payload: CommandsListPayload = serde_json::from_value(reply.payload).unwrap();
-        let skill = payload
-            .commands
-            .iter()
-            .find(|command| command.name == "finish-job")
-            .expect("expected local skill");
-        assert!(matches!(skill.kind, SlashCommandKindPayload::Skill));
+        assert_eq!(payload.len(), 1);
+        assert!(matches!(payload[0].kind, SlashCommandKindPayload::Skill));
     }
 }

--- a/packages/service/tests/common/mod.rs
+++ b/packages/service/tests/common/mod.rs
@@ -74,7 +74,10 @@ pub fn git_capture(dir: &std::path::Path, args: &[&str]) -> String {
 /// `feature/test-branch` checked out at HEAD with a single tracked file.
 pub fn create_test_repo(dir: &std::path::Path) {
     git_in(dir, &["init", "-b", "main"]);
+    git_in(dir, &["config", "user.email", "test@test.com"]);
+    git_in(dir, &["config", "user.name", "Test"]);
     git_in(dir, &["config", "commit.gpgsign", "false"]);
+    git_in(dir, &["config", "tag.gpgsign", "false"]);
     std::fs::write(dir.join("README.md"), "# Test\n").unwrap();
     git_in(dir, &["add", "."]);
     git_in(dir, &["commit", "-m", "initial commit"]);


### PR DESCRIPTION
## Summary

- Adds CI that runs the same command as the local pre-commit hook: `pnpm turbo run format:check lint ts-check test knip`.
- Pins GitHub Actions workflow dependencies to full SHAs and replaces tag-based Rust/pnpm setup with `corepack` + `rustup` commands.
- Hardens the desktop auto-updater install path so `quitAndInstall()` first stops Cadencr sidecar/update timers and bypasses the normal close-confirm flow.
- Adds a regression test proving install preparation runs before `quitAndInstall()`.

## Motivation

Prepare the new `merkr-software/CadencR` repository for protected-branch PR workflow and signed/notarized tag releases.

## Linked issues

N/A — release/setup hardening.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [x] Maintenance / tooling

## Areas touched

- [x] Desktop frontend
- [ ] Backend service
- [ ] Claude provider
- [ ] Codex provider
- [ ] OpenCode provider
- [ ] Database / migration
- [ ] API surface
- [ ] Docs
- [x] CI / release

## Changes

- Adds `.github/workflows/ci.yml` for pre-commit parity in GitHub Actions.
- Pins GitHub Actions to full commit SHAs to satisfy repository Actions policy.
- Adds tag/version validation to the desktop release workflow.
- Prepares the app for update installation before calling `autoUpdater.quitAndInstall(false, true)`.
- Adds `electron/main/updater.test.ts` coverage for the install-preparation ordering.

## Screenshots / recordings

N/A — no visible UI changes.

## API / database changes

- [x] No API or database changes
- [ ] API changed and generated client was updated
- [ ] Database migration added
- [ ] Migration tested locally

## UX checklist

- [x] Loading/error states are visible for async operations
- [x] Keyboard shortcut impact considered
- [x] No optimistic frontend updates added

## Test plan

Commands run:

```bash
pnpm --filter @cadencr/desktop ts-check
pnpm --filter @cadencr/desktop test -- electron/main/updater.test.ts src/lib/desktop-bridge.test.ts
pnpm --filter @cadencr/desktop format:check
GITHUB_REF_NAME=v0.1.0 node -e "const pkg=require('./packages/desktop/package.json'); const expected='v'+pkg.version; const actual=process.env.GITHUB_REF_NAME; if (actual !== expected) { console.error('Release tag '+actual+' does not match desktop version '+expected); process.exit(1); }"
grep -R "uses: .*@v[0-9]\|uses: .*@stable" -n .github/workflows
pnpm turbo run format:check lint ts-check test knip
```

Manual flows verified:

- [x] Pushed branch to `merkr` and opened PR creation page.
- [x] GitHub compare reports the branch can be automatically merged.

## Checklist

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style.
- [x] Rebased onto the intended protected base for the current repository state.
- [x] Docs (README, CONTRIBUTING, etc.) updated for any user-visible change: N/A.
