### PR TITLE
dev: add nix flake shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "Cadencr development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          darwinPackages = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.apple-sdk_15
+            pkgs.libiconv
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cargo-watch
+              git
+              nodejs_22
+              openssl
+              pkg-config
+              pnpm_9
+              rustup
+              sqlite
+            ] ++ darwinPackages;
+
+            RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+            COREPACK_ENABLE_DOWNLOAD_PROMPT = "0";
+
+            shellHook = ''
+              echo "Cadencr dev shell"
+              echo "Node: $(node --version)"
+              echo "pnpm: $(pnpm --version)"
+              if rustc --version >/dev/null 2>&1; then
+                echo "Rust: $(rustc --version)"
+              else
+                echo "Rust: install a toolchain with: rustup toolchain install stable --component rustfmt --component clippy"
+              fi
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary
- Add a project-level Nix flake dev shell with Node, pnpm, Rust tooling via rustup, SQLite, OpenSSL, and Darwin SDK dependencies.
- Keep the shell hook informative without failing when rustup has not installed a Rust toolchain yet.

## Tests
- `nix flake check`