### PR TITLE
fix(service): route GitHub Copilot models via OpenCode

### DIFF
--- a/packages/service/src/domain/agents/model_refs.rs
+++ b/packages/service/src/domain/agents/model_refs.rs
@@ -9,6 +9,7 @@ const OPENCODE_MODEL_PROVIDER_PREFIXES: &[&str] = &[
     "fireworks",
     "google",
     "groq",
+    "github-copilot",
     "mistral",
     "moonshot",
     "ollama",
@@ -41,6 +42,7 @@ mod tests {
     fn detects_provider_scoped_opencode_models() {
         assert!(is_opencode_model_ref("openai/gpt-5.4"));
         assert!(is_opencode_model_ref("anthropic/claude-sonnet-4-5"));
+        assert!(is_opencode_model_ref("github-copilot/claude-opus-4.6"));
         assert!(is_opencode_model_ref("default/default"));
     }
 

--- a/packages/service/src/domain/agents/providers/mod.rs
+++ b/packages/service/src/domain/agents/providers/mod.rs
@@ -178,6 +178,13 @@ mod tests {
     }
 
     #[test]
+    fn adapter_for_model_routes_github_copilot_refs_to_opencode() {
+        let (id, _) = adapter_for_model("github-copilot/claude-opus-4.6")
+            .expect("should find opencode adapter");
+        assert_eq!(id, "opencode");
+    }
+
+    #[test]
     fn adapter_for_model_routes_bare_gpt_models_to_codex() {
         let (id, _) = adapter_for_model("gpt-5.4").expect("should find codex adapter");
         assert_eq!(id, "codex_cli");
@@ -199,6 +206,15 @@ mod tests {
     #[test]
     fn resolve_effective_provider_reroutes_default_when_model_belongs_to_other_adapter() {
         let routed = resolve_effective_provider("claude_code".to_string(), Some("openai/gpt-5.4"));
+        assert_eq!(routed, "opencode");
+    }
+
+    #[test]
+    fn resolve_effective_provider_reroutes_default_for_github_copilot_models() {
+        let routed = resolve_effective_provider(
+            "claude_code".to_string(),
+            Some("github-copilot/claude-opus-4.6"),
+        );
         assert_eq!(routed, "opencode");
     }
 

--- a/packages/service/src/domain/agents/providers/opencode/mod.rs
+++ b/packages/service/src/domain/agents/providers/opencode/mod.rs
@@ -122,6 +122,7 @@ fn catalog_from_response(
 fn provider_display_label(provider_id: &str) -> String {
     match provider_id {
         "opencode" => "OpenCode".to_string(),
+        "github-copilot" => "GitHub Copilot".to_string(),
         "openai" => "OpenAI".to_string(),
         _ => provider_id.to_string(),
     }
@@ -276,6 +277,28 @@ mod tests {
             .find(|model| model.id == "openai/gpt-5.4")
             .expect("gpt-5.4 entry");
         assert_eq!(model.label, "OpenAI: GPT-5.4");
+    }
+
+    #[test]
+    fn catalog_from_response_labels_github_copilot_without_wire_name() {
+        let response = parse(json!({
+            "providers": [
+                {
+                    "id": "github-copilot",
+                    "models": {
+                        "claude-opus-4.6": { "name": "Claude Opus 4.6" }
+                    }
+                }
+            ],
+            "default": { "github-copilot": "claude-opus-4.6" }
+        }));
+        let (catalog, _) = catalog_from_response(response);
+        let model = catalog
+            .models
+            .iter()
+            .find(|model| model.id == "github-copilot/claude-opus-4.6")
+            .expect("copilot opus entry");
+        assert_eq!(model.label, "GitHub Copilot: Claude Opus 4.6");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Recognize `github-copilot/...` model refs as OpenCode-backed models.
- Route Copilot Opus selections through OpenCode instead of Claude Code.
- Label GitHub Copilot models cleanly in the OpenCode catalog.

## Tests
- `cargo test -p cadencr-service model_refs`
- `cargo test -p cadencr-service providers::tests`
- `cargo test -p cadencr-service github_copilot`