### PR TITLE
fix(desktop): avoid reconnecting agents on app visibility restore

### DIFF
--- a/packages/desktop/src/hooks/useConnectionWatchdog.test.tsx
+++ b/packages/desktop/src/hooks/useConnectionWatchdog.test.tsx
@@ -1,0 +1,128 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDesktopBridgeOverrideForTests,
+  setDesktopBridgeOverrideForTests,
+} from "@/lib/desktop-bridge";
+import type { CadencrDesktopBridge, DesktopTheme } from "@/lib/desktop-bridge";
+import { useConnectionWatchdog } from "./useConnectionWatchdog";
+
+const mocks = vi.hoisted(() => ({
+  forceReconnectAll: vi.fn(),
+  startHealthPolling: vi.fn(),
+  stopHealthPolling: vi.fn(),
+}));
+
+vi.mock("@/stores/connection-status-store", () => ({
+  useConnectionStatusStore: {
+    getState: () => ({ forceReconnectAll: mocks.forceReconnectAll }),
+  },
+  startHealthPolling: mocks.startHealthPolling,
+  stopHealthPolling: mocks.stopHealthPolling,
+}));
+
+function bridge(isElectron: boolean): CadencrDesktopBridge {
+  return {
+    isElectron,
+    runtimeConfig: vi.fn(() => Promise.resolve({ baseUrl: "", authToken: null })),
+    readFileBase64: vi.fn(() => Promise.resolve("")),
+    onFileDrop: vi.fn(() => () => undefined),
+    revealInFinder: vi.fn(() => Promise.resolve()),
+    openExternal: vi.fn(() => Promise.resolve()),
+    pickDirectory: vi.fn(() => Promise.resolve(null)),
+    notifyPermission: vi.fn(() => Promise.resolve(false)),
+    notify: vi.fn(() => Promise.resolve()),
+    notifyTest: vi.fn(() => Promise.resolve()),
+    onNotificationClicked: vi.fn(() => () => undefined),
+    onNotificationFailed: vi.fn(() => () => undefined),
+    onNotificationFallback: vi.fn(() => () => undefined),
+    onCloseRequested: vi.fn(() => () => undefined),
+    confirmClose: vi.fn(() => Promise.resolve()),
+    requestQuit: vi.fn(() => Promise.resolve()),
+    setZoom: vi.fn(() => Promise.resolve()),
+    currentTheme: vi.fn<() => Promise<DesktopTheme>>(() => Promise.resolve("light")),
+    onThemeChange: vi.fn(() => () => undefined),
+    setBusy: vi.fn(() => Promise.resolve()),
+    onPowerSuspend: vi.fn(() => () => undefined),
+    onPowerResume: vi.fn(() => () => undefined),
+    checkForUpdates: vi.fn(() => Promise.resolve()),
+    installUpdate: vi.fn(() => Promise.resolve()),
+    fetchChangelog: vi.fn(() => Promise.resolve(null)),
+    onUpdateEvent: vi.fn(() => () => undefined),
+  };
+}
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: state,
+  });
+}
+
+function dispatchVisibilityChange(state: DocumentVisibilityState): void {
+  setVisibilityState(state);
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useConnectionWatchdog", () => {
+  beforeEach(() => {
+    clearDesktopBridgeOverrideForTests();
+    setVisibilityState("visible");
+    mocks.forceReconnectAll.mockClear();
+    mocks.startHealthPolling.mockClear();
+    mocks.stopHealthPolling.mockClear();
+  });
+
+  afterEach(() => {
+    clearDesktopBridgeOverrideForTests();
+    vi.useRealTimers();
+  });
+
+  it("does not force-reconnect Electron sockets after an app visibility restore", () => {
+    setDesktopBridgeOverrideForTests(bridge(true));
+    const { unmount } = renderHook(() => useConnectionWatchdog());
+
+    dispatchVisibilityChange("hidden");
+    dispatchVisibilityChange("visible");
+
+    expect(mocks.forceReconnectAll).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("still force-reconnects browser sockets after a tab visibility restore", () => {
+    setDesktopBridgeOverrideForTests(bridge(false));
+    const { unmount } = renderHook(() => useConnectionWatchdog());
+
+    dispatchVisibilityChange("hidden");
+    dispatchVisibilityChange("visible");
+
+    expect(mocks.forceReconnectAll).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("does not force-reconnect Electron sockets after a clock-jump wake", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    setDesktopBridgeOverrideForTests(bridge(true));
+    const { unmount } = renderHook(() => useConnectionWatchdog());
+
+    vi.setSystemTime(31_000);
+    act(() => vi.advanceTimersByTime(1_000));
+
+    expect(mocks.forceReconnectAll).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("still force-reconnects browser sockets after a clock-jump wake", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    setDesktopBridgeOverrideForTests(bridge(false));
+    const { unmount } = renderHook(() => useConnectionWatchdog());
+
+    vi.setSystemTime(31_000);
+    act(() => vi.advanceTimersByTime(1_000));
+
+    expect(mocks.forceReconnectAll).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});

--- a/packages/desktop/src/hooks/useConnectionWatchdog.ts
+++ b/packages/desktop/src/hooks/useConnectionWatchdog.ts
@@ -1,16 +1,17 @@
 /**
- * Detects sleep/wake, network online/offline, and tab-visibility changes,
- * and uses each as a trigger to immediately force every registered WS
- * reconnector and run a fresh `/api/health` probe.
+ * Detects browser sleep/wake, network online/offline, and tab-visibility
+ * changes, then uses those triggers to immediately force every registered WS
+ * reconnector and run a fresh `/api/health` probe. In Electron, OS sleep/wake
+ * reconnection is owned by `usePowerEvents` via the powerMonitor bridge.
  *
  * Mounted once at the app shell (`__root.tsx`). The hook owns its own
  * timers/listeners and cleans up on unmount.
  *
  * Why this matters:
  *
- * - Without this, the only path back to "connected" after macOS sleep is
+ * - Without this, the only path back to "connected" after browser sleep is
  *   the slow TCP-level close detection (can be 30 s+) plus exponential
- *   backoff. With it, the moment the OS surface fires `visible` /
+ *   backoff. With it, the moment the browser surface fires `visible` /
  *   `online` we tear down stale sockets and reconnect at base delay —
  *   typically restoring the UI in well under a second.
  *
@@ -25,6 +26,7 @@ import {
   startHealthPolling,
   stopHealthPolling,
 } from "@/stores/connection-status-store";
+import { desktopBridge } from "@/lib/desktop-bridge";
 
 /** Threshold above which a setInterval delta is interpreted as a wake. */
 const CLOCK_JUMP_WAKE_MS = 30_000;
@@ -57,7 +59,7 @@ export function useConnectionWatchdog(): void {
         // means the event loop was paused (laptop sleep / heavy debugger
         // pause). 30 s is a comfortable buffer above any plausible GC/JIT
         // stall and well below the TCP keep-alive timeout.
-        if (elapsed > CLOCK_JUMP_WAKE_MS) force();
+        if (elapsed > CLOCK_JUMP_WAKE_MS && !desktopBridge.isElectron) force();
       }, CLOCK_TICK_MS);
     }
     function stopClockTicker(): void {
@@ -73,7 +75,11 @@ export function useConnectionWatchdog(): void {
       // resume on visible.
       if (document.visibilityState === "visible") {
         startClockTicker();
-        force();
+        // In Electron, switching to another fullscreen app can emit the same
+        // hidden -> visible transition as a browser tab restore. Do not tear
+        // down live agent sockets for ordinary app switches; real OS sleep is
+        // handled by usePowerEvents via Electron's powerMonitor bridge.
+        if (!desktopBridge.isElectron) force();
       } else {
         stopClockTicker();
       }


### PR DESCRIPTION
## Summary
- keep Electron app visibility restores from force-reconnecting live agent WebSockets
- leave real Electron sleep/wake recovery to the powerMonitor path
- preserve browser tab visibility and clock-jump recovery behavior

## Tests
- pnpm --filter @cadencr/desktop test -- useConnectionWatchdog --run
- pnpm --filter @cadencr/desktop ts-check