### PR TITLE
feat(desktop): collapse Bash command output by default

### DIFF
--- a/packages/desktop/src/components/AgentBlock.tsx
+++ b/packages/desktop/src/components/AgentBlock.tsx
@@ -148,6 +148,7 @@ export const AgentBlock = memo(function AgentBlock({
             isError={result?.isError}
             messageId={result ? messageIdFromBlockId(result.id) : undefined}
             truncatedContent={result?.truncatedContent === true}
+            collapsible
           />
         );
       }

--- a/packages/desktop/src/components/BashBlock.tsx
+++ b/packages/desktop/src/components/BashBlock.tsx
@@ -31,6 +31,8 @@ export interface BashBlockProps {
   truncatedContent?: boolean;
   bodyExtraClassName?: string;
   runningFooter?: ReactNode;
+  /** Start with the output collapsed; the command header stays visible. */
+  collapsible?: boolean;
 }
 
 export const BashBlock = memo(function BashBlock({
@@ -43,6 +45,7 @@ export const BashBlock = memo(function BashBlock({
   truncatedContent,
   bodyExtraClassName,
   runningFooter,
+  collapsible,
 }: BashBlockProps): ReactElement {
   const lines = content?.split("\n") ?? [];
   const totalLines = lines.length;
@@ -61,6 +64,7 @@ export const BashBlock = memo(function BashBlock({
             totalCount={totalLines}
             visibleCount={maxLines}
             unit="lines"
+            collapsible={collapsible}
             className={isError ? "border-destructive/40" : "border-border"}
             headerClassName={cn(
               "bg-[var(--block-bash-header-bg)] py-1",

--- a/packages/desktop/src/components/ui/collapsible-block.test.tsx
+++ b/packages/desktop/src/components/ui/collapsible-block.test.tsx
@@ -50,4 +50,38 @@ describe("CollapsibleBlock", () => {
     await user.click(screen.getByRole("button"));
     expect(screen.getByText("showing all")).toBeInTheDocument();
   });
+
+  describe("collapsible mode", () => {
+    it("hides the body by default while keeping the header visible", () => {
+      render(
+        <CollapsibleBlock
+          collapsible
+          totalCount={3}
+          visibleCount={5}
+          unit="lines"
+          header={<span>Header</span>}
+        >
+          {() => <div>Body content</div>}
+        </CollapsibleBlock>,
+      );
+      expect(screen.getByText("Header")).toBeInTheDocument();
+      expect(screen.queryByText("Body content")).not.toBeInTheDocument();
+    });
+
+    it("reveals the body when the header is clicked", async () => {
+      const { user } = render(
+        <CollapsibleBlock
+          collapsible
+          totalCount={3}
+          visibleCount={5}
+          unit="lines"
+          header={<span>Header</span>}
+        >
+          {() => <div>Body content</div>}
+        </CollapsibleBlock>,
+      );
+      await user.click(screen.getByRole("button", { name: /header/i }));
+      expect(screen.getByText("Body content")).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/desktop/src/components/ui/collapsible-block.tsx
+++ b/packages/desktop/src/components/ui/collapsible-block.tsx
@@ -1,4 +1,5 @@
-import { useState, type ReactNode } from "react";
+import { useState, type KeyboardEvent, type ReactNode } from "react";
+import { ChevronRightIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface CollapsibleBlockProps {
@@ -12,6 +13,11 @@ interface CollapsibleBlockProps {
   header: ReactNode;
   /** Render the visible slice of items */
   children: (range: { showAll: boolean }) => ReactNode;
+  /**
+   * When true, the whole body can be toggled open/closed via the header and
+   * starts closed. The header (and its command) stays visible while closed.
+   */
+  collapsible?: boolean;
   /** Class for the outer wrapper */
   className?: string;
   /** Class for the header bar */
@@ -30,6 +36,7 @@ export function CollapsibleBlock({
   unit,
   header,
   children,
+  collapsible = false,
   className,
   headerClassName,
   toggleClassName,
@@ -37,31 +44,61 @@ export function CollapsibleBlock({
   truncationClassName,
 }: CollapsibleBlockProps) {
   const [showAll, setShowAll] = useState(false);
+  const [open, setOpen] = useState(!collapsible);
   const needsCollapse = totalCount > visibleCount;
   const hiddenCount = totalCount - visibleCount;
 
+  const toggleOpen = (): void => setOpen((value) => !value);
+  const onHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      toggleOpen();
+    }
+  };
+
   return (
     <div className={cn("my-1 rounded-md border overflow-hidden", className)}>
-      <div className={cn("flex items-center gap-2 px-3 py-1.5 text-xs", headerClassName)}>
+      <div
+        className={cn(
+          "flex items-center gap-2 px-3 py-1.5 text-xs",
+          collapsible && "cursor-pointer select-none",
+          headerClassName,
+        )}
+        role={collapsible ? "button" : undefined}
+        tabIndex={collapsible ? 0 : undefined}
+        aria-expanded={collapsible ? open : undefined}
+        onClick={collapsible ? toggleOpen : undefined}
+        onKeyDown={collapsible ? onHeaderKeyDown : undefined}
+      >
+        {collapsible && (
+          <ChevronRightIcon
+            className={cn("size-3 shrink-0 transition-transform", open && "rotate-90")}
+          />
+        )}
         {header}
-        {needsCollapse && (
+        {open && needsCollapse && (
           <button
             type="button"
             className={cn("shrink-0", toggleClassName)}
-            onClick={() => setShowAll(!showAll)}
+            onClick={(event) => {
+              event.stopPropagation();
+              setShowAll(!showAll);
+            }}
           >
             {showAll ? `Show last ${visibleCount}` : `Show all ${totalCount}`}
           </button>
         )}
       </div>
-      <div className={bodyClassName}>
-        {!showAll && needsCollapse && (
-          <div className={cn("text-xs", truncationClassName)}>
-            ... ({hiddenCount} {unit} above)
-          </div>
-        )}
-        {children({ showAll: showAll || !needsCollapse })}
-      </div>
+      {open && (
+        <div className={bodyClassName}>
+          {!showAll && needsCollapse && (
+            <div className={cn("text-xs", truncationClassName)}>
+              ... ({hiddenCount} {unit} above)
+            </div>
+          )}
+          {children({ showAll: showAll || !needsCollapse })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Bash tool calls in the agent stream now start collapsed — the command header stays visible, but the verbose stdout/stderr body is hidden until the user expands it.

## Motivation

Long Bash output (greps, finds, multi-step pipelines) dominated the agent conversation and made it hard to scan what the agent did.

## Linked issues

- Closes #13

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Maintenance / tooling

## Areas touched

- [x] Desktop frontend

## Changes

- Add a `collapsible` mode to `CollapsibleBlock`: hides the body by default and toggles open/closed via the header (focusable, Enter/Space accessible, chevron indicator).
- Add a `collapsible` prop to `BashBlock`, threaded through to `CollapsibleBlock`.
- `AgentBlock` opts Bash blocks into `collapsible`; dedicated git output panes (commit/push) are unaffected and stay expanded.
- Add tests for the new collapsible behavior in `collapsible-block.test.tsx`.

## Screenshots / recordings

N/A — behavior change; collapsed Bash blocks show the command header only until expanded.

## API / database changes

- [x] No API or database changes

## UX checklist

- [x] Loading/error states are visible for async operations
- [x] Keyboard shortcut impact considered
- [x] No optimistic frontend updates added

## Test plan

Commands run:

\`\`\`bash
pnpm --filter @cadencr/desktop ts-check
pnpm --filter @cadencr/desktop exec vitest run src/components/ui/collapsible-block.test.tsx src/components/BashBlock.test.tsx src/components/AgentBlock.test.tsx
\`\`\`

Manual flows verified:

- [x] Bash blocks in the agent stream start collapsed; clicking the header expands/collapses output
- [x] Git commit/push output panes remain expanded

## Checklist

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style.
- [x] Rebased onto the latest \`main\`.
- [ ] Docs (README, CONTRIBUTING, etc.) updated for any user-visible change.