### PR TITLE
fix(desktop): focus selected model in picker

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,8 @@
 set -u
 
 cmd="pnpm turbo run format:check lint ts-check test knip"
-log_file="$(mktemp -t cadencr-precommit-log)" || exit 1
-tmp_dir="$(mktemp -d -t cadencr-precommit)" || {
+log_file="$(mktemp -t cadencr-precommit-log.XXXXXX)" || exit 1
+tmp_dir="$(mktemp -d -t cadencr-precommit.XXXXXX)" || {
   rm -f "$log_file"
   exit 1
 }

--- a/packages/desktop/src/components/RuntimeModelPicker.test.tsx
+++ b/packages/desktop/src/components/RuntimeModelPicker.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@/test-utils";
 import { RuntimeModelPicker } from "./RuntimeModelPicker";
 
@@ -38,6 +38,10 @@ function Harness(props: {
 }
 
 describe("RuntimeModelPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("calls the post-close callback after selecting a model", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
@@ -50,6 +54,29 @@ describe("RuntimeModelPicker", () => {
 
     expect(onSelect).toHaveBeenCalledWith("claude_code", "opus");
     await waitFor(() => expect(onAfterSelectClose).toHaveBeenCalled());
+  });
+
+  it("focuses and scrolls to the selected model when opened", async () => {
+    const user = userEvent.setup();
+    const models = [
+      ...Array.from({ length: 24 }, (_, index) => ({
+        id: `model-${index}`,
+        label: `Model ${index}`,
+      })),
+      { id: "opus", label: "Opus" },
+    ];
+
+    render(<Harness models={models} />);
+
+    await user.click(screen.getByRole("button", { name: "Open picker" }));
+
+    const selectedOption = screen.getByRole("option", { name: /Claude \/ Opus/i });
+    await waitFor(() => expect(selectedOption).toHaveAttribute("data-selected", "true"));
+    await waitFor(() =>
+      expect(window.HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
+        block: "nearest",
+      }),
+    );
   });
 
   it("resets the results scroll position when the filter changes", async () => {

--- a/packages/desktop/src/components/RuntimeModelPicker.tsx
+++ b/packages/desktop/src/components/RuntimeModelPicker.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { CheckIcon, LockIcon } from "lucide-react";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
+import { Command, CommandEmpty, CommandInput, CommandList } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { ProviderIcon } from "@/lib/provider-icons";
 import { cn } from "@/lib/utils";
+import {
+  ModelGroup,
+  ProviderStateGroup,
+  SelectionGroup,
+  getModelEntries,
+  getProviderStateEntries,
+  type ModelEntry,
+  type ProviderStateEntry,
+  type RuntimeModelPickerAction,
+} from "./RuntimeModelPickerSections";
 
 export interface RuntimeModelPickerModel {
   id: string;
@@ -25,15 +26,6 @@ export interface RuntimeModelPickerProvider {
   status?: "available" | "unavailable" | "coming_soon";
   statusMessage?: string;
   models: RuntimeModelPickerModel[];
-}
-
-interface RuntimeModelPickerAction {
-  id: string;
-  label: string;
-  description?: string;
-  selected: boolean;
-  keywords?: string[];
-  onSelect: () => void;
 }
 
 interface RuntimeModelPickerProps {
@@ -52,18 +44,39 @@ interface RuntimeModelPickerProps {
   onAfterSelectClose?: () => void;
 }
 
-interface ModelEntry {
-  providerId: string;
-  providerLabel: string;
-  modelId: string;
-  modelLabel: string;
-  description?: string;
+interface SelectedModelScrollParams {
+  listRef: React.RefObject<HTMLDivElement | null>;
+  resolvedOpen: boolean;
+  search: string;
+  selectedModelValue: string;
 }
 
-interface ProviderStateEntry {
-  providerId: string;
-  providerLabel: string;
-  statusLabel: string;
+function useScrollSelectedModel({
+  listRef,
+  resolvedOpen,
+  search,
+  selectedModelValue,
+}: SelectedModelScrollParams): void {
+  useEffect(() => {
+    if (!resolvedOpen || !listRef.current) return undefined;
+
+    const frameId = requestAnimationFrame(() => {
+      const list = listRef.current;
+      if (!list) return;
+
+      if (search.length === 0 && selectedModelValue) {
+        const selectedItem = list.querySelector<HTMLElement>('[data-selected="true"]');
+        if (selectedItem) {
+          selectedItem.scrollIntoView({ block: "nearest" });
+          return;
+        }
+      }
+
+      list.scrollTop = 0;
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [listRef, resolvedOpen, search, selectedModelValue]);
 }
 
 export function RuntimeModelPicker({
@@ -80,59 +93,27 @@ export function RuntimeModelPicker({
   align = "start",
   contentClassName,
   onAfterSelectClose,
-}: RuntimeModelPickerProps) {
+}: RuntimeModelPickerProps): React.ReactElement {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const restoreFocusAfterCloseRef = useRef(false);
   const [internalOpen, setInternalOpen] = useState(false);
   const [search, setSearch] = useState("");
   const resolvedOpen = open ?? internalOpen;
+  const selectedModelValue =
+    selectedProviderId && selectedModelId ? `${selectedProviderId}:${selectedModelId}` : "";
+  const selectedCommandValue = selectedModelValue || (action?.selected ? action.id : "");
 
   useEffect(() => {
     if (!resolvedOpen) setSearch("");
   }, [resolvedOpen]);
 
-  useEffect(() => {
-    if (!resolvedOpen || !listRef.current) return undefined;
+  useScrollSelectedModel({ listRef, resolvedOpen, search, selectedModelValue });
 
-    const frameId = requestAnimationFrame(() => {
-      if (listRef.current) listRef.current.scrollTop = 0;
-    });
-
-    return () => cancelAnimationFrame(frameId);
-  }, [resolvedOpen, search]);
-
-  const modelEntries = useMemo<ModelEntry[]>(
-    () =>
-      providers.flatMap((provider) => {
-        if (provider.disabled || provider.models.length === 0) return [];
-        return provider.models.map((model) => ({
-          providerId: provider.id,
-          providerLabel: provider.label,
-          modelId: model.id,
-          modelLabel: model.label,
-          description: model.description,
-        }));
-      }),
-    [providers],
-  );
+  const modelEntries = useMemo<ModelEntry[]>(() => getModelEntries(providers), [providers]);
 
   const providerStateEntries = useMemo<ProviderStateEntry[]>(
-    () =>
-      providers.flatMap((provider) => {
-        if (!provider.disabled && provider.models.length > 0) return [];
-        return [
-          {
-            providerId: provider.id,
-            providerLabel: provider.label,
-            statusLabel: provider.disabled
-              ? provider.status === "unavailable"
-                ? (provider.statusMessage ?? "Unavailable")
-                : "Coming soon"
-              : "No models available",
-          },
-        ];
-      }),
+    () => getProviderStateEntries(providers),
     [providers],
   );
 
@@ -143,6 +124,19 @@ export function RuntimeModelPicker({
   function handleOpenChange(nextOpen: boolean): void {
     if (open === undefined) setInternalOpen(nextOpen);
     onOpenChange?.(nextOpen);
+  }
+
+  function handleActionSelect(): void {
+    if (!action) return;
+    restoreFocusAfterCloseRef.current = true;
+    action.onSelect();
+    handleOpenChange(false);
+  }
+
+  function handleModelSelect(entry: ModelEntry): void {
+    restoreFocusAfterCloseRef.current = true;
+    onSelect(entry.providerId, entry.modelId);
+    handleOpenChange(false);
   }
 
   return (
@@ -162,7 +156,7 @@ export function RuntimeModelPicker({
           onAfterSelectClose?.();
         }}
       >
-        <Command>
+        <Command defaultValue={selectedCommandValue}>
           <CommandInput
             ref={inputRef}
             placeholder={searchPlaceholder}
@@ -172,107 +166,16 @@ export function RuntimeModelPicker({
           />
           <CommandList ref={listRef} className="max-h-[320px]">
             <CommandEmpty className="py-3 text-center text-xs">{emptyText}</CommandEmpty>
-            {action ? (
-              <CommandGroup heading="Selection">
-                <CommandItem
-                  value={action.id}
-                  keywords={action.keywords}
-                  onSelect={() => {
-                    restoreFocusAfterCloseRef.current = true;
-                    action.onSelect();
-                    handleOpenChange(false);
-                  }}
-                  className="flex items-start gap-2 text-xs"
-                >
-                  <CheckIcon
-                    className={cn(
-                      "mt-0.5 size-3 shrink-0",
-                      action.selected ? "opacity-100" : "opacity-0",
-                    )}
-                  />
-                  <span className="flex min-w-0 flex-col gap-0.5">
-                    <span className="truncate text-foreground">{action.label}</span>
-                    {action.description ? (
-                      <span className="truncate text-[11px] text-muted-foreground">
-                        {action.description}
-                      </span>
-                    ) : null}
-                  </span>
-                </CommandItem>
-              </CommandGroup>
-            ) : null}
-
+            {action ? <SelectionGroup action={action} onSelect={handleActionSelect} /> : null}
             {modelEntries.length > 0 ? (
-              <CommandGroup heading="Models">
-                {modelEntries.map((entry) => (
-                  <CommandItem
-                    key={`${entry.providerId}:${entry.modelId}`}
-                    value={`${entry.providerId}:${entry.modelId}`}
-                    keywords={[
-                      entry.providerLabel,
-                      entry.providerId,
-                      entry.modelLabel,
-                      entry.modelId,
-                      entry.description ?? "",
-                    ]}
-                    onSelect={() => {
-                      restoreFocusAfterCloseRef.current = true;
-                      onSelect(entry.providerId, entry.modelId);
-                      handleOpenChange(false);
-                    }}
-                    className="flex items-start justify-between gap-2 text-xs"
-                    title={entry.description}
-                  >
-                    <span className="flex min-w-0 items-start gap-2">
-                      <ProviderIcon
-                        providerId={entry.providerId}
-                        alt={entry.modelLabel}
-                        className="mt-0.5 size-3.5 shrink-0 rounded-sm"
-                      />
-                      <span className="flex min-w-0 flex-col gap-0.5">
-                        <span className="truncate text-foreground">
-                          {entry.providerLabel} / {entry.modelLabel}
-                        </span>
-                        {entry.description ? (
-                          <span className="truncate text-[11px] text-muted-foreground">
-                            {entry.description}
-                          </span>
-                        ) : null}
-                      </span>
-                    </span>
-                    <CheckIcon
-                      className={cn(
-                        "mt-0.5 size-3 shrink-0 text-violet-400",
-                        entry.providerId === selectedProviderId && entry.modelId === selectedModelId
-                          ? "opacity-100"
-                          : "opacity-0",
-                      )}
-                    />
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+              <ModelGroup
+                entries={modelEntries}
+                selectedModelValue={selectedModelValue}
+                onSelect={handleModelSelect}
+              />
             ) : null}
-
             {providerStateEntries.length > 0 ? (
-              <CommandGroup heading="Providers">
-                {providerStateEntries.map((entry) => (
-                  <CommandItem
-                    key={`${entry.providerId}:state`}
-                    value={`${entry.providerId}:state`}
-                    keywords={[entry.providerLabel, entry.providerId, entry.statusLabel]}
-                    disabled
-                    className="flex items-start gap-2 text-xs"
-                  >
-                    <LockIcon className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
-                    <span className="flex min-w-0 flex-col gap-0.5">
-                      <span className="truncate text-muted-foreground">{entry.providerLabel}</span>
-                      <span className="truncate text-[11px] text-muted-foreground">
-                        {entry.statusLabel}
-                      </span>
-                    </span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+              <ProviderStateGroup entries={providerStateEntries} />
             ) : null}
           </CommandList>
         </Command>

--- a/packages/desktop/src/components/RuntimeModelPicker.tsx
+++ b/packages/desktop/src/components/RuntimeModelPicker.tsx
@@ -65,7 +65,13 @@ function useScrollSelectedModel({
       if (!list) return;
 
       if (search.length === 0 && selectedModelValue) {
-        const selectedItem = list.querySelector<HTMLElement>('[data-selected="true"]');
+        // Query by the specific value rather than [data-selected="true"]:
+        // cmdk's data-selected tracks the currently highlighted item, which
+        // can drift after the user types and clears the search. data-value
+        // is stable, so we always scroll to the actual selected model.
+        const selectedItem = list.querySelector<HTMLElement>(
+          `[data-value="${CSS.escape(selectedModelValue)}"]`,
+        );
         if (selectedItem) {
           selectedItem.scrollIntoView({ block: "nearest" });
           return;

--- a/packages/desktop/src/components/RuntimeModelPickerSections.tsx
+++ b/packages/desktop/src/components/RuntimeModelPickerSections.tsx
@@ -1,0 +1,190 @@
+import { CheckIcon, LockIcon } from "lucide-react";
+import { CommandGroup, CommandItem } from "@/components/ui/command";
+import { ProviderIcon } from "@/lib/provider-icons";
+import { cn } from "@/lib/utils";
+import type { RuntimeModelPickerProvider } from "./RuntimeModelPicker";
+
+export interface RuntimeModelPickerAction {
+  id: string;
+  label: string;
+  description?: string;
+  selected: boolean;
+  keywords?: string[];
+  onSelect: () => void;
+}
+
+export interface ModelEntry {
+  providerId: string;
+  providerLabel: string;
+  modelId: string;
+  modelLabel: string;
+  description?: string;
+  value: string;
+  keywords: string[];
+}
+
+export interface ProviderStateEntry {
+  providerId: string;
+  providerLabel: string;
+  statusLabel: string;
+  value: string;
+  keywords: string[];
+}
+
+interface SelectionGroupProps {
+  action: RuntimeModelPickerAction;
+  onSelect: () => void;
+}
+
+interface ModelGroupProps {
+  entries: ModelEntry[];
+  selectedModelValue: string;
+  onSelect: (entry: ModelEntry) => void;
+}
+
+interface ModelItemProps {
+  entry: ModelEntry;
+  isSelected: boolean;
+  onSelect: (entry: ModelEntry) => void;
+}
+
+interface ProviderStateGroupProps {
+  entries: ProviderStateEntry[];
+}
+
+export function getModelEntries(providers: RuntimeModelPickerProvider[]): ModelEntry[] {
+  return providers.flatMap((provider) => {
+    if (provider.disabled || provider.models.length === 0) return [];
+    return provider.models.map((model) => ({
+      providerId: provider.id,
+      providerLabel: provider.label,
+      modelId: model.id,
+      modelLabel: model.label,
+      description: model.description,
+      value: `${provider.id}:${model.id}`,
+      keywords: [provider.label, provider.id, model.label, model.id, model.description ?? ""],
+    }));
+  });
+}
+
+export function getProviderStateEntries(
+  providers: RuntimeModelPickerProvider[],
+): ProviderStateEntry[] {
+  return providers.flatMap((provider) => {
+    if (!provider.disabled && provider.models.length > 0) return [];
+    const statusLabel = getProviderStatusLabel(provider);
+    return [
+      {
+        providerId: provider.id,
+        providerLabel: provider.label,
+        statusLabel,
+        value: `${provider.id}:state`,
+        keywords: [provider.label, provider.id, statusLabel],
+      },
+    ];
+  });
+}
+
+function getProviderStatusLabel(provider: RuntimeModelPickerProvider): string {
+  if (!provider.disabled) return "No models available";
+  if (provider.status === "unavailable") return provider.statusMessage ?? "Unavailable";
+  return "Coming soon";
+}
+
+export function SelectionGroup({ action, onSelect }: SelectionGroupProps): React.ReactElement {
+  return (
+    <CommandGroup heading="Selection">
+      <CommandItem
+        value={action.id}
+        keywords={action.keywords}
+        onSelect={onSelect}
+        className="flex items-start gap-2 text-xs"
+      >
+        <CheckIcon
+          className={cn("mt-0.5 size-3 shrink-0", action.selected ? "opacity-100" : "opacity-0")}
+        />
+        <span className="flex min-w-0 flex-col gap-0.5">
+          <span className="truncate text-foreground">{action.label}</span>
+          {action.description ? (
+            <span className="truncate text-[11px] text-muted-foreground">{action.description}</span>
+          ) : null}
+        </span>
+      </CommandItem>
+    </CommandGroup>
+  );
+}
+
+export function ModelGroup({
+  entries,
+  selectedModelValue,
+  onSelect,
+}: ModelGroupProps): React.ReactElement {
+  return (
+    <CommandGroup heading="Models">
+      {entries.map((entry) => (
+        <ModelItem
+          key={entry.value}
+          entry={entry}
+          isSelected={entry.value === selectedModelValue}
+          onSelect={onSelect}
+        />
+      ))}
+    </CommandGroup>
+  );
+}
+
+function ModelItem({ entry, isSelected, onSelect }: ModelItemProps): React.ReactElement {
+  return (
+    <CommandItem
+      value={entry.value}
+      keywords={entry.keywords}
+      onSelect={() => onSelect(entry)}
+      className="flex items-start justify-between gap-2 text-xs"
+      title={entry.description}
+    >
+      <span className="flex min-w-0 items-start gap-2">
+        <ProviderIcon
+          providerId={entry.providerId}
+          alt={entry.modelLabel}
+          className="mt-0.5 size-3.5 shrink-0 rounded-sm"
+        />
+        <span className="flex min-w-0 flex-col gap-0.5">
+          <span className="truncate text-foreground">
+            {entry.providerLabel} / {entry.modelLabel}
+          </span>
+          {entry.description ? (
+            <span className="truncate text-[11px] text-muted-foreground">{entry.description}</span>
+          ) : null}
+        </span>
+      </span>
+      <CheckIcon
+        className={cn(
+          "mt-0.5 size-3 shrink-0 text-violet-400",
+          isSelected ? "opacity-100" : "opacity-0",
+        )}
+      />
+    </CommandItem>
+  );
+}
+
+export function ProviderStateGroup({ entries }: ProviderStateGroupProps): React.ReactElement {
+  return (
+    <CommandGroup heading="Providers">
+      {entries.map((entry) => (
+        <CommandItem
+          key={entry.value}
+          value={entry.value}
+          keywords={entry.keywords}
+          disabled
+          className="flex items-start gap-2 text-xs"
+        >
+          <LockIcon className="mt-0.5 size-3 shrink-0 text-muted-foreground" />
+          <span className="flex min-w-0 flex-col gap-0.5">
+            <span className="truncate text-muted-foreground">{entry.providerLabel}</span>
+            <span className="truncate text-[11px] text-muted-foreground">{entry.statusLabel}</span>
+          </span>
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  );
+}

--- a/packages/service/src/domain/git/commands/worktree_ops.rs
+++ b/packages/service/src/domain/git/commands/worktree_ops.rs
@@ -333,6 +333,9 @@ detached
         crate::shared::git_cli::run_git(&["config", "user.name", "Test"], &repo)
             .await
             .unwrap();
+        crate::shared::git_cli::run_git(&["config", "commit.gpgsign", "false"], &repo)
+            .await
+            .unwrap();
         std::fs::write(repo.join("README.md"), "hello").unwrap();
         crate::shared::git_cli::run_git(&["add", "README.md"], &repo)
             .await

--- a/packages/service/src/domain/git/watcher/filter.rs
+++ b/packages/service/src/domain/git/watcher/filter.rs
@@ -234,5 +234,10 @@ mod tests {
             .current_dir(dir)
             .status()
             .unwrap();
+        Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(dir)
+            .status()
+            .unwrap();
     }
 }


### PR DESCRIPTION
Keep the model picker scrolled to the currently selected model when opened so users do not have to search through the list manually.

Also: fix pre-commit hook mktemp template for GNU/nix compat, and disable gpgsign in service test repos that run git-commit internally.

## Summary

<!-- What changed and why. One or two sentences is usually enough. -->

## Motivation

<!-- What problem does this solve? Link the issue(s) this closes: "Closes #123" -->

## Linked issues

<!-- Use GitHub closing keywords when applicable: "Closes #123". If no issue exists, explain why. -->

- Closes #

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Maintenance / tooling

## Areas touched

- [ ] Desktop frontend
- [ ] Backend service
- [ ] Claude provider
- [ ] Codex provider
- [ ] OpenCode provider
- [ ] Database / migration
- [ ] API surface
- [ ] Docs
- [ ] CI / release

## Changes

<!-- Bullet list of the concrete changes. Keep it tight. -->

-
-

## Screenshots / recordings

<!-- Required for visible UI changes. Otherwise write "N/A". -->

## API / database changes

- [ ] No API or database changes
- [ ] API changed and generated client was updated
- [ ] Database migration added
- [ ] Migration tested locally

## UX checklist

- [ ] Loading/error states are visible for async operations
- [ ] Keyboard shortcut impact considered
- [ ] No optimistic frontend updates added

## Test plan

<!-- How did you verify this? Commands you ran, flows you exercised, screenshots for UI changes. -->

Commands run:

```bash
# paste commands here
```

Manual flows verified:

- [ ]
- [ ]

## Checklist

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style.
- [ ] Rebased onto the latest `main`.
- [ ] Docs (README, CONTRIBUTING, etc.) updated for any user-visible change.
