### PR TITLE
fix(service): show working status before runtime spawn

### DIFF
--- a/packages/service/src/domain/ws_session/handler/mod.rs
+++ b/packages/service/src/domain/ws_session/handler/mod.rs
@@ -553,6 +553,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_first_prompt_broadcasts_agent_before_runtime_spawn() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sdk_sessions: SdkSessions = Arc::new(Mutex::new(HashMap::new()));
+        let app_state = make_test_app_state().await;
+        let missing_cwd = "/tmp/cadencr-test-missing-runtime-cwd";
+        let _ = tokio::fs::remove_dir_all(missing_cwd).await;
+        let session_id = init_session_with_payload(
+            &tx,
+            &mut rx,
+            &sdk_sessions,
+            &app_state,
+            SessionInitPayload {
+                provider: Some(crate::domain::agents::runtime::DEFAULT_PROVIDER.to_string()),
+                model: None,
+                thinking_effort: None,
+                permission_mode: None,
+                system_prompt: None,
+                cwd: Some(missing_cwd.to_string()),
+                feature_id: Some(1),
+            },
+        )
+        .await;
+        let db_id: i64 = session_id.parse().unwrap();
+        let mut status_rx = app_state.session_status_tx.subscribe();
+
+        let envelope = make_envelope(
+            "session",
+            "prompt.send",
+            serde_json::json!({
+                "session_id": session_id,
+                "text": "start working",
+            }),
+        );
+        dispatch_envelope(envelope, &tx, &sdk_sessions, &app_state).await;
+
+        let status_event =
+            tokio::time::timeout(std::time::Duration::from_secs(2), status_rx.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        assert_eq!(status_event.session_id, db_id);
+        assert_eq!(
+            status_event.status,
+            crate::domain::session_status::AgentStatus::Agent
+        );
+    }
+
+    #[tokio::test]
     async fn test_init_missing_feature_id_returns_error() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let sdk_sessions: SdkSessions = Arc::new(Mutex::new(HashMap::new()));
@@ -1381,6 +1429,7 @@ mod tests {
         let session_id = init_session(&tx, &mut rx, &sdk_sessions, &app_state, 1).await;
         let db_id: i64 = session_id.parse().unwrap();
         let release = Arc::new(tokio::sync::Notify::new());
+        let mut status_rx = app_state.session_status_tx.subscribe();
 
         {
             let mut sessions = sdk_sessions.lock().await;
@@ -1413,6 +1462,13 @@ mod tests {
         assert!(
             result.is_ok(),
             "follow-up prompt handling must return without waiting for the provider turn"
+        );
+
+        let status_event = status_rx.recv().await.unwrap();
+        assert_eq!(status_event.session_id, db_id);
+        assert_eq!(
+            status_event.status,
+            crate::domain::session_status::AgentStatus::Agent
         );
     }
 

--- a/packages/service/src/domain/ws_session/handler/session_prompt/prompt_send.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/prompt_send.rs
@@ -180,6 +180,32 @@ pub(crate) async fn handle_prompt_send(
                 );
                 p.persist_user_message(&persist_content).await;
             }
+            let adapter = match runtime_adapter(&provider_id) {
+                Some(adapter) => adapter,
+                None => {
+                    let message =
+                        format!("No runtime adapter registered for provider '{provider_id}'");
+                    persist_pause_and_send_session_error(
+                        &write_pool,
+                        &app_state.session_status_tx,
+                        sender,
+                        &envelope.id,
+                        feature_id,
+                        db_session_id,
+                        "UNSUPPORTED_PROVIDER",
+                        &message,
+                    )
+                    .await;
+                    return;
+                }
+            };
+            mark_agent_running(
+                &write_pool,
+                &app_state.session_status_tx,
+                db_session_id,
+                feature_id,
+            )
+            .await;
 
             // Worktree creation (blocking) — must complete before runtime spawn.
             let use_worktree = payload.use_worktree.unwrap_or(false);
@@ -254,26 +280,6 @@ pub(crate) async fn handle_prompt_send(
             // Set up permission bridge.
             let (permission_tx, permission_rx) = mpsc::channel::<PermissionResponse>(16);
             let content_value = build_content_value(&payload.text, &payload.images);
-            let adapter = match runtime_adapter(&provider_id) {
-                Some(adapter) => adapter,
-                None => {
-                    let message =
-                        format!("No runtime adapter registered for provider '{provider_id}'");
-                    persist_pause_and_send_session_error(
-                        &write_pool,
-                        &app_state.session_status_tx,
-                        sender,
-                        &envelope.id,
-                        feature_id,
-                        db_session_id,
-                        "UNSUPPORTED_PROVIDER",
-                        &message,
-                    )
-                    .await;
-                    return;
-                }
-            };
-
             let bridge = WsBridgeCanUseTool {
                 sender: sender.clone(),
                 response_rx: Arc::new(Mutex::new(permission_rx)),
@@ -309,8 +315,6 @@ pub(crate) async fn handle_prompt_send(
                         db_session_id,
                         "runtime query spawned successfully, starting stream reader"
                     );
-                    WsSessionPersistence::mark_running_static(&app_state.write_pool, db_session_id)
-                        .await;
                     let provider_context_window = runtime_session.context_window();
                     let runtime_control_endpoint = runtime_session.runtime_control_endpoint();
                     if let Some(cw) = provider_context_window {
@@ -321,13 +325,6 @@ pub(crate) async fn handle_prompt_send(
                         )
                         .await;
                     }
-                    WsSessionPersistence::broadcast_session_status(
-                        &app_state.session_status_tx,
-                        db_session_id,
-                        feature_id,
-                        crate::domain::session_status::AgentStatus::Agent,
-                        None,
-                    );
                     let message_rx = runtime_session.take_message_rx();
                     let query_arc = Arc::new(tokio::sync::RwLock::new(runtime_session));
 
@@ -447,14 +444,7 @@ pub(crate) async fn handle_prompt_send(
             // writes, turn 1's `mark_completed_static` + `"none"` tombstone
             // from `stream_reader.rs:191-197` stay sticky across the second
             // prompt and the UI never shows the agent is alive again.
-            WsSessionPersistence::mark_running_static(&write_pool, db_session_id).await;
-            WsSessionPersistence::broadcast_session_status(
-                &session_status_tx,
-                db_session_id,
-                feature_id,
-                crate::domain::session_status::AgentStatus::Agent,
-                None,
-            );
+            mark_agent_running(&write_pool, &session_status_tx, db_session_id, feature_id).await;
 
             info!(db_session_id, "follow-up prompt");
             let content = build_content_value(&payload.text, &payload.images);
@@ -490,4 +480,20 @@ pub(crate) async fn handle_prompt_send(
             });
         }
     }
+}
+
+async fn mark_agent_running(
+    write_pool: &sqlx::SqlitePool,
+    session_status_tx: &crate::domain::session_status::SessionStatusBroadcaster,
+    db_session_id: i64,
+    feature_id: i64,
+) {
+    WsSessionPersistence::mark_running_static(write_pool, db_session_id).await;
+    WsSessionPersistence::broadcast_session_status(
+        session_status_tx,
+        db_session_id,
+        feature_id,
+        crate::domain::session_status::AgentStatus::Agent,
+        None,
+    );
 }


### PR DESCRIPTION
## Summary
- Mark a session as working as soon as the backend accepts and persists the first prompt.
- Avoid UI delay while OpenCode ACP startup, worktree setup, or runtime spawn is still happening.
- Reuse the same running-status helper for follow-up prompts.

## Tests
- `cargo fmt --check`
- `cargo test -p cadencr-service prompt_send`