### PR TITLE
feat(opencode): cycle custom agents with Shift Tab

### DIFF
--- a/packages/desktop/src/api/agentRuntime.ts
+++ b/packages/desktop/src/api/agentRuntime.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { customInstance } from "./client";
 import { AGENT_TYPES, DEFAULT_PROVIDER, type AgentTypeSetting } from "../shared/models";
+import type { PermissionMode } from "@/types/permission-mode";
 
 export interface RuntimeModelOption {
   id: string;
@@ -19,7 +20,14 @@ export interface RuntimeProviderOption {
   status: "available" | "unavailable" | "coming_soon";
   status_message?: string;
   models: RuntimeModelOption[];
+  modes?: RuntimeProviderModeOption[];
   default_model: string | null;
+}
+
+export interface RuntimeProviderModeOption {
+  id: PermissionMode;
+  label: string;
+  description?: string;
 }
 
 export interface AgentCatalog {
@@ -43,6 +51,7 @@ function defaultProviderSettings(): ProviderSettings {
 interface QueryExtras {
   enabled?: boolean;
   staleTime?: number;
+  cwd?: string;
 }
 
 function readQueryExtras(arg: boolean | QueryExtras | undefined): QueryExtras {
@@ -52,10 +61,16 @@ function readQueryExtras(arg: boolean | QueryExtras | undefined): QueryExtras {
 }
 
 export function useAgentCatalog(extras?: QueryExtras) {
+  const { cwd, ...queryExtras } = extras ?? {};
   return useQuery({
-    queryKey: ["agent-catalog"],
-    queryFn: () => customInstance<AgentCatalog>({ method: "GET", url: "/api/agent-catalog" }),
-    ...extras,
+    queryKey: ["agent-catalog", cwd ?? null],
+    queryFn: () =>
+      customInstance<AgentCatalog>({
+        method: "GET",
+        url: "/api/agent-catalog",
+        params: cwd ? { cwd } : undefined,
+      }),
+    ...queryExtras,
   });
 }
 

--- a/packages/desktop/src/api/generated/index.ts
+++ b/packages/desktop/src/api/generated/index.ts
@@ -926,6 +926,7 @@ export interface ProviderCatalogEntry {
   id: string;
   label: string;
   models: ModelCatalogEntry[];
+  modes?: ProviderModeCatalogEntry[];
   status: ProviderStatus;
   status_message?: ProviderCatalogEntryStatusMessage;
 }
@@ -943,6 +944,14 @@ export interface ProviderDiscovery {
   /** User-set override path persisted in settings. `None` if unset. */
   override_path?: ProviderDiscoveryOverridePath;
   selected?: ProviderDiscoverySelected;
+}
+
+export type ProviderModeCatalogEntryDescription = string | null;
+
+export interface ProviderModeCatalogEntry {
+  description?: ProviderModeCatalogEntryDescription;
+  id: string;
+  label: string;
 }
 
 export interface ProviderSettings {
@@ -1354,6 +1363,13 @@ export interface WriteFileResponse {
   success: boolean;
 }
 
+export type GetAgentCatalogParams = {
+  /**
+   * Workspace path used to discover project-local provider modes
+   */
+  cwd?: string;
+};
+
 export type GetUnifiedAgentsParams = {
   mode?: null | UnifiedAgentsMode;
   fresh_minutes?: number | null;
@@ -1585,26 +1601,32 @@ export type ListProjectWorktreesParams = {
   project_id: number;
 };
 
-export const getAgentCatalog = (signal?: AbortSignal) => {
-  return customInstance<AgentCatalogResponse>({ url: `/api/agent-catalog`, method: "GET", signal });
+export const getAgentCatalog = (params?: GetAgentCatalogParams, signal?: AbortSignal) => {
+  return customInstance<AgentCatalogResponse>({
+    url: `/api/agent-catalog`,
+    method: "GET",
+    params,
+    signal,
+  });
 };
 
-export const getGetAgentCatalogQueryKey = () => {
-  return [`/api/agent-catalog`] as const;
+export const getGetAgentCatalogQueryKey = (params?: GetAgentCatalogParams) => {
+  return [`/api/agent-catalog`, ...(params ? [params] : [])] as const;
 };
 
 export const getGetAgentCatalogQueryOptions = <
   TData = Awaited<ReturnType<typeof getAgentCatalog>>,
   TError = ErrorType<unknown>,
->(options?: {
-  query?: UseQueryOptions<Awaited<ReturnType<typeof getAgentCatalog>>, TError, TData>;
-}) => {
+>(
+  params?: GetAgentCatalogParams,
+  options?: { query?: UseQueryOptions<Awaited<ReturnType<typeof getAgentCatalog>>, TError, TData> },
+) => {
   const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGetAgentCatalogQueryKey();
+  const queryKey = queryOptions?.queryKey ?? getGetAgentCatalogQueryKey(params);
 
   const queryFn: QueryFunction<Awaited<ReturnType<typeof getAgentCatalog>>> = ({ signal }) =>
-    getAgentCatalog(signal);
+    getAgentCatalog(params, signal);
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
     Awaited<ReturnType<typeof getAgentCatalog>>,
@@ -1619,10 +1641,11 @@ export type GetAgentCatalogQueryError = ErrorType<unknown>;
 export function useGetAgentCatalog<
   TData = Awaited<ReturnType<typeof getAgentCatalog>>,
   TError = ErrorType<unknown>,
->(options?: {
-  query?: UseQueryOptions<Awaited<ReturnType<typeof getAgentCatalog>>, TError, TData>;
-}): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-  const queryOptions = getGetAgentCatalogQueryOptions(options);
+>(
+  params?: GetAgentCatalogParams,
+  options?: { query?: UseQueryOptions<Awaited<ReturnType<typeof getAgentCatalog>>, TError, TData> },
+): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+  const queryOptions = getGetAgentCatalogQueryOptions(params, options);
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & { queryKey: QueryKey };
 

--- a/packages/desktop/src/components/WebSocketSessionFeatureBlock.tsx
+++ b/packages/desktop/src/components/WebSocketSessionFeatureBlock.tsx
@@ -85,7 +85,7 @@ function WebSocketSessionFeatureBody(
     gitMetadataEnabled: !embedded || gitVisible,
     projectLookupEnabled: !embedded,
   });
-  const controls = useSessionControls(sessionId, featureId, projectId, cwd, data.featureSettings, {
+  const controls = useSessionControls(sessionId, featureId, projectId, data.effectiveCwd, {
     loadPersistedState: !embedded,
   });
   const refs = useSessionRefs();

--- a/packages/desktop/src/components/WebSocketSessionFeatureBlockHooks.tsx
+++ b/packages/desktop/src/components/WebSocketSessionFeatureBlockHooks.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { AgentSessionHandle } from "@/components/agent-session";
 import type { FeatureTerminalTabHandle } from "@/components/FeatureTerminalTab";
-import { useAgentCatalog } from "@/api/agentRuntime";
+import { useAgentCatalog, type RuntimeProviderModeOption } from "@/api/agentRuntime";
 import {
   useGetBranch,
   useGetFeatureSettings,
@@ -75,9 +75,12 @@ interface SessionControls {
   activeProviderId: string;
   supportedThinkingEfforts: ReturnType<typeof supportedThinkingEffortLevels>;
   enabledOptInModes: PermissionMode[];
+  providerModes: readonly RuntimeProviderModeOption[];
   handlePermissionModeToggle: () => void;
   initialCwd: string;
 }
+
+const EMPTY_PROVIDER_MODES: readonly RuntimeProviderModeOption[] = [];
 
 export function useSessionRefs(): SessionRefs {
   const agent = useRef<AgentSessionHandle>(null);
@@ -176,8 +179,7 @@ export function useSessionControls(
   sessionId: string,
   featureId: number,
   projectId: number,
-  cwd: string,
-  featureSettings: Record<string, string>,
+  effectiveCwd: string,
   options?: { loadPersistedState?: boolean },
 ): SessionControls {
   const ws = useWebSocketSession(sessionId, featureId, {
@@ -191,7 +193,7 @@ export function useSessionControls(
   const setProjectSetting = useSetProjectSetting();
   const defaultWorktreeMode = defaultWorktreeModeFromSettings(projectSettingsData, "skip");
   const { resolveModel, resolveProvider, resolveModelThinkingEffort } = useResolvedModelContext();
-  const agentCatalog = useAgentCatalog();
+  const agentCatalog = useAgentCatalog({ cwd: effectiveCwd, staleTime: 30_000 });
   const resolvedProviderId = resolveProvider("session");
   const resolvedModelId = resolveModel("session");
   const resolvedThinkingEffort = resolveModelThinkingEffort(resolvedProviderId, resolvedModelId);
@@ -201,10 +203,14 @@ export function useSessionControls(
     ?.models.find((model) => model.id === (ws.currentModelId || resolvedModelId));
   const supportedThinkingEfforts = supportedThinkingEffortLevels(activeSessionModel);
   const enabledOptInModes = useEnabledOptInModes(activeProviderId);
+  const providerModes =
+    agentCatalog.data?.providers.find((provider) => provider.id === activeProviderId)?.modes ??
+    EMPTY_PROVIDER_MODES;
   const handlePermissionModeToggle = usePermissionModeToggle(
     sessionId,
     activeProviderId,
     enabledOptInModes,
+    providerModes,
   );
   useEffect(() => {
     if (projectSettingsData == null || worktreeDefaultProjectRef.current === projectId) return;
@@ -244,15 +250,15 @@ export function useSessionControls(
       activeProviderId,
       supportedThinkingEfforts,
       enabledOptInModes,
+      providerModes,
       handlePermissionModeToggle,
-      initialCwd: featureSettings.worktree_path ?? cwd,
+      initialCwd: effectiveCwd,
     }),
     [
       activeProviderId,
       agentCatalog,
-      cwd,
+      effectiveCwd,
       enabledOptInModes,
-      featureSettings.worktree_path,
       handlePermissionModeToggle,
       initializedRef,
       resolveModelThinkingEffort,
@@ -260,6 +266,7 @@ export function useSessionControls(
       resolvedProviderId,
       resolvedThinkingEffort,
       selectedBranch,
+      providerModes,
       supportedThinkingEfforts,
       toggleWorktree,
       useWorktree,
@@ -272,14 +279,20 @@ function usePermissionModeToggle(
   sessionId: string,
   activeProviderId: string,
   enabledOptInModes: PermissionMode[],
+  providerModes: readonly RuntimeProviderModeOption[],
 ): () => void {
   return useCallback((): void => {
     const store = useWsSessionStore.getState();
     const session = store.sessions[sessionId];
     if (!session) return;
-    const next = nextProviderMode(activeProviderId, session.permissionMode, enabledOptInModes);
+    const next = nextProviderMode(
+      activeProviderId,
+      session.permissionMode,
+      enabledOptInModes,
+      providerModes ?? [],
+    );
     if (next !== session.permissionMode) store.setPermissionMode(sessionId, next);
-  }, [activeProviderId, enabledOptInModes, sessionId]);
+  }, [activeProviderId, enabledOptInModes, providerModes, sessionId]);
 }
 
 export function useWsSessionEffects(args: {

--- a/packages/desktop/src/components/WebSocketSessionFeatureBlockTabs.tsx
+++ b/packages/desktop/src/components/WebSocketSessionFeatureBlockTabs.tsx
@@ -103,6 +103,8 @@ function useAgentTab(args: UseSessionTabsArgs): FeatureTabDef {
           onAnswerSubmit={controls.ws.respondToQuestion}
           permissionMode={controls.ws.permissionMode}
           enabledOptInModes={controls.enabledOptInModes}
+          providerModes={controls.providerModes}
+          agentCatalog={controls.agentCatalog}
           onPermissionModeToggle={controls.handlePermissionModeToggle}
           pendingPlanApproval={controls.ws.pendingPlanApproval}
           onPlanApprove={controls.ws.approvePlan}

--- a/packages/desktop/src/components/agent-session/AgentSession.tsx
+++ b/packages/desktop/src/components/agent-session/AgentSession.tsx
@@ -82,6 +82,8 @@ export const AgentSession = memo(
       permissionMode,
       onPermissionModeToggle,
       enabledOptInModes,
+      providerModes,
+      agentCatalog: providedAgentCatalog,
       pendingPlanApproval,
       planApproveLabel,
       planApprovalError,
@@ -128,7 +130,8 @@ export const AgentSession = memo(
     const containerRef = useRef<HTMLDivElement>(null);
     const headerRef = useRef<HTMLDivElement>(null);
 
-    const agentCatalog = useAgentCatalog();
+    const fallbackAgentCatalog = useAgentCatalog({ enabled: providedAgentCatalog == null });
+    const agentCatalog = providedAgentCatalog ?? fallbackAgentCatalog;
     const cwdQuery = useGetFeatureWorkingDir(
       featureId ?? 0,
       { project_id: projectId ?? 0 },
@@ -298,6 +301,7 @@ export const AgentSession = memo(
         permissionMode={permissionMode}
         onPermissionModeToggle={onPermissionModeToggle}
         enabledOptInModes={enabledOptInModes}
+        providerModes={providerModes}
         showWorktreeChip={showWorktreeChip}
         useWorktree={useWorktree}
         onToggleWorktree={onToggleWorktree}

--- a/packages/desktop/src/components/agent-session/MetaBar.tsx
+++ b/packages/desktop/src/components/agent-session/MetaBar.tsx
@@ -10,6 +10,7 @@ import type { TodoItem } from "@/types/agent";
 import type { ThinkingEffortLevel } from "@/shared/thinking-effort";
 import { findProviderMode, getVisibleModes } from "@/lib/provider-modes";
 import type { PermissionMode } from "@/types/permission-mode";
+import type { RuntimeProviderModeOption } from "@/api/agentRuntime";
 import { ModelMetaChip, type Model, type Provider } from "./ModelMetaChip";
 import { META_BAR_CHIP, WORKTREE_ACTIVE_CHIP } from "./meta-bar-chip-styles";
 
@@ -27,6 +28,7 @@ export interface MetaBarProps {
    * appear here.
    */
   enabledOptInModes?: PermissionMode[];
+  providerModes?: readonly RuntimeProviderModeOption[];
   showWorktreeChip: boolean;
   useWorktree?: boolean;
   onToggleWorktree?: () => void;
@@ -94,6 +96,7 @@ export const MetaBar = forwardRef<MetaBarHandle, MetaBarProps>(function MetaBar(
     permissionMode,
     onPermissionModeToggle,
     enabledOptInModes,
+    providerModes = [],
     showWorktreeChip,
     useWorktree,
     onToggleWorktree,
@@ -159,10 +162,10 @@ export const MetaBar = forwardRef<MetaBarHandle, MetaBarProps>(function MetaBar(
   // Hide the chip when the provider can't cycle (< 2 visible modes).
   const activeMode = useMemo(() => {
     if (!onPermissionModeToggle || !permissionMode) return null;
-    const visibleModes = getVisibleModes(displayProviderId, enabledOptInModes ?? []);
+    const visibleModes = getVisibleModes(displayProviderId, enabledOptInModes ?? [], providerModes);
     if (visibleModes.length < 2) return null;
-    return findProviderMode(displayProviderId, permissionMode) ?? visibleModes[0];
-  }, [displayProviderId, enabledOptInModes, onPermissionModeToggle, permissionMode]);
+    return findProviderMode(displayProviderId, permissionMode, providerModes) ?? visibleModes[0];
+  }, [displayProviderId, enabledOptInModes, onPermissionModeToggle, permissionMode, providerModes]);
 
   const isStandalone = variant === "standalone";
   const shouldShowModel = !!onModelChange || showReadOnlyModel;

--- a/packages/desktop/src/components/agent-session/types.ts
+++ b/packages/desktop/src/components/agent-session/types.ts
@@ -12,6 +12,8 @@ import type { LiveAgentStatus as AgentStatus } from "@/types/agent";
 import type { SlashCommand } from "@/hooks/useSlashCommand";
 import type { ThinkingEffortLevel } from "@/shared/thinking-effort";
 import type { PermissionMode } from "@/types/permission-mode";
+import type { RuntimeProviderModeOption } from "@/api/agentRuntime";
+import type { AgentCatalog } from "@/api/agentRuntime";
 import type { TurnLifecycle } from "@/stores/ws-turn-lifecycle";
 import type { TurnTimingState } from "@/stores/ws-turn-timing";
 
@@ -94,6 +96,9 @@ export interface AgentSessionProps {
    * `codex_full_access_enabled` workspace settings.
    */
   enabledOptInModes?: PermissionMode[];
+  providerModes?: readonly RuntimeProviderModeOption[];
+  /** Optional catalog query supplied by parents that already fetched it. */
+  agentCatalog?: { data?: AgentCatalog };
   /** Pending plan approval from ExitPlanMode tool call */
   pendingPlanApproval?: {
     allowedPrompts?: Array<{ tool: string; prompt: string }>;

--- a/packages/desktop/src/lib/provider-modes.test.ts
+++ b/packages/desktop/src/lib/provider-modes.test.ts
@@ -57,6 +57,23 @@ describe("getVisibleModes", () => {
     const visible = getVisibleModes(PROVIDER_IDS.OPENCODE, ["bypassPermissions"]);
     expect(visible.map((m) => m.id)).toEqual(["acceptEdits", "plan"]);
   });
+
+  it("adds project OpenCode agents to visible modes", () => {
+    const catalogModes = [
+      { id: "opencodeAgent:documentor" as const, label: "documentor" },
+      { id: "opencodeAgent:scenario-builder" as const, label: "scenario-builder" },
+    ];
+    const visible = getVisibleModes(PROVIDER_IDS.OPENCODE, [], catalogModes);
+    expect(visible.map((m) => m.id)).toEqual([
+      "acceptEdits",
+      "plan",
+      "opencodeAgent:documentor",
+      "opencodeAgent:scenario-builder",
+    ]);
+    expect(
+      findProviderMode(PROVIDER_IDS.OPENCODE, "opencodeAgent:documentor", catalogModes)?.label,
+    ).toBe("documentor");
+  });
 });
 
 describe("nextProviderMode (cycle)", () => {
@@ -78,6 +95,16 @@ describe("nextProviderMode (cycle)", () => {
   it("two-mode toggle for OpenCode", () => {
     expect(nextProviderMode(PROVIDER_IDS.OPENCODE, "acceptEdits", [])).toBe("plan");
     expect(nextProviderMode(PROVIDER_IDS.OPENCODE, "plan", [])).toBe("acceptEdits");
+  });
+
+  it("cycles through OpenCode custom agents", () => {
+    const customModes = [{ id: "opencodeAgent:documentor" as const, label: "documentor" }];
+    expect(nextProviderMode(PROVIDER_IDS.OPENCODE, "plan", [], customModes)).toBe(
+      "opencodeAgent:documentor",
+    );
+    expect(
+      nextProviderMode(PROVIDER_IDS.OPENCODE, "opencodeAgent:documentor", [], customModes),
+    ).toBe("acceptEdits");
   });
 
   it("Codex cycle: default → plan → [full access] → wrap", () => {

--- a/packages/desktop/src/lib/provider-modes.ts
+++ b/packages/desktop/src/lib/provider-modes.ts
@@ -7,6 +7,7 @@
  */
 import {
   ClipboardList,
+  Bot,
   FileEditIcon,
   Hammer,
   ShieldOff,
@@ -16,6 +17,7 @@ import {
 } from "lucide-react";
 
 import { PROVIDER_IDS, type ProviderId } from "./providers";
+import type { RuntimeProviderModeOption } from "@/api/agentRuntime";
 import type { PermissionMode } from "@/types/permission-mode";
 
 export interface ProviderMode {
@@ -135,11 +137,26 @@ export const PROVIDER_MODES: Record<ProviderId, ProviderMode[]> = {
  * the chip hides via the standard < 2 visible-modes gate in MetaBar — better
  * than masquerading as a Claude session with Claude colors and labels.
  */
-export function getProviderModes(providerId?: string | null): ProviderMode[] {
+export function getProviderModes(
+  providerId?: string | null,
+  catalogModes: readonly RuntimeProviderModeOption[] = [],
+): ProviderMode[] {
   if (providerId && providerId in PROVIDER_MODES) {
-    return PROVIDER_MODES[providerId as ProviderId];
+    const modes = PROVIDER_MODES[providerId as ProviderId];
+    if (providerId !== PROVIDER_IDS.OPENCODE || catalogModes.length === 0) return modes;
+    return [...modes, ...catalogModes.map(opencodeCatalogMode)];
   }
   return [];
+}
+
+function opencodeCatalogMode(mode: RuntimeProviderModeOption): ProviderMode {
+  return {
+    id: mode.id,
+    label: mode.label,
+    icon: Bot,
+    chipClass: "bg-[var(--acc-cyan)]/15 text-[var(--acc-cyan)] hover:bg-[var(--acc-cyan)]/25",
+    description: mode.description ?? `Use the OpenCode ${mode.label} agent.`,
+  };
 }
 
 /**
@@ -150,8 +167,9 @@ export function getProviderModes(providerId?: string | null): ProviderMode[] {
 export function getVisibleModes(
   providerId: string | null | undefined,
   enabledOptInIds: PermissionMode[] = [],
+  catalogModes: readonly RuntimeProviderModeOption[] = [],
 ): ProviderMode[] {
-  return getProviderModes(providerId).filter(
+  return getProviderModes(providerId, catalogModes).filter(
     (mode) => !mode.optIn || enabledOptInIds.includes(mode.id),
   );
 }
@@ -164,8 +182,9 @@ export function getVisibleModes(
 export function findProviderMode(
   providerId: string | null | undefined,
   modeId: PermissionMode,
+  catalogModes: readonly RuntimeProviderModeOption[] = [],
 ): ProviderMode | null {
-  return getProviderModes(providerId).find((m) => m.id === modeId) ?? null;
+  return getProviderModes(providerId, catalogModes).find((m) => m.id === modeId) ?? null;
 }
 
 /**
@@ -191,8 +210,9 @@ export function nextProviderMode(
   providerId: string | null | undefined,
   current: PermissionMode,
   enabledOptInIds: PermissionMode[] = [],
+  catalogModes: readonly RuntimeProviderModeOption[] = [],
 ): PermissionMode {
-  const visible = getVisibleModes(providerId, enabledOptInIds);
+  const visible = getVisibleModes(providerId, enabledOptInIds, catalogModes);
   if (visible.length < 2) return current;
   const idx = visible.findIndex((m) => m.id === current);
   if (idx === -1) return visible[0].id;

--- a/packages/desktop/src/stores/ws-envelope-handler.test.ts
+++ b/packages/desktop/src/stores/ws-envelope-handler.test.ts
@@ -128,6 +128,21 @@ describe("handleEnvelope mode.changed", () => {
 
     expect(ctx.getSession("s1").permissionMode).toBe("acceptEdits");
   });
+
+  it("accepts project-scoped OpenCode agent modes", () => {
+    const session = createSessionEntry();
+    session.currentProviderId = "opencode";
+    session.permissionMode = "acceptEdits";
+    const ctx = createTestContext(session);
+
+    handleEnvelope(ctx, "s1", {
+      domain: "session",
+      action: "mode.changed",
+      payload: { mode: "opencodeAgent:documentor" },
+    });
+
+    expect(ctx.getSession("s1").permissionMode).toBe("opencodeAgent:documentor");
+  });
 });
 
 describe("handleEnvelope provider.set.ok", () => {

--- a/packages/desktop/src/stores/ws-envelope-handler.ts
+++ b/packages/desktop/src/stores/ws-envelope-handler.ts
@@ -44,7 +44,11 @@ import { updateSession } from "./ws-session-types";
 import { transitionTurn, type TurnTerminalReason } from "./ws-turn-lifecycle";
 import { findProviderMode, nextProviderMode } from "@/lib/provider-modes";
 import { getEnabledOptInModesFromCache } from "@/hooks/useEnabledOptInModes";
-import type { PermissionMode } from "@/types/permission-mode";
+import {
+  OPENCODE_AGENT_MODE_PREFIX,
+  parsePermissionMode,
+  type PermissionMode,
+} from "@/types/permission-mode";
 import { upsertPendingPermission } from "@/lib/pending-permission-queue";
 import {
   deferTailPromptTurnBoundary,
@@ -176,12 +180,16 @@ function handleSessionAction(
       // before we ever see this event, so reaching this branch with an
       // unrecognized mode would mean the FE catalog is stale.
       const session = p?.mode ? ctx.getSession(sessionId) : null;
-      if (p?.mode && session) {
+      const parsedMode = p?.mode ? parsePermissionMode(p.mode) : null;
+      if (parsedMode && session) {
         const providerId = session.currentProviderId || session.runtimeProvider;
-        if (findProviderMode(providerId, p.mode as PermissionMode)) {
+        if (
+          findProviderMode(providerId, parsedMode) ||
+          parsedMode.startsWith(OPENCODE_AGENT_MODE_PREFIX)
+        ) {
           ctx.set(
             updateSession(ctx.get(), sessionId, {
-              permissionMode: p.mode as PermissionMode,
+              permissionMode: parsedMode,
             }),
           );
         }

--- a/packages/desktop/src/types/permission-mode.test.ts
+++ b/packages/desktop/src/types/permission-mode.test.ts
@@ -11,8 +11,13 @@ describe("parsePermissionMode", () => {
     expect(parsePermissionMode("dontAsk")).toBe("dontAsk");
   });
 
+  it("accepts OpenCode agent modes", () => {
+    expect(parsePermissionMode("opencodeAgent:documentor")).toBe("opencodeAgent:documentor");
+  });
+
   it("rejects unknown and non-string values", () => {
     expect(parsePermissionMode("codex")).toBeNull();
+    expect(parsePermissionMode("opencodeAgent:")).toBeNull();
     expect(parsePermissionMode(null)).toBeNull();
     expect(parsePermissionMode(undefined)).toBeNull();
   });

--- a/packages/desktop/src/types/permission-mode.ts
+++ b/packages/desktop/src/types/permission-mode.ts
@@ -7,6 +7,8 @@ export const PERMISSION_MODES = [
   "dontAsk",
 ] as const;
 
+export const OPENCODE_AGENT_MODE_PREFIX = "opencodeAgent:";
+
 /**
  * Shared permission-mode union. Wire values match the backend's
  * `parse_permission_mode` (packages/service/src/domain/ws_session/handler/mod.rs).
@@ -15,10 +17,22 @@ export const PERMISSION_MODES = [
  * the per-provider catalog (drives chip rendering & the Shift+Tab cycle) and
  * `provider_supports_mode` on the backend (the validation gate).
  */
-export type PermissionMode = (typeof PERMISSION_MODES)[number];
+export type BuiltinPermissionMode = (typeof PERMISSION_MODES)[number];
+export type OpenCodeAgentPermissionMode = `${typeof OPENCODE_AGENT_MODE_PREFIX}${string}`;
+export type PermissionMode = BuiltinPermissionMode | OpenCodeAgentPermissionMode;
+
+export function opencodeAgentPermissionMode(agentName: string): OpenCodeAgentPermissionMode {
+  return `${OPENCODE_AGENT_MODE_PREFIX}${agentName}`;
+}
 
 export function parsePermissionMode(value: unknown): PermissionMode | null {
-  return typeof value === "string" && (PERMISSION_MODES as readonly string[]).includes(value)
-    ? (value as PermissionMode)
-    : null;
+  if (typeof value !== "string") return null;
+  if ((PERMISSION_MODES as readonly string[]).includes(value)) return value as PermissionMode;
+  if (
+    value.startsWith(OPENCODE_AGENT_MODE_PREFIX) &&
+    value.length > OPENCODE_AGENT_MODE_PREFIX.length
+  ) {
+    return value as OpenCodeAgentPermissionMode;
+  }
+  return null;
 }

--- a/packages/service/src/api/mod.rs
+++ b/packages/service/src/api/mod.rs
@@ -19,14 +19,39 @@ use crate::domain::sessions::routes::sessions_router;
 use crate::domain::terminal::routes::terminal_router;
 use crate::domain::workspace::routes::workspace_router;
 use crate::domain::ws_session::handler::ws_handler;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::routing::get;
 use axum::Json;
 use axum::Router;
+use serde::Deserialize;
+use std::path::PathBuf;
 
-#[utoipa::path(get, path = "/api/agent-catalog", responses((status = 200, body = AgentCatalogResponse)))]
-pub async fn get_agent_catalog(State(state): State<AppState>) -> Json<AgentCatalogResponse> {
-    Json(crate::domain::agents::providers::provider_catalog_live(&state.read_pool).await)
+#[utoipa::path(
+    get,
+    path = "/api/agent-catalog",
+    params(("cwd" = Option<String>, Query, description = "Workspace path used to discover project-local provider modes")),
+    responses((status = 200, body = AgentCatalogResponse))
+)]
+pub async fn get_agent_catalog(
+    State(state): State<AppState>,
+    Query(query): Query<AgentCatalogQuery>,
+) -> Json<AgentCatalogResponse> {
+    let catalog = match query.cwd.as_deref() {
+        Some(cwd) => {
+            crate::domain::agents::providers::provider_catalog_live_for_cwd(
+                &state.read_pool,
+                Some(cwd),
+            )
+            .await
+        }
+        None => crate::domain::agents::providers::provider_catalog_live(&state.read_pool).await,
+    };
+    Json(catalog)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentCatalogQuery {
+    cwd: Option<PathBuf>,
 }
 
 pub fn build_router(state: AppState) -> Router {

--- a/packages/service/src/domain/agents/acp/runtime/event_loop_state.rs
+++ b/packages/service/src/domain/agents/acp/runtime/event_loop_state.rs
@@ -86,7 +86,7 @@ mod tests {
         fn flatten_tool_result_content(&self, blocks: &[Value]) -> Value {
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }
@@ -109,7 +109,7 @@ mod tests {
         fn flatten_tool_result_content(&self, blocks: &[Value]) -> Value {
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
         async fn record_available_commands(&self, cwd: &Path, commands: Vec<RuntimeSlashCommand>) {

--- a/packages/service/src/domain/agents/acp/runtime/events.rs
+++ b/packages/service/src/domain/agents/acp/runtime/events.rs
@@ -22,7 +22,7 @@ mod tests {
         fn flatten_tool_result_content(&self, blocks: &[Value]) -> Value {
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }

--- a/packages/service/src/domain/agents/acp/runtime/events_plan.rs
+++ b/packages/service/src/domain/agents/acp/runtime/events_plan.rs
@@ -97,7 +97,7 @@ mod tests {
             input
         }
 
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }

--- a/packages/service/src/domain/agents/acp/runtime/events_tool_call.rs
+++ b/packages/service/src/domain/agents/acp/runtime/events_tool_call.rs
@@ -122,7 +122,7 @@ mod tests {
             }
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }

--- a/packages/service/src/domain/agents/acp/runtime/events_tool_call_input.rs
+++ b/packages/service/src/domain/agents/acp/runtime/events_tool_call_input.rs
@@ -194,7 +194,7 @@ mod tests {
         fn flatten_tool_result_content(&self, blocks: &[Value]) -> Value {
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }

--- a/packages/service/src/domain/agents/acp/runtime/events_tool_call_update.rs
+++ b/packages/service/src/domain/agents/acp/runtime/events_tool_call_update.rs
@@ -129,7 +129,7 @@ mod tests {
             }
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }
@@ -287,7 +287,7 @@ mod tests {
         fn normalize_tool_input(&self, _: &str, input: Value) -> Value {
             input
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
         fn suppresses_raw_output(&self, tool_name: &str) -> bool {

--- a/packages/service/src/domain/agents/acp/runtime/lifecycle.rs
+++ b/packages/service/src/domain/agents/acp/runtime/lifecycle.rs
@@ -242,8 +242,8 @@ mod tests {
             input
         }
 
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
-            Some("build")
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
+            Some("build".to_string())
         }
 
         fn supports_durable_resume(&self) -> bool {

--- a/packages/service/src/domain/agents/acp/runtime/provider_hooks.rs
+++ b/packages/service/src/domain/agents/acp/runtime/provider_hooks.rs
@@ -48,7 +48,7 @@ impl AcpProviderHooks for DefaultFlattenHooks {
     fn normalize_tool_input(&self, _tool_name: &str, input: Value) -> Value {
         input
     }
-    fn mode_for_permission_mode(&self, _mode: RuntimePermissionMode) -> Option<&'static str> {
+    fn mode_for_permission_mode(&self, _mode: RuntimePermissionMode) -> Option<String> {
         None
     }
 }
@@ -72,7 +72,7 @@ pub trait AcpProviderHooks: Send + Sync {
     }
 
     /// Map a Cadencr permission mode onto the provider's mode id.
-    fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<&'static str>;
+    fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<String>;
 
     /// Provider config id for model changes over `session/set_config_option`.
     fn model_config_id(&self) -> Option<&'static str> {

--- a/packages/service/src/domain/agents/acp/runtime/server_request_event_loop_tests.rs
+++ b/packages/service/src/domain/agents/acp/runtime/server_request_event_loop_tests.rs
@@ -22,7 +22,7 @@ impl AcpProviderHooks for PlainHooks {
     fn normalize_tool_input(&self, _: &str, input: Value) -> Value {
         input
     }
-    fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+    fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
         None
     }
 }

--- a/packages/service/src/domain/agents/acp/runtime/session.rs
+++ b/packages/service/src/domain/agents/acp/runtime/session.rs
@@ -40,10 +40,10 @@ mod tests {
         fn flatten_tool_result_content(&self, blocks: &[Value]) -> Value {
             json!(blocks)
         }
-        fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<String> {
             Some(match mode {
-                RuntimePermissionMode::Plan => "plan",
-                _ => "build",
+                RuntimePermissionMode::Plan => "plan".to_string(),
+                _ => "build".to_string(),
             })
         }
     }

--- a/packages/service/src/domain/agents/acp/runtime/session/compact.rs
+++ b/packages/service/src/domain/agents/acp/runtime/session/compact.rs
@@ -211,7 +211,7 @@ mod tests {
             input
         }
 
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
 

--- a/packages/service/src/domain/agents/acp/runtime/session/implementation.rs
+++ b/packages/service/src/domain/agents/acp/runtime/session/implementation.rs
@@ -273,7 +273,7 @@ impl AgentRuntimeSession for AcpRuntimeSession {
         let mode_id = self
             .hooks
             .mode_for_permission_mode(mode)
-            .or_else(|| self.hooks.default_mode_id())
+            .or_else(|| self.hooks.default_mode_id().map(ToOwned::to_owned))
             .ok_or_else(|| RuntimeError::new("ACP provider does not support permission modes"))?;
         let session_id = self.require_session_id().await?;
         set_session_mode(
@@ -281,7 +281,7 @@ impl AgentRuntimeSession for AcpRuntimeSession {
             &session_id,
             &self.current_mode,
             &self.supports_set_mode,
-            mode_id,
+            &mode_id,
         )
         .await
     }

--- a/packages/service/src/domain/agents/acp/runtime/session_spawn_integration_tests.rs
+++ b/packages/service/src/domain/agents/acp/runtime/session_spawn_integration_tests.rs
@@ -33,12 +33,15 @@ impl AcpProviderHooks for SpawnHooks {
     fn normalize_tool_input(&self, _: &str, input: Value) -> Value {
         input
     }
-    fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<&'static str> {
-        Some(if matches!(mode, RuntimePermissionMode::Plan) {
-            "plan"
-        } else {
-            "build"
-        })
+    fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<String> {
+        Some(
+            if matches!(mode, RuntimePermissionMode::Plan) {
+                "plan"
+            } else {
+                "build"
+            }
+            .to_string(),
+        )
     }
     fn model_config_id(&self) -> Option<&'static str> {
         Some("model")

--- a/packages/service/src/domain/agents/acp/runtime/spawn_initial_config.rs
+++ b/packages/service/src/domain/agents/acp/runtime/spawn_initial_config.rs
@@ -74,7 +74,7 @@ mod tests {
         fn normalize_tool_input(&self, _: &str, input: Value) -> Value {
             input
         }
-        fn mode_for_permission_mode(&self, _mode: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _mode: RuntimePermissionMode) -> Option<String> {
             None
         }
         fn model_config_id(&self) -> Option<&'static str> {

--- a/packages/service/src/domain/agents/acp/runtime/spawn_initial_mode.rs
+++ b/packages/service/src/domain/agents/acp/runtime/spawn_initial_mode.rs
@@ -41,7 +41,7 @@ pub(super) async fn apply_initial_permission_mode(
         &negotiated.session_id,
         &session.current_mode,
         &session.supports_set_mode,
-        target,
+        &target,
     )
     .await
 }
@@ -70,12 +70,15 @@ mod tests {
         fn normalize_tool_input(&self, _: &str, input: Value) -> Value {
             input
         }
-        fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<&'static str> {
-            Some(if matches!(mode, RuntimePermissionMode::Plan) {
-                "plan"
-            } else {
-                "build"
-            })
+        fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<String> {
+            Some(
+                if matches!(mode, RuntimePermissionMode::Plan) {
+                    "plan"
+                } else {
+                    "build"
+                }
+                .to_string(),
+            )
         }
         fn default_mode_id(&self) -> Option<&'static str> {
             Some("build")

--- a/packages/service/src/domain/agents/acp/runtime/turn_lifecycle.rs
+++ b/packages/service/src/domain/agents/acp/runtime/turn_lifecycle.rs
@@ -188,7 +188,7 @@ mod tests {
         fn normalize_tool_input(&self, _: &str, input: Value) -> Value {
             input
         }
-        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<&'static str> {
+        fn mode_for_permission_mode(&self, _: RuntimePermissionMode) -> Option<String> {
             None
         }
     }

--- a/packages/service/src/domain/agents/adapter.rs
+++ b/packages/service/src/domain/agents/adapter.rs
@@ -31,6 +31,7 @@ pub enum RuntimePermissionMode {
     /// permission level when this is selected.
     Auto,
     DontAsk,
+    OpenCodeAgent(String),
 }
 
 #[derive(Debug, Clone)]
@@ -693,6 +694,16 @@ pub trait AgentRuntimeAdapter: Send + Sync {
         self.catalog_entry()
     }
 
+    /// Live catalog entry scoped to a workspace path. Providers whose catalog
+    /// includes project-local data (OpenCode agents, commands, etc.) can
+    /// override this without forcing global settings pages to pick a cwd.
+    async fn catalog_entry_live_for_cwd(
+        &self,
+        _cwd: Option<&Path>,
+    ) -> super::runtime::ProviderCatalogEntry {
+        self.catalog_entry_live().await
+    }
+
     /// Extra models contributed by user configuration (e.g. custom Claude Code
     /// model aliases stored in SQLite). Returned entries are merged into the
     /// adapter's catalog; on id collision the user entry wins.
@@ -1042,6 +1053,7 @@ mod tests {
                 status: crate::domain::agents::runtime::ProviderStatus::Available,
                 status_message: None,
                 models: vec![],
+                modes: vec![],
                 default_model: None,
             }
         }

--- a/packages/service/src/domain/agents/claude_code/mod.rs
+++ b/packages/service/src/domain/agents/claude_code/mod.rs
@@ -171,6 +171,7 @@ fn map_permission_mode(mode: RuntimePermissionMode) -> claude_agent_sdk_rs::Perm
         RuntimePermissionMode::Plan => claude_agent_sdk_rs::PermissionMode::Plan,
         RuntimePermissionMode::Auto => claude_agent_sdk_rs::PermissionMode::Auto,
         RuntimePermissionMode::DontAsk => claude_agent_sdk_rs::PermissionMode::DontAsk,
+        RuntimePermissionMode::OpenCodeAgent(_) => claude_agent_sdk_rs::PermissionMode::Default,
     }
 }
 
@@ -319,6 +320,7 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
             status: ProviderStatus::Available,
             status_message: None,
             models,
+            modes: Vec::new(),
             default_model,
         }
     }
@@ -371,9 +373,9 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
         Ok(commands)
     }
 
-    fn supports_permission_mode(&self, _mode: &RuntimePermissionMode) -> bool {
-        // Claude Code's CLI accepts every variant the SDK exposes.
-        true
+    fn supports_permission_mode(&self, mode: &RuntimePermissionMode) -> bool {
+        // Claude Code's CLI accepts every built-in variant the SDK exposes.
+        !matches!(mode, RuntimePermissionMode::OpenCodeAgent(_))
     }
     // Default edit mode maps to Claude Code's primary edit mode.
 
@@ -421,6 +423,7 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
             status: ProviderStatus::Available,
             status_message: None,
             models,
+            modes: Vec::new(),
             default_model,
         }
     }

--- a/packages/service/src/domain/agents/codex/mod.rs
+++ b/packages/service/src/domain/agents/codex/mod.rs
@@ -112,6 +112,7 @@ fn catalog_from_models(models: Vec<CodexModel>) -> ProviderCatalogEntry {
         status: ProviderStatus::Available,
         status_message: None,
         models: models.into_iter().map(model_entry).collect(),
+        modes: Vec::new(),
         default_model,
     }
 }
@@ -123,6 +124,7 @@ fn unavailable_catalog(message: impl Into<String>) -> ProviderCatalogEntry {
         status: ProviderStatus::Unavailable,
         status_message: Some(message.into()),
         models: Vec::new(),
+        modes: Vec::new(),
         default_model: None,
     }
 }

--- a/packages/service/src/domain/agents/opencode/acp/adapter.rs
+++ b/packages/service/src/domain/agents/opencode/acp/adapter.rs
@@ -59,10 +59,11 @@ impl AcpProviderHooks for OpenCodeAcpAdapter {
     fn flatten_tool_result_content(&self, blocks: &[Value]) -> Value {
         flatten_tool_result_content(blocks)
     }
-    fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<&'static str> {
+    fn mode_for_permission_mode(&self, mode: RuntimePermissionMode) -> Option<String> {
         Some(match mode {
-            RuntimePermissionMode::Plan => "plan",
-            _ => "build",
+            RuntimePermissionMode::Plan => "plan".to_string(),
+            RuntimePermissionMode::OpenCodeAgent(name) => name,
+            _ => "build".to_string(),
         })
     }
     fn model_config_id(&self) -> Option<&'static str> {

--- a/packages/service/src/domain/agents/opencode/agents.rs
+++ b/packages/service/src/domain/agents/opencode/agents.rs
@@ -1,0 +1,162 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use crate::domain::agents::adapter::RuntimeError;
+use crate::domain::agents::runtime::ProviderModeCatalogEntry;
+
+const AGENT_LIST_TIMEOUT: Duration = Duration::from_secs(10);
+const AGENT_LIST_CACHE_TTL: Duration = Duration::from_secs(30);
+const MODE_PREFIX: &str = "opencodeAgent:";
+const BUILTIN_PRIMARY_AGENTS: &[&str] = &["build", "plan", "summary", "title", "compaction"];
+
+#[derive(Clone)]
+struct CachedAgentModes {
+    modes: Vec<ProviderModeCatalogEntry>,
+    fetched_at: Instant,
+}
+
+static AGENT_MODE_CACHE: OnceLock<Mutex<HashMap<PathBuf, CachedAgentModes>>> = OnceLock::new();
+
+pub(crate) fn mode_id_for_agent(name: &str) -> String {
+    format!("{MODE_PREFIX}{name}")
+}
+
+pub(crate) fn agent_name_from_mode_id(mode: &str) -> Option<&str> {
+    mode.strip_prefix(MODE_PREFIX)
+        .filter(|name| !name.is_empty())
+}
+
+pub(in crate::domain::agents::opencode) async fn primary_agent_modes(
+    cwd: &Path,
+) -> Vec<ProviderModeCatalogEntry> {
+    let cache_key = cwd.to_path_buf();
+    if let Some(modes) = cached_modes(&cache_key).await {
+        return modes;
+    }
+
+    match list_agents_output(cwd).await {
+        Ok(output) => {
+            let modes = parse_primary_agent_modes(&output);
+            cache_modes(cache_key, modes.clone()).await;
+            modes
+        }
+        Err(error) => {
+            tracing::warn!(%error, cwd = %cwd.display(), "failed to list OpenCode agents");
+            Vec::new()
+        }
+    }
+}
+
+async fn cached_modes(cwd: &Path) -> Option<Vec<ProviderModeCatalogEntry>> {
+    let cache = AGENT_MODE_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let cache = cache.lock().await;
+    let cached = cache.get(cwd)?;
+    (cached.fetched_at.elapsed() < AGENT_LIST_CACHE_TTL).then(|| cached.modes.clone())
+}
+
+async fn cache_modes(cwd: PathBuf, modes: Vec<ProviderModeCatalogEntry>) {
+    let cache = AGENT_MODE_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    cache.lock().await.insert(
+        cwd,
+        CachedAgentModes {
+            modes,
+            fetched_at: Instant::now(),
+        },
+    );
+}
+
+async fn list_agents_output(cwd: &Path) -> Result<String, RuntimeError> {
+    let binary = opencode_sdk_rs::process::resolve_binary().await?;
+    let mut command = Command::new(binary);
+    command
+        .arg("agent")
+        .arg("list")
+        .current_dir(cwd)
+        .kill_on_drop(true);
+    let output = tokio::time::timeout(AGENT_LIST_TIMEOUT, command.output())
+        .await
+        .map_err(|_| RuntimeError::new("opencode agent list timed out"))?
+        .map_err(|error| RuntimeError::new(format!("opencode agent list failed: {error}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(RuntimeError::new(format!(
+            "opencode agent list exited with status {}: {stderr}",
+            output.status,
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn parse_primary_agent_modes(raw: &str) -> Vec<ProviderModeCatalogEntry> {
+    let mut seen = HashSet::new();
+    let mut modes = Vec::new();
+
+    for line in raw.lines().map(str::trim) {
+        let Some((name, mode)) = parse_agent_header(line) else {
+            continue;
+        };
+        if mode != "primary" || BUILTIN_PRIMARY_AGENTS.contains(&name) || !seen.insert(name) {
+            continue;
+        }
+        modes.push(ProviderModeCatalogEntry {
+            id: mode_id_for_agent(name),
+            label: name.to_string(),
+            description: Some(format!("Use the OpenCode {name} agent.")),
+        });
+    }
+
+    modes
+}
+
+fn parse_agent_header(line: &str) -> Option<(&str, &str)> {
+    let (name, suffix) = line.rsplit_once(" (")?;
+    let mode = suffix.strip_suffix(')')?;
+    if name.is_empty() || mode.is_empty() {
+        return None;
+    }
+    Some((name, mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{agent_name_from_mode_id, parse_primary_agent_modes};
+
+    #[test]
+    fn parses_custom_primary_agents_from_cli_output() {
+        let modes = parse_primary_agent_modes(
+            r#"build (primary)
+  [{"permission":"*"}]
+documentor (primary)
+  []
+scenario-builder (primary)
+  []
+explore (subagent)
+  []
+scenario-builder/SCENARIO_TEMPLATE (all)
+  []
+"#,
+        );
+
+        assert_eq!(modes.len(), 2);
+        assert_eq!(modes[0].id, "opencodeAgent:documentor");
+        assert_eq!(modes[0].label, "documentor");
+        assert_eq!(modes[1].id, "opencodeAgent:scenario-builder");
+    }
+
+    #[test]
+    fn parses_agent_name_from_mode_id() {
+        assert_eq!(
+            agent_name_from_mode_id("opencodeAgent:documentor"),
+            Some("documentor")
+        );
+        assert_eq!(agent_name_from_mode_id("opencodeAgent:"), None);
+        assert_eq!(agent_name_from_mode_id("plan"), None);
+    }
+}

--- a/packages/service/src/domain/agents/opencode/mod.rs
+++ b/packages/service/src/domain/agents/opencode/mod.rs
@@ -1,4 +1,5 @@
 pub(in crate::domain::agents) mod acp;
+pub(in crate::domain::agents) mod agents;
 pub(in crate::domain::agents::opencode) mod commands;
 pub(crate) mod permissions;
 mod questions;
@@ -59,6 +60,17 @@ impl AgentRuntimeAdapter for OpenCodeAdapter {
 
     async fn catalog_entry_live(&self) -> crate::domain::agents::runtime::ProviderCatalogEntry {
         super::providers::opencode::catalog_entry_live().await
+    }
+
+    async fn catalog_entry_live_for_cwd(
+        &self,
+        cwd: Option<&std::path::Path>,
+    ) -> crate::domain::agents::runtime::ProviderCatalogEntry {
+        let mut entry = super::providers::opencode::catalog_entry_live().await;
+        if let Some(cwd) = cwd {
+            entry.modes = agents::primary_agent_modes(cwd).await;
+        }
+        entry
     }
 
     async fn context_window_for_model(&self, model_id: &str) -> Option<u64> {
@@ -139,6 +151,7 @@ impl AgentRuntimeAdapter for OpenCodeAdapter {
             RuntimePermissionMode::Default
                 | RuntimePermissionMode::AcceptEdits
                 | RuntimePermissionMode::Plan
+                | RuntimePermissionMode::OpenCodeAgent(_)
         )
     }
     // Default `default_permission_mode_wire` ("acceptEdits") maps to OpenCode's

--- a/packages/service/src/domain/agents/permission_modes.rs
+++ b/packages/service/src/domain/agents/permission_modes.rs
@@ -3,6 +3,10 @@ use super::runtime_adapter;
 
 /// Parse a permission mode string from the client into a PermissionMode enum value.
 pub(crate) fn parse_permission_mode(mode: &str) -> RuntimePermissionMode {
+    if let Some(agent_name) = super::opencode::agents::agent_name_from_mode_id(mode) {
+        return RuntimePermissionMode::OpenCodeAgent(agent_name.to_string());
+    }
+
     match mode {
         "acceptEdits" => RuntimePermissionMode::AcceptEdits,
         "bypassPermissions" => RuntimePermissionMode::BypassPermissions,
@@ -13,14 +17,33 @@ pub(crate) fn parse_permission_mode(mode: &str) -> RuntimePermissionMode {
     }
 }
 
-pub(crate) fn permission_mode_wire(mode: &RuntimePermissionMode) -> &'static str {
+pub(crate) fn permission_mode_wire(mode: &RuntimePermissionMode) -> String {
     match mode {
-        RuntimePermissionMode::Default => "default",
-        RuntimePermissionMode::AcceptEdits => "acceptEdits",
-        RuntimePermissionMode::BypassPermissions => "bypassPermissions",
-        RuntimePermissionMode::Plan => "plan",
-        RuntimePermissionMode::Auto => "auto",
-        RuntimePermissionMode::DontAsk => "dontAsk",
+        RuntimePermissionMode::Default => "default".to_string(),
+        RuntimePermissionMode::AcceptEdits => "acceptEdits".to_string(),
+        RuntimePermissionMode::BypassPermissions => "bypassPermissions".to_string(),
+        RuntimePermissionMode::Plan => "plan".to_string(),
+        RuntimePermissionMode::Auto => "auto".to_string(),
+        RuntimePermissionMode::DontAsk => "dontAsk".to_string(),
+        RuntimePermissionMode::OpenCodeAgent(name) => {
+            super::opencode::agents::mode_id_for_agent(name)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_permission_mode, permission_mode_wire};
+    use crate::domain::agents::adapter::RuntimePermissionMode;
+
+    #[test]
+    fn parses_opencode_agent_mode() {
+        let mode = parse_permission_mode("opencodeAgent:documentor");
+        assert_eq!(
+            mode,
+            RuntimePermissionMode::OpenCodeAgent("documentor".to_string())
+        );
+        assert_eq!(permission_mode_wire(&mode), "opencodeAgent:documentor");
     }
 }
 

--- a/packages/service/src/domain/agents/providers/mod.rs
+++ b/packages/service/src/domain/agents/providers/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod opencode;
 
 use sqlx::SqlitePool;
+use std::path::Path;
 
 use super::adapter::AgentRuntimeAdapter;
 use super::runtime::{AgentCatalogResponse, ModelCatalogEntry, DEFAULT_PROVIDER};
@@ -68,8 +69,15 @@ fn merge_extra_models(
 }
 
 pub async fn provider_catalog_live(read_pool: &SqlitePool) -> AgentCatalogResponse {
+    provider_catalog_live_for_cwd(read_pool, None).await
+}
+
+pub async fn provider_catalog_live_for_cwd(
+    read_pool: &SqlitePool,
+    cwd: Option<&Path>,
+) -> AgentCatalogResponse {
     let providers = futures::future::join_all(ADAPTERS.iter().map(|(_, adapter)| async move {
-        let mut entry = adapter.catalog_entry_live().await;
+        let mut entry = adapter.catalog_entry_live_for_cwd(cwd).await;
         let extra = adapter.extra_models(read_pool).await;
         if !extra.is_empty() {
             entry.models = merge_extra_models(entry.models, extra);

--- a/packages/service/src/domain/agents/providers/opencode/mod.rs
+++ b/packages/service/src/domain/agents/providers/opencode/mod.rs
@@ -37,6 +37,7 @@ pub(crate) fn catalog_entry() -> ProviderCatalogEntry {
             supports_fast_mode: None,
             supports_auto_mode: None,
         }],
+        modes: Vec::new(),
         default_model: Some(FALLBACK_MODEL_ID.to_string()),
     }
 }
@@ -114,6 +115,7 @@ fn catalog_from_response(
         status: ProviderStatus::Available,
         status_message: None,
         models,
+        modes: Vec::new(),
         default_model,
     };
     (catalog, context_windows)

--- a/packages/service/src/domain/agents/runtime.rs
+++ b/packages/service/src/domain/agents/runtime.rs
@@ -57,7 +57,17 @@ pub struct ProviderCatalogEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
     pub models: Vec<ModelCatalogEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<ProviderModeCatalogEntry>,
     pub default_model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ProviderModeCatalogEntry {
+    pub id: String,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/packages/service/src/domain/ws_session/handler/post_plan_mode.rs
+++ b/packages/service/src/domain/ws_session/handler/post_plan_mode.rs
@@ -29,7 +29,7 @@ pub(super) async fn transition_session_to_post_plan_mode(
     db_session_id: i64,
     write_pool: &sqlx::SqlitePool,
     sender: &WsSender,
-) -> Result<Option<&'static str>, RuntimeError> {
+) -> Result<Option<String>, RuntimeError> {
     let (transition, runtime_provider) = {
         let mut sessions = sdk_sessions.lock().await;
         let Some(handle) = sessions.get_mut(&db_session_id) else {
@@ -98,7 +98,7 @@ pub(super) async fn transition_session_to_post_plan_mode(
         }
     }
 
-    WsSessionPersistence::update_permission_mode_static(write_pool, db_session_id, applied_wire)
+    WsSessionPersistence::update_permission_mode_static(write_pool, db_session_id, &applied_wire)
         .await;
     let envelope = WsEnvelope::new(
         "session",
@@ -125,7 +125,7 @@ fn recoverable_fallback_mode(
         {
             let fallback_wire = post_plan_approval_fallback_mode_wire(
                 runtime_provider,
-                permission_mode_wire(failed_mode),
+                &permission_mode_wire(failed_mode),
             )?;
             Some(parse_permission_mode(fallback_wire))
         }
@@ -414,7 +414,7 @@ mod tests {
         // The orchestrator picked `auto` first, the CLI rejected it, so we
         // ended up in `acceptEdits` — surfaced via the return value, the
         // session handle, the DB, and the broadcast envelope.
-        assert_eq!(changed, Some("acceptEdits"));
+        assert_eq!(changed.as_deref(), Some("acceptEdits"));
         assert_eq!(
             *modes.lock().await,
             vec![RuntimePermissionMode::AcceptEdits],
@@ -464,7 +464,7 @@ mod tests {
 
         let changed = transition_session_to_post_plan_mode(&sdk_sessions, 7, &pool, &sender).await;
 
-        assert_eq!(changed.unwrap(), Some("default"));
+        assert_eq!(changed.unwrap().as_deref(), Some("default"));
         assert_eq!(*modes.lock().await, vec![RuntimePermissionMode::Default]);
         let stored: String =
             sqlx::query_scalar("SELECT permission_mode FROM agent_sessions WHERE id = 7")

--- a/packages/service/src/domain/ws_session/handler/session_control.rs
+++ b/packages/service/src/domain/ws_session/handler/session_control.rs
@@ -701,7 +701,7 @@ pub(super) async fn handle_mode_set(
                         SessionErrorPayload {
                             code: "MODE_REJECTED_BY_CLI".into(),
                             message: e.to_string(),
-                            mode: Some(permission_mode_wire(&new_mode).into()),
+                            mode: Some(permission_mode_wire(&new_mode)),
                         }
                     }
                     _ => SessionErrorPayload {


### PR DESCRIPTION
## Summary
- Discover project-local OpenCode primary agents and expose them as provider modes.
- Add `opencodeAgent:<name>` modes so Shift+Tab can cycle Build, Plan, and custom primary agents such as `documentor` and `scenario-builder`.
- Pass the cwd-scoped catalog through the agent UI to avoid duplicate catalog fetches.
- Cache OpenCode agent discovery per cwd to avoid repeatedly spawning `opencode agent list`.
- Regenerate the desktop API client for the new provider mode catalog shape.

## Tests
- `cargo fmt --check`
- `cargo check -p cadencr-service`
- `cargo test -p cadencr-service opencode::agents`
- `cargo test -p cadencr-service permission_modes`
- `pnpm --filter @cadencr/desktop ts-check`
- `pnpm --filter @cadencr/desktop test -- provider-modes permission-mode ws-envelope-handler --run`
- `pnpm --filter @cadencr/desktop run generate:api`