### PR TITLE
feat(desktop): add in-buffer search to the editor (Cmd+F)

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -48,6 +48,7 @@
     "@codemirror/legacy-modes": "^6.4.2",
     "@codemirror/lsp-client": "^6.2.4",
     "@codemirror/merge": "^6.12.1",
+    "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.43.0",
     "@dnd-kit/core": "^6.3.1",

--- a/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
+++ b/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
@@ -12,7 +12,6 @@ import BaseCodeMirrorEditor from "./BaseCodeMirrorEditor";
 import { LspStatusIndicator } from "./LspStatusIndicator";
 import EditorSearchPanel from "./editor-search/EditorSearchPanel";
 import { bufferSearchExtension } from "./editor-search/search-extension";
-import { getPaneSearch, setPaneSearch, type PaneSearchState } from "./editor-search/search-cache";
 import { toast } from "sonner";
 
 interface CodeMirrorEditorProps {
@@ -201,18 +200,6 @@ export default function CodeMirrorEditor({
     [onEditorViewChange, paneId],
   );
 
-  const initialSearchState = useMemo<PaneSearchState>(
-    () => getPaneSearch(featureId, paneId),
-    [featureId, paneId],
-  );
-
-  const handleSearchChange = useCallback(
-    (next: PaneSearchState): void => {
-      setPaneSearch(featureId, paneId, next);
-    },
-    [featureId, paneId],
-  );
-
   const bufferSearch = useMemo(() => bufferSearchExtension(), []);
 
   const langExt = useMemo(() => getLanguageExtension(filePath), [filePath]);
@@ -327,9 +314,9 @@ export default function CodeMirrorEditor({
       {searchOpen && editorView && (
         <EditorSearchPanel
           view={editorView}
-          initialState={initialSearchState}
+          featureId={featureId}
+          paneId={paneId}
           reopenSignal={searchReopenSignal}
-          onChange={handleSearchChange}
           onClose={onCloseSearch}
         />
       )}

--- a/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
+++ b/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
@@ -10,6 +10,9 @@ import { gitBlameExtension } from "./git-blame-extension";
 import { registerSave, unregisterSave } from "./editorSaveRegistry";
 import BaseCodeMirrorEditor from "./BaseCodeMirrorEditor";
 import { LspStatusIndicator } from "./LspStatusIndicator";
+import EditorSearchPanel from "./editor-search/EditorSearchPanel";
+import { bufferSearchExtension } from "./editor-search/search-extension";
+import { getPaneSearch, setPaneSearch, type PaneSearchState } from "./editor-search/search-cache";
 import { toast } from "sonner";
 
 interface CodeMirrorEditorProps {
@@ -17,6 +20,9 @@ interface CodeMirrorEditorProps {
   projectId: number;
   paneId: string;
   featureId: number;
+  searchOpen: boolean;
+  searchReopenSignal: number;
+  onCloseSearch: () => void;
   onEditorViewChange?: (paneId: string, view: EditorView | null) => void;
 }
 
@@ -57,9 +63,13 @@ export default function CodeMirrorEditor({
   projectId,
   paneId,
   featureId,
+  searchOpen,
+  searchReopenSignal,
+  onCloseSearch,
   onEditorViewChange,
 }: CodeMirrorEditorProps) {
   const viewRef = useRef<EditorView | null>(null);
+  const [editorView, setEditorView] = useState<EditorView | null>(null);
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [autoSavedVisible, setAutoSavedVisible] = useState(false);
   const autoSavedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -185,10 +195,25 @@ export default function CodeMirrorEditor({
 
   const handleEditorViewChange = useCallback(
     (view: EditorView | null): void => {
+      setEditorView(view);
       onEditorViewChange?.(paneId, view);
     },
     [onEditorViewChange, paneId],
   );
+
+  const initialSearchState = useMemo<PaneSearchState>(
+    () => getPaneSearch(featureId, paneId),
+    [featureId, paneId],
+  );
+
+  const handleSearchChange = useCallback(
+    (next: PaneSearchState): void => {
+      setPaneSearch(featureId, paneId, next);
+    },
+    [featureId, paneId],
+  );
+
+  const bufferSearch = useMemo(() => bufferSearchExtension(), []);
 
   const langExt = useMemo(() => getLanguageExtension(filePath), [filePath]);
 
@@ -293,11 +318,21 @@ export default function CodeMirrorEditor({
           cursorExtension,
           blameCompartment.current.of([]),
           lspCompartment.current.of([]),
+          bufferSearch,
         ]}
         editorViewRef={viewRef}
         onEditorViewChange={handleEditorViewChange}
         className="flex-1 overflow-auto"
       />
+      {searchOpen && editorView && (
+        <EditorSearchPanel
+          view={editorView}
+          initialState={initialSearchState}
+          reopenSignal={searchReopenSignal}
+          onChange={handleSearchChange}
+          onClose={onCloseSearch}
+        />
+      )}
       <StatusBar
         line={cursorPosition.line}
         col={cursorPosition.col}

--- a/packages/desktop/src/components/editor/ContentSearchDialog.tsx
+++ b/packages/desktop/src/components/editor/ContentSearchDialog.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CaseSensitive, WholeWord, Regex, Loader2 } from "lucide-react";
+import SearchToggleButton from "./SearchToggleButton";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useDebouncedSetting } from "@/hooks/useDebouncedSetting";
 import { useContentSearch, type ContentMatch, type ContentSearchParams } from "@/api/generated";
@@ -164,25 +165,25 @@ export default function ContentSearchDialog({
             className="flex-1"
           />
           <div className="flex items-center gap-1 shrink-0">
-            <ToggleButton
+            <SearchToggleButton
               active={caseSensitive}
               onToggle={setCaseSensitive}
               title="Case Sensitive"
               icon={<CaseSensitive className="w-4 h-4" />}
             />
-            <ToggleButton
+            <SearchToggleButton
               active={wholeWord}
               onToggle={setWholeWord}
               title="Whole Word"
               icon={<WholeWord className="w-4 h-4" />}
             />
-            <ToggleButton
+            <SearchToggleButton
               active={isRegex}
               onToggle={setIsRegex}
               title="Regex"
               icon={<Regex className="w-4 h-4" />}
             />
-            <ToggleButton
+            <SearchToggleButton
               active={respectGitignore}
               onToggle={setRespectGitignore}
               title="Only search git-tracked files"
@@ -231,44 +232,6 @@ export default function ContentSearchDialog({
     </Dialog>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function ToggleButton({
-  active,
-  onToggle,
-  title,
-  icon,
-  label,
-}: {
-  active: boolean;
-  onToggle: (v: boolean) => void;
-  title: string;
-  icon?: ReactNode;
-  label?: string;
-}) {
-  return (
-    <button
-      type="button"
-      title={title}
-      onClick={() => onToggle(!active)}
-      className={`flex items-center gap-1 rounded px-1.5 py-1 text-xs transition-colors ${
-        active
-          ? "bg-primary text-primary-foreground"
-          : "bg-muted text-foreground/70 hover:bg-accent hover:text-foreground"
-      }`}
-    >
-      {icon}
-      {label && <span>{label}</span>}
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Results rendering
-// ---------------------------------------------------------------------------
 
 interface FileGroupData {
   path: string;

--- a/packages/desktop/src/components/editor/EditorPane.tsx
+++ b/packages/desktop/src/components/editor/EditorPane.tsx
@@ -1,6 +1,7 @@
 import type { EditorView } from "@codemirror/view";
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useCallback, useState } from "react";
 import { useEditorStore } from "@/stores/editor-store";
+import { useScopedGlobalShortcutById } from "@/hooks/useShortcut";
 import EditorSubTabs from "./EditorSubTabs";
 
 const CodeMirrorEditor = lazy(() => import("./CodeMirrorEditor"));
@@ -23,7 +24,32 @@ export default function EditorPane({
   const activeFilePath = useEditorStore(
     (s) => s.features[featureId]?.panes[paneId]?.activeFilePath ?? null,
   );
+  const activePaneId = useEditorStore((s) => s.features[featureId]?.activePaneId);
   const setActivePane = useEditorStore((s) => s.setActivePane);
+
+  const isFocusedPane = activePaneId === paneId;
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchReopenSignal, setSearchReopenSignal] = useState(0);
+
+  const openSearch = useCallback((): void => {
+    setSearchOpen((wasOpen) => {
+      if (wasOpen) setSearchReopenSignal((n) => n + 1);
+      return true;
+    });
+  }, []);
+  const closeSearch = useCallback((): void => setSearchOpen(false), []);
+
+  useScopedGlobalShortcutById(
+    "editor-buffer-search",
+    (event) => {
+      if (!isFocusedPane || !activeFilePath) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openSearch();
+    },
+    "editor",
+    { enabled: isFocusedPane && Boolean(activeFilePath) },
+  );
 
   function handleFocus() {
     if (!isActive) {
@@ -52,6 +78,9 @@ export default function EditorPane({
               projectId={projectId}
               paneId={paneId}
               featureId={featureId}
+              searchOpen={searchOpen}
+              searchReopenSignal={searchReopenSignal}
+              onCloseSearch={closeSearch}
               onEditorViewChange={onEditorViewChange}
             />
           </Suspense>

--- a/packages/desktop/src/components/editor/EditorPane.tsx
+++ b/packages/desktop/src/components/editor/EditorPane.tsx
@@ -1,8 +1,9 @@
 import type { EditorView } from "@codemirror/view";
-import { lazy, Suspense, useCallback, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { useEditorStore } from "@/stores/editor-store";
 import { useScopedGlobalShortcutById } from "@/hooks/useShortcut";
 import EditorSubTabs from "./EditorSubTabs";
+import { clearPaneSearch } from "./editor-search/search-cache";
 
 const CodeMirrorEditor = lazy(() => import("./CodeMirrorEditor"));
 
@@ -50,6 +51,10 @@ export default function EditorPane({
     "editor",
     { enabled: isFocusedPane && Boolean(activeFilePath) },
   );
+
+  useEffect(() => {
+    return () => clearPaneSearch(featureId, paneId);
+  }, [featureId, paneId]);
 
   function handleFocus() {
     if (!isActive) {

--- a/packages/desktop/src/components/editor/SearchToggleButton.tsx
+++ b/packages/desktop/src/components/editor/SearchToggleButton.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
 
 interface SearchToggleButtonProps {
   active: boolean;
@@ -21,11 +22,12 @@ export default function SearchToggleButton({
       title={title}
       aria-pressed={active}
       onClick={() => onToggle(!active)}
-      className={`flex items-center gap-1 rounded px-1.5 py-1 text-xs transition-colors ${
+      className={cn(
+        "flex items-center gap-1 rounded px-1.5 py-1 text-xs transition-colors",
         active
           ? "bg-primary text-primary-foreground"
-          : "bg-muted text-foreground/70 hover:bg-accent hover:text-foreground"
-      }`}
+          : "bg-muted text-foreground/70 hover:bg-accent hover:text-foreground",
+      )}
     >
       {icon}
       {label && <span>{label}</span>}

--- a/packages/desktop/src/components/editor/SearchToggleButton.tsx
+++ b/packages/desktop/src/components/editor/SearchToggleButton.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+interface SearchToggleButtonProps {
+  active: boolean;
+  onToggle: (next: boolean) => void;
+  title: string;
+  icon?: ReactNode;
+  label?: string;
+}
+
+export default function SearchToggleButton({
+  active,
+  onToggle,
+  title,
+  icon,
+  label,
+}: SearchToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      title={title}
+      aria-pressed={active}
+      onClick={() => onToggle(!active)}
+      className={`flex items-center gap-1 rounded px-1.5 py-1 text-xs transition-colors ${
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-foreground/70 hover:bg-accent hover:text-foreground"
+      }`}
+    >
+      {icon}
+      {label && <span>{label}</span>}
+    </button>
+  );
+}

--- a/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
@@ -64,11 +64,6 @@ vi.mock("../editor-search/search-extension", () => ({
   bufferSearchExtension: vi.fn(() => []),
 }));
 
-vi.mock("../editor-search/search-cache", () => ({
-  getPaneSearch: vi.fn(() => ({ query: "", caseSensitive: false, regex: false })),
-  setPaneSearch: vi.fn(),
-}));
-
 vi.mock("../editor-search/EditorSearchPanel", () => ({
   default: () => null,
 }));

--- a/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
@@ -60,6 +60,19 @@ vi.mock("../git-blame-extension", () => ({
   gitBlameExtension: vi.fn(() => []),
 }));
 
+vi.mock("../editor-search/search-extension", () => ({
+  bufferSearchExtension: vi.fn(() => []),
+}));
+
+vi.mock("../editor-search/search-cache", () => ({
+  getPaneSearch: vi.fn(() => ({ query: "", caseSensitive: false, regex: false })),
+  setPaneSearch: vi.fn(),
+}));
+
+vi.mock("../editor-search/EditorSearchPanel", () => ({
+  default: () => null,
+}));
+
 let mockReadFileReturn: { data: unknown; isLoading: boolean; error: Error | null } = {
   data: undefined,
   isLoading: true,
@@ -109,6 +122,9 @@ const defaultProps = {
   projectId: 42,
   paneId: "pane-1",
   featureId: 1,
+  searchOpen: false,
+  searchReopenSignal: 0,
+  onCloseSearch: () => {},
 };
 
 beforeEach(() => {

--- a/packages/desktop/src/components/editor/__tests__/EditorPaneSearchShortcut.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/EditorPaneSearchShortcut.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, render } from "@/test-utils";
+import EditorPane from "../EditorPane";
+
+// Capture the scoped Cmd+F handler and the props passed to CodeMirrorEditor so
+// we can inspect open/reopen behavior without booting the real editor.
+interface CapturedShortcut {
+  callback: ((e: KeyboardEvent) => void) | null;
+  enabled: boolean;
+}
+const captured: CapturedShortcut = { callback: null, enabled: true };
+
+interface CapturedEditor {
+  searchOpen: boolean;
+  searchReopenSignal: number;
+  renders: number;
+}
+const editor: CapturedEditor = { searchOpen: false, searchReopenSignal: 0, renders: 0 };
+
+vi.mock("@/hooks/useShortcut", () => ({
+  useScopedGlobalShortcutById: (
+    _id: string,
+    callback: (e: KeyboardEvent) => void,
+    _scope: string,
+    options?: { enabled?: boolean },
+  ) => {
+    captured.callback = callback;
+    captured.enabled = options?.enabled ?? true;
+  },
+}));
+
+const storeState = {
+  features: {
+    7: {
+      activePaneId: "main",
+      panes: {
+        main: { tabs: [], activeFilePath: "/file.ts" },
+      },
+    },
+  } as Record<
+    number,
+    {
+      activePaneId: string;
+      panes: Record<string, { tabs: unknown[]; activeFilePath: string | null }>;
+    }
+  >,
+  setActivePane: vi.fn(),
+};
+
+vi.mock("@/stores/editor-store", () => ({
+  useEditorStore: (selector: (s: typeof storeState) => unknown) => selector(storeState),
+}));
+
+vi.mock("../EditorSubTabs", () => ({
+  default: () => <div data-testid="editor-subtabs" />,
+}));
+
+vi.mock("../CodeMirrorEditor", () => ({
+  default: (props: { searchOpen: boolean; searchReopenSignal: number }) => {
+    editor.renders += 1;
+    editor.searchOpen = props.searchOpen;
+    editor.searchReopenSignal = props.searchReopenSignal;
+    return <div data-testid="codemirror" />;
+  },
+}));
+
+const clearPaneSearchMock = vi.fn();
+vi.mock("../editor-search/search-cache", () => ({
+  clearPaneSearch: (...args: unknown[]) => clearPaneSearchMock(...args),
+}));
+
+beforeEach(() => {
+  captured.callback = null;
+  captured.enabled = true;
+  editor.searchOpen = false;
+  editor.searchReopenSignal = 0;
+  editor.renders = 0;
+  clearPaneSearchMock.mockClear();
+  storeState.features[7] = {
+    activePaneId: "main",
+    panes: { main: { tabs: [], activeFilePath: "/file.ts" } },
+  };
+});
+
+function press(): void {
+  const event = new KeyboardEvent("keydown");
+  Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+  Object.defineProperty(event, "stopPropagation", { value: vi.fn() });
+  act(() => captured.callback?.(event));
+}
+
+describe("EditorPane Cmd+F shortcut", () => {
+  it("registers the editor-buffer-search shortcut as enabled when this pane is focused and has a file", () => {
+    render(<EditorPane featureId={7} paneId="main" projectId={1} isActive />);
+    expect(captured.enabled).toBe(true);
+  });
+
+  it("opens the search panel on first press", () => {
+    render(<EditorPane featureId={7} paneId="main" projectId={1} isActive />);
+    expect(editor.searchOpen).toBe(false);
+    press();
+    expect(editor.searchOpen).toBe(true);
+  });
+
+  it("bumps reopenSignal on a second press while already open", () => {
+    render(<EditorPane featureId={7} paneId="main" projectId={1} isActive />);
+    press();
+    const firstSignal = editor.searchReopenSignal;
+    press();
+    expect(editor.searchOpen).toBe(true);
+    expect(editor.searchReopenSignal).toBeGreaterThan(firstSignal);
+  });
+
+  it("disables the shortcut when no file is open", () => {
+    storeState.features[7] = {
+      activePaneId: "main",
+      panes: { main: { tabs: [], activeFilePath: null } },
+    };
+    render(<EditorPane featureId={7} paneId="main" projectId={1} isActive />);
+    expect(captured.enabled).toBe(false);
+  });
+
+  it("disables the shortcut when this pane is not the focused pane", () => {
+    storeState.features[7] = {
+      activePaneId: "other",
+      panes: { main: { tabs: [], activeFilePath: "/file.ts" } },
+    };
+    render(<EditorPane featureId={7} paneId="main" projectId={1} isActive />);
+    expect(captured.enabled).toBe(false);
+  });
+
+  it("clears the per-pane search cache on unmount", () => {
+    const { unmount } = render(<EditorPane featureId={7} paneId="main" projectId={1} isActive />);
+    unmount();
+    expect(clearPaneSearchMock).toHaveBeenCalledWith(7, "main");
+  });
+});

--- a/packages/desktop/src/components/editor/editor-search/EditorSearchPanel.tsx
+++ b/packages/desktop/src/components/editor/editor-search/EditorSearchPanel.tsx
@@ -1,0 +1,303 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import type { EditorView } from "@codemirror/view";
+import { CaseSensitive, ChevronDown, ChevronUp, Regex, Search, X } from "lucide-react";
+import SearchToggleButton from "../SearchToggleButton";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { cn } from "@/lib/utils";
+import {
+  MAX_BUFFER_MATCHES,
+  closeBufferSearch,
+  findNextMatch,
+  findPrevMatch,
+  getBufferSearchState,
+  setBufferSearchQuery,
+} from "./search-extension";
+import type { PaneSearchState } from "./search-cache";
+
+interface EditorSearchPanelProps {
+  view: EditorView;
+  initialState: PaneSearchState;
+  /** Bumped by the parent every time Cmd+F is pressed while the panel is already open. */
+  reopenSignal: number;
+  onChange: (state: PaneSearchState) => void;
+  onClose: () => void;
+}
+
+const QUERY_DEBOUNCE_MS = 80;
+
+interface MatchInfo {
+  total: number;
+  active: number;
+  truncated: boolean;
+  error: string | null;
+}
+
+function EditorSearchPanel({
+  view,
+  initialState,
+  reopenSignal,
+  onChange,
+  onClose,
+}: EditorSearchPanelProps) {
+  const [query, setQuery] = useState<string>(initialState.query);
+  const [caseSensitive, setCaseSensitive] = useState<boolean>(initialState.caseSensitive);
+  const [regex, setRegex] = useState<boolean>(initialState.regex);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const debouncedQuery = useDebouncedValue(query, QUERY_DEBOUNCE_MS);
+
+  useEffect(() => {
+    setBufferSearchQuery(view, { query: debouncedQuery, caseSensitive, regex });
+  }, [view, debouncedQuery, caseSensitive, regex]);
+
+  useEffect(() => {
+    onChange({ query, caseSensitive, regex });
+  }, [query, caseSensitive, regex, onChange]);
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.select();
+  }, [reopenSignal]);
+
+  const matchInfo = useLiveMatchInfo(view);
+
+  const handleNext = useCallback((): void => findNextMatch(view), [view]);
+  const handlePrev = useCallback((): void => findPrevMatch(view), [view]);
+  const handleClose = useCallback((): void => {
+    closeBufferSearch(view);
+    onClose();
+    view.focus();
+  }, [view, onClose]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+        return;
+      }
+      if (event.key !== "Enter") return;
+      event.preventDefault();
+      if ((event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        event.currentTarget.blur();
+        view.focus();
+        return;
+      }
+      if (event.shiftKey) handlePrev();
+      else handleNext();
+    },
+    [handleClose, handleNext, handlePrev, view],
+  );
+
+  const counterLabel = useMemo(() => buildCounterLabel(query, matchInfo), [query, matchInfo]);
+  const hasError = matchInfo.error !== null;
+  const showNoMatches = query.length > 0 && matchInfo.total === 0 && !hasError;
+
+  return (
+    <div
+      className="absolute top-2 right-3 z-20 flex items-center gap-1 rounded-md border border-border bg-card/95 px-2 py-1 shadow-md backdrop-blur"
+      role="search"
+      aria-label="Find in file"
+      onMouseDown={(event) => {
+        if (event.target !== inputRef.current) event.preventDefault();
+      }}
+    >
+      <SearchInputRow
+        inputRef={inputRef}
+        query={query}
+        onQueryChange={setQuery}
+        onKeyDown={handleKeyDown}
+        counterLabel={counterLabel}
+        hasError={hasError}
+        errorTitle={matchInfo.error}
+        muted={showNoMatches}
+      />
+      <SearchPanelControls
+        disabled={matchInfo.total === 0}
+        caseSensitive={caseSensitive}
+        regex={regex}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onToggleCase={setCaseSensitive}
+        onToggleRegex={setRegex}
+        onClose={handleClose}
+      />
+    </div>
+  );
+}
+
+interface SearchInputRowProps {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  query: string;
+  onQueryChange: (value: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  counterLabel: string;
+  hasError: boolean;
+  errorTitle: string | null;
+  muted: boolean;
+}
+
+function SearchInputRow({
+  inputRef,
+  query,
+  onQueryChange,
+  onKeyDown,
+  counterLabel,
+  hasError,
+  errorTitle,
+  muted,
+}: SearchInputRowProps) {
+  return (
+    <>
+      <Search className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <input
+        ref={inputRef}
+        autoFocus
+        type="text"
+        spellCheck={false}
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Find"
+        title={errorTitle ?? undefined}
+        className={cn(
+          "w-44 bg-transparent text-sm outline-none placeholder:text-muted-foreground/70",
+          hasError && "text-destructive",
+          muted && "text-muted-foreground",
+        )}
+        aria-invalid={hasError}
+      />
+      <span
+        className="shrink-0 min-w-[68px] text-right text-xs tabular-nums text-muted-foreground"
+        aria-live="polite"
+      >
+        {counterLabel}
+      </span>
+    </>
+  );
+}
+
+interface SearchPanelControlsProps {
+  disabled: boolean;
+  caseSensitive: boolean;
+  regex: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  onToggleCase: (v: boolean) => void;
+  onToggleRegex: (v: boolean) => void;
+  onClose: () => void;
+}
+
+function SearchPanelControls({
+  disabled,
+  caseSensitive,
+  regex,
+  onPrev,
+  onNext,
+  onToggleCase,
+  onToggleRegex,
+  onClose,
+}: SearchPanelControlsProps) {
+  return (
+    <div className="flex items-center gap-0.5 border-l border-border/60 pl-1">
+      <IconButton title="Previous match (Shift+Enter)" onClick={onPrev} disabled={disabled}>
+        <ChevronUp className="size-3.5" />
+      </IconButton>
+      <IconButton title="Next match (Enter)" onClick={onNext} disabled={disabled}>
+        <ChevronDown className="size-3.5" />
+      </IconButton>
+      <SearchToggleButton
+        active={caseSensitive}
+        onToggle={onToggleCase}
+        title="Match case"
+        icon={<CaseSensitive className="size-3.5" />}
+      />
+      <SearchToggleButton
+        active={regex}
+        onToggle={onToggleRegex}
+        title="Use regular expression"
+        icon={<Regex className="size-3.5" />}
+      />
+      <IconButton title="Close (Esc)" onClick={onClose}>
+        <X className="size-3.5" />
+      </IconButton>
+    </div>
+  );
+}
+
+interface IconButtonProps {
+  title: string;
+  onClick: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+function IconButton({ title, onClick, children, disabled }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "flex items-center justify-center rounded px-1 py-1 text-foreground/70 transition-colors",
+        "hover:bg-accent hover:text-foreground",
+        "disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-foreground/70 disabled:cursor-not-allowed",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function useLiveMatchInfo(view: EditorView): MatchInfo {
+  const [info, setInfo] = useState<MatchInfo>(() => readMatchInfo(view));
+  useEffect(() => {
+    let raf = 0;
+    let prev: MatchInfo = readMatchInfo(view);
+    setInfo(prev);
+    function tick(): void {
+      const next = readMatchInfo(view);
+      if (!matchInfoEqual(prev, next)) {
+        prev = next;
+        setInfo(next);
+      }
+      raf = requestAnimationFrame(tick);
+    }
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [view]);
+  return info;
+}
+
+function readMatchInfo(view: EditorView): MatchInfo {
+  const s = getBufferSearchState(view);
+  return {
+    total: s.matches.length,
+    active: s.activeIndex,
+    truncated: s.truncated,
+    error: s.error,
+  };
+}
+
+function matchInfoEqual(a: MatchInfo, b: MatchInfo): boolean {
+  return (
+    a.total === b.total &&
+    a.active === b.active &&
+    a.truncated === b.truncated &&
+    a.error === b.error
+  );
+}
+
+function buildCounterLabel(query: string, info: MatchInfo): string {
+  if (info.error) return "Bad regex";
+  if (!query) return "";
+  if (info.total === 0) return "No results";
+  const totalLabel = info.truncated ? `${MAX_BUFFER_MATCHES}+` : `${info.total}`;
+  const activeLabel = info.active >= 0 ? info.active + 1 : 1;
+  return `${activeLabel} of ${totalLabel}`;
+}
+
+export default memo(EditorSearchPanel);

--- a/packages/desktop/src/components/editor/editor-search/EditorSearchPanel.tsx
+++ b/packages/desktop/src/components/editor/editor-search/EditorSearchPanel.tsx
@@ -24,14 +24,19 @@ import {
   setBufferSearchQuery,
   subscribeBufferSearch,
 } from "./search-extension";
-import type { PaneSearchState } from "./search-cache";
+import { getPaneSearch, setPaneSearch } from "./search-cache";
 
 interface EditorSearchPanelProps {
   view: EditorView;
-  initialState: PaneSearchState;
+  /**
+   * Identifies which pane's persisted search state to hydrate from and write
+   * back to. The panel reads the cache lazily on every mount, so reopening
+   * Cmd+F after closing restores the user's last query.
+   */
+  featureId: number;
+  paneId: string;
   /** Bumped by the parent every time Cmd+F is pressed while the panel is already open. */
   reopenSignal: number;
-  onChange: (state: PaneSearchState) => void;
   onClose: () => void;
 }
 
@@ -46,14 +51,18 @@ interface MatchInfo {
 
 function EditorSearchPanel({
   view,
-  initialState,
+  featureId,
+  paneId,
   reopenSignal,
-  onChange,
   onClose,
 }: EditorSearchPanelProps) {
-  const [query, setQuery] = useState<string>(initialState.query);
-  const [caseSensitive, setCaseSensitive] = useState<boolean>(initialState.caseSensitive);
-  const [regex, setRegex] = useState<boolean>(initialState.regex);
+  // Lazy initializers re-read the cache on every mount, so closing and
+  // reopening Cmd+F within the same pane restores the previous query.
+  const [query, setQueryState] = useState<string>(() => getPaneSearch(featureId, paneId).query);
+  const [caseSensitive, setCaseSensitiveState] = useState<boolean>(
+    () => getPaneSearch(featureId, paneId).caseSensitive,
+  );
+  const [regex, setRegexState] = useState<boolean>(() => getPaneSearch(featureId, paneId).regex);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const debouncedQuery = useDebouncedValue(query, QUERY_DEBOUNCE_MS);
@@ -62,9 +71,33 @@ function EditorSearchPanel({
     setBufferSearchQuery(view, { query: debouncedQuery, caseSensitive, regex });
   }, [view, debouncedQuery, caseSensitive, regex]);
 
-  useEffect(() => {
-    onChange({ query, caseSensitive, regex });
-  }, [query, caseSensitive, regex, onChange]);
+  // Persist directly from the setters rather than from a mount-time effect, so
+  // we never clobber the cache with the panel's initial values on remount.
+  const setQuery = useCallback(
+    (next: string): void => {
+      setQueryState(next);
+      setPaneSearch(featureId, paneId, {
+        query: next,
+        caseSensitive,
+        regex,
+      });
+    },
+    [featureId, paneId, caseSensitive, regex],
+  );
+  const setCaseSensitive = useCallback(
+    (next: boolean): void => {
+      setCaseSensitiveState(next);
+      setPaneSearch(featureId, paneId, { query, caseSensitive: next, regex });
+    },
+    [featureId, paneId, query, regex],
+  );
+  const setRegex = useCallback(
+    (next: boolean): void => {
+      setRegexState(next);
+      setPaneSearch(featureId, paneId, { query, caseSensitive, regex: next });
+    },
+    [featureId, paneId, query, caseSensitive],
+  );
 
   useEffect(() => {
     const el = inputRef.current;
@@ -291,7 +324,9 @@ function buildCounterLabel(query: string, info: MatchInfo): string {
   if (!query) return "";
   if (info.total === 0) return "No results";
   const totalLabel = info.truncated ? `${MAX_BUFFER_MATCHES}+` : `${info.total}`;
-  const activeLabel = info.active >= 0 ? info.active + 1 : 1;
+  // When matches exist but no active match is highlighted (transient states
+  // between dispatches), render an em-dash rather than a misleading "1 of N".
+  const activeLabel = info.active >= 0 ? String(info.active + 1) : "–";
   return `${activeLabel} of ${totalLabel}`;
 }
 

--- a/packages/desktop/src/components/editor/editor-search/EditorSearchPanel.tsx
+++ b/packages/desktop/src/components/editor/editor-search/EditorSearchPanel.tsx
@@ -1,7 +1,17 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
 import type { EditorView } from "@codemirror/view";
 import { CaseSensitive, ChevronDown, ChevronUp, Regex, Search, X } from "lucide-react";
 import SearchToggleButton from "../SearchToggleButton";
+import { Button } from "@/components/ui/button";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { cn } from "@/lib/utils";
 import {
@@ -10,7 +20,9 @@ import {
   findNextMatch,
   findPrevMatch,
   getBufferSearchState,
+  selectActiveMatch,
   setBufferSearchQuery,
+  subscribeBufferSearch,
 } from "./search-extension";
 import type { PaneSearchState } from "./search-cache";
 
@@ -81,6 +93,7 @@ function EditorSearchPanel({
       if (event.key !== "Enter") return;
       event.preventDefault();
       if ((event.metaKey || event.ctrlKey) && !event.shiftKey) {
+        selectActiveMatch(view);
         event.currentTarget.blur();
         view.focus();
         return;
@@ -129,7 +142,7 @@ function EditorSearchPanel({
 }
 
 interface SearchInputRowProps {
-  inputRef: React.RefObject<HTMLInputElement | null>;
+  inputRef: RefObject<HTMLInputElement | null>;
   query: string;
   onQueryChange: (value: string) => void;
   onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
@@ -202,12 +215,26 @@ function SearchPanelControls({
 }: SearchPanelControlsProps) {
   return (
     <div className="flex items-center gap-0.5 border-l border-border/60 pl-1">
-      <IconButton title="Previous match (Shift+Enter)" onClick={onPrev} disabled={disabled}>
-        <ChevronUp className="size-3.5" />
-      </IconButton>
-      <IconButton title="Next match (Enter)" onClick={onNext} disabled={disabled}>
-        <ChevronDown className="size-3.5" />
-      </IconButton>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        title="Previous match (Shift+Enter)"
+        aria-label="Previous match"
+        onClick={onPrev}
+        disabled={disabled}
+      >
+        <ChevronUp />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        title="Next match (Enter)"
+        aria-label="Next match"
+        onClick={onNext}
+        disabled={disabled}
+      >
+        <ChevronDown />
+      </Button>
       <SearchToggleButton
         active={caseSensitive}
         onToggle={onToggleCase}
@@ -220,54 +247,31 @@ function SearchPanelControls({
         title="Use regular expression"
         icon={<Regex className="size-3.5" />}
       />
-      <IconButton title="Close (Esc)" onClick={onClose}>
-        <X className="size-3.5" />
-      </IconButton>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        title="Close (Esc)"
+        aria-label="Close search"
+        onClick={onClose}
+      >
+        <X />
+      </Button>
     </div>
-  );
-}
-
-interface IconButtonProps {
-  title: string;
-  onClick: () => void;
-  children: React.ReactNode;
-  disabled?: boolean;
-}
-
-function IconButton({ title, onClick, children, disabled }: IconButtonProps) {
-  return (
-    <button
-      type="button"
-      title={title}
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "flex items-center justify-center rounded px-1 py-1 text-foreground/70 transition-colors",
-        "hover:bg-accent hover:text-foreground",
-        "disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-foreground/70 disabled:cursor-not-allowed",
-      )}
-    >
-      {children}
-    </button>
   );
 }
 
 function useLiveMatchInfo(view: EditorView): MatchInfo {
   const [info, setInfo] = useState<MatchInfo>(() => readMatchInfo(view));
   useEffect(() => {
-    let raf = 0;
-    let prev: MatchInfo = readMatchInfo(view);
-    setInfo(prev);
-    function tick(): void {
-      const next = readMatchInfo(view);
-      if (!matchInfoEqual(prev, next)) {
-        prev = next;
-        setInfo(next);
-      }
-      raf = requestAnimationFrame(tick);
-    }
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
+    setInfo(readMatchInfo(view));
+    return subscribeBufferSearch(view, (state) => {
+      setInfo({
+        total: state.matches.length,
+        active: state.activeIndex,
+        truncated: state.truncated,
+        error: state.error,
+      });
+    });
   }, [view]);
   return info;
 }
@@ -280,15 +284,6 @@ function readMatchInfo(view: EditorView): MatchInfo {
     truncated: s.truncated,
     error: s.error,
   };
-}
-
-function matchInfoEqual(a: MatchInfo, b: MatchInfo): boolean {
-  return (
-    a.total === b.total &&
-    a.active === b.active &&
-    a.truncated === b.truncated &&
-    a.error === b.error
-  );
 }
 
 function buildCounterLabel(query: string, info: MatchInfo): string {

--- a/packages/desktop/src/components/editor/editor-search/__tests__/EditorSearchPanel.test.tsx
+++ b/packages/desktop/src/components/editor/editor-search/__tests__/EditorSearchPanel.test.tsx
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   selectActiveMatch: vi.fn(),
   subscribeBufferSearch: vi.fn(),
   getBufferSearchState: vi.fn(),
+  getPaneSearch: vi.fn(),
+  setPaneSearch: vi.fn(),
 }));
 
 vi.mock("../search-extension", async () => {
@@ -25,6 +27,13 @@ vi.mock("../search-extension", async () => {
     selectActiveMatch: mocks.selectActiveMatch,
     subscribeBufferSearch: mocks.subscribeBufferSearch,
     getBufferSearchState: mocks.getBufferSearchState,
+  };
+});
+
+vi.mock("../search-cache", async () => {
+  return {
+    getPaneSearch: mocks.getPaneSearch,
+    setPaneSearch: mocks.setPaneSearch,
   };
 });
 
@@ -45,6 +54,8 @@ function emptyState(): BufferSearchState {
 }
 
 const defaultInitial: PaneSearchState = { query: "", caseSensitive: false, regex: false };
+const FEATURE_ID = 7;
+const PANE_ID = "main";
 
 beforeEach(() => {
   mocks.setBufferSearchQuery.mockClear();
@@ -55,27 +66,31 @@ beforeEach(() => {
   mocks.subscribeBufferSearch.mockClear();
   mocks.subscribeBufferSearch.mockImplementation(() => () => {});
   mocks.getBufferSearchState.mockReturnValue(emptyState());
+  mocks.getPaneSearch.mockReset();
+  mocks.getPaneSearch.mockReturnValue(defaultInitial);
+  mocks.setPaneSearch.mockClear();
 });
 
 function renderPanel(overrides?: {
   initialState?: PaneSearchState;
   reopenSignal?: number;
   onClose?: () => void;
-  onChange?: (s: PaneSearchState) => void;
 }) {
+  if (overrides?.initialState) {
+    mocks.getPaneSearch.mockReturnValue(overrides.initialState);
+  }
   const view = makeMockView();
   const onClose = overrides?.onClose ?? vi.fn();
-  const onChange = overrides?.onChange ?? vi.fn();
   const utils = render(
     <EditorSearchPanel
       view={view}
-      initialState={overrides?.initialState ?? defaultInitial}
+      featureId={FEATURE_ID}
+      paneId={PANE_ID}
       reopenSignal={overrides?.reopenSignal ?? 0}
-      onChange={onChange}
       onClose={onClose}
     />,
   );
-  return { view, onClose, onChange, ...utils };
+  return { view, onClose, ...utils };
 }
 
 function pushState(state: Partial<BufferSearchState>): void {
@@ -94,13 +109,22 @@ describe("EditorSearchPanel", () => {
     expect(screen.queryByText(/of/)).not.toBeInTheDocument();
   });
 
-  it("hydrates from initialState", () => {
+  it("hydrates from the persisted pane state on mount", () => {
     renderPanel({
       initialState: { query: "hello", caseSensitive: true, regex: false },
     });
     expect((screen.getByPlaceholderText("Find") as HTMLInputElement).value).toBe("hello");
     const caseToggle = screen.getByTitle("Match case");
     expect(caseToggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("does not write back to the cache on mount", () => {
+    renderPanel({
+      initialState: { query: "hello", caseSensitive: true, regex: false },
+    });
+    // The panel should NOT call setPaneSearch just for mounting — only when
+    // the user actually edits the query or toggles a flag.
+    expect(mocks.setPaneSearch).not.toHaveBeenCalled();
   });
 
   it("shows 'No results' when the live state reports zero matches", () => {
@@ -123,6 +147,16 @@ describe("EditorSearchPanel", () => {
       activeIndex: 1,
     });
     expect(screen.getByText("2 of 2")).toBeInTheDocument();
+  });
+
+  it("renders an em-dash for the active index when no match is highlighted", () => {
+    renderPanel({ initialState: { query: "foo", caseSensitive: false, regex: false } });
+    pushState({
+      query: { query: "foo", caseSensitive: false, regex: false },
+      matches: [{ from: 0, to: 3 }],
+      activeIndex: -1,
+    });
+    expect(screen.getByText("– of 1")).toBeInTheDocument();
   });
 
   it("renders the truncated suffix when MAX_BUFFER_MATCHES is hit", () => {
@@ -209,28 +243,46 @@ describe("EditorSearchPanel", () => {
     expect(btn).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("persists state to onChange whenever query, case, or regex change", () => {
-    const onChange = vi.fn();
-    renderPanel({ onChange });
-    onChange.mockClear();
+  it("persists state to the cache when the query changes", () => {
+    renderPanel();
     fireEvent.change(screen.getByPlaceholderText("Find"), { target: { value: "abc" } });
-    expect(onChange).toHaveBeenLastCalledWith({
+    expect(mocks.setPaneSearch).toHaveBeenLastCalledWith(FEATURE_ID, PANE_ID, {
       query: "abc",
       caseSensitive: false,
       regex: false,
     });
   });
 
+  it("persists state to the cache when case-sensitive is toggled", () => {
+    renderPanel({ initialState: { query: "foo", caseSensitive: false, regex: false } });
+    fireEvent.click(screen.getByTitle("Match case"));
+    expect(mocks.setPaneSearch).toHaveBeenLastCalledWith(FEATURE_ID, PANE_ID, {
+      query: "foo",
+      caseSensitive: true,
+      regex: false,
+    });
+  });
+
+  it("persists state to the cache when regex is toggled", () => {
+    renderPanel({ initialState: { query: "foo", caseSensitive: false, regex: false } });
+    fireEvent.click(screen.getByTitle("Use regular expression"));
+    expect(mocks.setPaneSearch).toHaveBeenLastCalledWith(FEATURE_ID, PANE_ID, {
+      query: "foo",
+      caseSensitive: false,
+      regex: true,
+    });
+  });
+
   it("re-focuses and selects the input when reopenSignal increments", () => {
-    const { rerender, view, onClose, onChange } = renderPanel({ reopenSignal: 0 });
+    const { rerender, view, onClose } = renderPanel({ reopenSignal: 0 });
     const input = screen.getByPlaceholderText("Find") as HTMLInputElement;
     input.blur();
     rerender(
       <EditorSearchPanel
         view={view}
-        initialState={defaultInitial}
+        featureId={FEATURE_ID}
+        paneId={PANE_ID}
         reopenSignal={1}
-        onChange={onChange}
         onClose={onClose}
       />,
     );

--- a/packages/desktop/src/components/editor/editor-search/__tests__/EditorSearchPanel.test.tsx
+++ b/packages/desktop/src/components/editor/editor-search/__tests__/EditorSearchPanel.test.tsx
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
+import { act, fireEvent, render, screen } from "@/test-utils";
+import type { EditorView } from "@codemirror/view";
+import EditorSearchPanel from "../EditorSearchPanel";
+import type { PaneSearchState } from "../search-cache";
+import type { BufferSearchState } from "../search-extension";
+
+const mocks = vi.hoisted(() => ({
+  setBufferSearchQuery: vi.fn(),
+  findNextMatch: vi.fn(),
+  findPrevMatch: vi.fn(),
+  closeBufferSearch: vi.fn(),
+  selectActiveMatch: vi.fn(),
+  subscribeBufferSearch: vi.fn(),
+  getBufferSearchState: vi.fn(),
+}));
+
+vi.mock("../search-extension", async () => {
+  return {
+    MAX_BUFFER_MATCHES: 5000,
+    setBufferSearchQuery: mocks.setBufferSearchQuery,
+    findNextMatch: mocks.findNextMatch,
+    findPrevMatch: mocks.findPrevMatch,
+    closeBufferSearch: mocks.closeBufferSearch,
+    selectActiveMatch: mocks.selectActiveMatch,
+    subscribeBufferSearch: mocks.subscribeBufferSearch,
+    getBufferSearchState: mocks.getBufferSearchState,
+  };
+});
+
+function makeMockView(): EditorView {
+  return {
+    focus: vi.fn(),
+  } as unknown as EditorView;
+}
+
+function emptyState(): BufferSearchState {
+  return {
+    query: { query: "", caseSensitive: false, regex: false },
+    matches: [],
+    activeIndex: -1,
+    truncated: false,
+    error: null,
+  };
+}
+
+const defaultInitial: PaneSearchState = { query: "", caseSensitive: false, regex: false };
+
+beforeEach(() => {
+  mocks.setBufferSearchQuery.mockClear();
+  mocks.findNextMatch.mockClear();
+  mocks.findPrevMatch.mockClear();
+  mocks.closeBufferSearch.mockClear();
+  mocks.selectActiveMatch.mockClear();
+  mocks.subscribeBufferSearch.mockClear();
+  mocks.subscribeBufferSearch.mockImplementation(() => () => {});
+  mocks.getBufferSearchState.mockReturnValue(emptyState());
+});
+
+function renderPanel(overrides?: {
+  initialState?: PaneSearchState;
+  reopenSignal?: number;
+  onClose?: () => void;
+  onChange?: (s: PaneSearchState) => void;
+}) {
+  const view = makeMockView();
+  const onClose = overrides?.onClose ?? vi.fn();
+  const onChange = overrides?.onChange ?? vi.fn();
+  const utils = render(
+    <EditorSearchPanel
+      view={view}
+      initialState={overrides?.initialState ?? defaultInitial}
+      reopenSignal={overrides?.reopenSignal ?? 0}
+      onChange={onChange}
+      onClose={onClose}
+    />,
+  );
+  return { view, onClose, onChange, ...utils };
+}
+
+function pushState(state: Partial<BufferSearchState>): void {
+  const cb = (mocks.subscribeBufferSearch.mock.calls.at(-1)?.[1] ?? null) as
+    | ((s: BufferSearchState) => void)
+    | null;
+  if (!cb) throw new Error("no subscriber registered");
+  act(() => cb({ ...emptyState(), ...state }));
+}
+
+describe("EditorSearchPanel", () => {
+  it("renders an empty input and no counter when query is empty", () => {
+    renderPanel();
+    const input = screen.getByPlaceholderText("Find") as HTMLInputElement;
+    expect(input.value).toBe("");
+    expect(screen.queryByText(/of/)).not.toBeInTheDocument();
+  });
+
+  it("hydrates from initialState", () => {
+    renderPanel({
+      initialState: { query: "hello", caseSensitive: true, regex: false },
+    });
+    expect((screen.getByPlaceholderText("Find") as HTMLInputElement).value).toBe("hello");
+    const caseToggle = screen.getByTitle("Match case");
+    expect(caseToggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows 'No results' when the live state reports zero matches", () => {
+    renderPanel({ initialState: { query: "xyz", caseSensitive: false, regex: false } });
+    pushState({
+      query: { query: "xyz", caseSensitive: false, regex: false },
+      matches: [],
+    });
+    expect(screen.getByText("No results")).toBeInTheDocument();
+  });
+
+  it("renders the counter as 'N of M' when matches exist", () => {
+    renderPanel({ initialState: { query: "foo", caseSensitive: false, regex: false } });
+    pushState({
+      query: { query: "foo", caseSensitive: false, regex: false },
+      matches: [
+        { from: 0, to: 3 },
+        { from: 4, to: 7 },
+      ],
+      activeIndex: 1,
+    });
+    expect(screen.getByText("2 of 2")).toBeInTheDocument();
+  });
+
+  it("renders the truncated suffix when MAX_BUFFER_MATCHES is hit", () => {
+    renderPanel({ initialState: { query: "a", caseSensitive: false, regex: false } });
+    pushState({
+      query: { query: "a", caseSensitive: false, regex: false },
+      matches: Array.from({ length: 5000 }, (_, i) => ({ from: i, to: i + 1 })),
+      activeIndex: 0,
+      truncated: true,
+    });
+    expect(screen.getByText("1 of 5000+")).toBeInTheDocument();
+  });
+
+  it("shows 'Bad regex' and marks the input invalid on regex error", () => {
+    renderPanel({ initialState: { query: "[", caseSensitive: false, regex: true } });
+    pushState({
+      query: { query: "[", caseSensitive: false, regex: true },
+      matches: [],
+      error: "Invalid regex",
+    });
+    expect(screen.getByText("Bad regex")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Find")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("calls findNextMatch on Enter", () => {
+    renderPanel();
+    fireEvent.keyDown(screen.getByPlaceholderText("Find"), { key: "Enter" });
+    expect(mocks.findNextMatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls findPrevMatch on Shift+Enter", () => {
+    renderPanel();
+    fireEvent.keyDown(screen.getByPlaceholderText("Find"), { key: "Enter", shiftKey: true });
+    expect(mocks.findPrevMatch).toHaveBeenCalledTimes(1);
+    expect(mocks.findNextMatch).not.toHaveBeenCalled();
+  });
+
+  it("on Cmd+Enter: selects the active match, blurs input, focuses buffer", () => {
+    const { view } = renderPanel();
+    fireEvent.keyDown(screen.getByPlaceholderText("Find"), { key: "Enter", metaKey: true });
+    expect(mocks.selectActiveMatch).toHaveBeenCalledWith(view);
+    expect(mocks.findNextMatch).not.toHaveBeenCalled();
+    expect(view.focus as Mock).toHaveBeenCalled();
+  });
+
+  it("on Escape: closes the search and calls onClose", () => {
+    const { view, onClose } = renderPanel();
+    fireEvent.keyDown(screen.getByPlaceholderText("Find"), { key: "Escape" });
+    expect(mocks.closeBufferSearch).toHaveBeenCalledWith(view);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(view.focus as Mock).toHaveBeenCalled();
+  });
+
+  it("clicking the next button calls findNextMatch when matches exist", () => {
+    renderPanel();
+    pushState({
+      query: { query: "x", caseSensitive: false, regex: false },
+      matches: [{ from: 0, to: 1 }],
+      activeIndex: 0,
+    });
+    fireEvent.click(screen.getByTitle("Next match (Enter)"));
+    expect(mocks.findNextMatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("next / prev buttons are disabled when there are no matches", () => {
+    renderPanel();
+    expect(screen.getByTitle("Next match (Enter)")).toBeDisabled();
+    expect(screen.getByTitle("Previous match (Shift+Enter)")).toBeDisabled();
+  });
+
+  it("toggling the case-sensitive button flips aria-pressed", () => {
+    renderPanel({ initialState: { query: "foo", caseSensitive: false, regex: false } });
+    const btn = screen.getByTitle("Match case");
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("toggling the regex button flips aria-pressed", () => {
+    renderPanel({ initialState: { query: "foo", caseSensitive: false, regex: false } });
+    const btn = screen.getByTitle("Use regular expression");
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("persists state to onChange whenever query, case, or regex change", () => {
+    const onChange = vi.fn();
+    renderPanel({ onChange });
+    onChange.mockClear();
+    fireEvent.change(screen.getByPlaceholderText("Find"), { target: { value: "abc" } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      query: "abc",
+      caseSensitive: false,
+      regex: false,
+    });
+  });
+
+  it("re-focuses and selects the input when reopenSignal increments", () => {
+    const { rerender, view, onClose, onChange } = renderPanel({ reopenSignal: 0 });
+    const input = screen.getByPlaceholderText("Find") as HTMLInputElement;
+    input.blur();
+    rerender(
+      <EditorSearchPanel
+        view={view}
+        initialState={defaultInitial}
+        reopenSignal={1}
+        onChange={onChange}
+        onClose={onClose}
+      />,
+    );
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/packages/desktop/src/components/editor/editor-search/__tests__/search-cache.test.ts
+++ b/packages/desktop/src/components/editor/editor-search/__tests__/search-cache.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { clearFeatureSearch, clearPaneSearch, getPaneSearch, setPaneSearch } from "../search-cache";
+
+describe("search-cache", () => {
+  // The cache is module-scoped; isolate every test by clearing the keys this
+  // test touches before each run.
+  beforeEach(() => {
+    clearFeatureSearch(1);
+    clearFeatureSearch(2);
+  });
+
+  it("returns the default state when no entry is set", () => {
+    expect(getPaneSearch(1, "main")).toEqual({
+      query: "",
+      caseSensitive: false,
+      regex: false,
+    });
+  });
+
+  it("round-trips a state through set then get", () => {
+    setPaneSearch(1, "main", { query: "foo", caseSensitive: true, regex: false });
+    expect(getPaneSearch(1, "main")).toEqual({
+      query: "foo",
+      caseSensitive: true,
+      regex: false,
+    });
+  });
+
+  it("isolates entries by featureId and paneId", () => {
+    setPaneSearch(1, "a", { query: "left", caseSensitive: false, regex: false });
+    setPaneSearch(1, "b", { query: "right", caseSensitive: false, regex: false });
+    setPaneSearch(2, "a", { query: "other", caseSensitive: false, regex: false });
+    expect(getPaneSearch(1, "a").query).toBe("left");
+    expect(getPaneSearch(1, "b").query).toBe("right");
+    expect(getPaneSearch(2, "a").query).toBe("other");
+  });
+
+  it("overwrites the existing entry for the same key", () => {
+    setPaneSearch(1, "main", { query: "first", caseSensitive: false, regex: false });
+    setPaneSearch(1, "main", { query: "second", caseSensitive: true, regex: true });
+    expect(getPaneSearch(1, "main")).toEqual({
+      query: "second",
+      caseSensitive: true,
+      regex: true,
+    });
+  });
+
+  it("clearPaneSearch drops only the targeted pane", () => {
+    setPaneSearch(1, "a", { query: "keep", caseSensitive: false, regex: false });
+    setPaneSearch(1, "b", { query: "drop", caseSensitive: false, regex: false });
+    clearPaneSearch(1, "b");
+    expect(getPaneSearch(1, "a").query).toBe("keep");
+    expect(getPaneSearch(1, "b").query).toBe("");
+  });
+
+  it("clearFeatureSearch drops every pane under a feature without touching others", () => {
+    setPaneSearch(1, "a", { query: "drop-a", caseSensitive: false, regex: false });
+    setPaneSearch(1, "b", { query: "drop-b", caseSensitive: false, regex: false });
+    setPaneSearch(2, "a", { query: "keep", caseSensitive: false, regex: false });
+    clearFeatureSearch(1);
+    expect(getPaneSearch(1, "a").query).toBe("");
+    expect(getPaneSearch(1, "b").query).toBe("");
+    expect(getPaneSearch(2, "a").query).toBe("keep");
+  });
+});

--- a/packages/desktop/src/components/editor/editor-search/__tests__/search-extension.test.ts
+++ b/packages/desktop/src/components/editor/editor-search/__tests__/search-extension.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, it, expect } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import {
+  MAX_BUFFER_MATCHES,
+  bufferSearchExtension,
+  bufferSearchField,
+  closeBufferSearch,
+  findNextMatch,
+  findPrevMatch,
+  setBufferSearchQuery,
+} from "../search-extension";
+
+const createdViews: EditorView[] = [];
+
+function makeView(doc: string): EditorView {
+  const state = EditorState.create({ doc, extensions: [bufferSearchExtension()] });
+  const view = new EditorView({ state });
+  createdViews.push(view);
+  return view;
+}
+
+afterEach(() => {
+  while (createdViews.length) {
+    createdViews.pop()?.destroy();
+  }
+});
+
+describe("bufferSearchField", () => {
+  it("starts empty", () => {
+    const view = makeView("hello world");
+    const s = view.state.field(bufferSearchField);
+    expect(s.matches).toEqual([]);
+    expect(s.activeIndex).toBe(-1);
+    expect(s.error).toBeNull();
+  });
+
+  it("finds literal matches case-insensitively by default", () => {
+    const view = makeView("Foo foo FOO bar");
+    setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+    const s = view.state.field(bufferSearchField);
+    expect(s.matches.length).toBe(3);
+    expect(s.activeIndex).toBe(0);
+  });
+
+  it("respects case-sensitive mode", () => {
+    const view = makeView("Foo foo FOO");
+    setBufferSearchQuery(view, { query: "foo", caseSensitive: true, regex: false });
+    const s = view.state.field(bufferSearchField);
+    expect(s.matches.length).toBe(1);
+    expect(s.matches[0]).toEqual({ from: 4, to: 7 });
+  });
+
+  it("supports regex search", () => {
+    const view = makeView("foo123 bar456 baz");
+    setBufferSearchQuery(view, { query: "\\d+", caseSensitive: false, regex: true });
+    const s = view.state.field(bufferSearchField);
+    expect(s.matches.length).toBe(2);
+    expect(s.matches[0].to - s.matches[0].from).toBe(3);
+  });
+
+  it("reports an error for invalid regex without throwing", () => {
+    const view = makeView("hello");
+    setBufferSearchQuery(view, { query: "[unterminated", caseSensitive: false, regex: true });
+    const s = view.state.field(bufferSearchField);
+    expect(s.error).not.toBeNull();
+    expect(s.matches).toEqual([]);
+  });
+
+  it("caps matches at MAX_BUFFER_MATCHES and reports truncation", () => {
+    const view = makeView("a".repeat(MAX_BUFFER_MATCHES + 50));
+    setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+    const s = view.state.field(bufferSearchField);
+    expect(s.matches.length).toBe(MAX_BUFFER_MATCHES);
+    expect(s.truncated).toBe(true);
+  });
+
+  it("findNextMatch wraps around at the end", () => {
+    const view = makeView("a b a b a");
+    setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(0);
+    findNextMatch(view);
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(1);
+    findNextMatch(view);
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(2);
+    findNextMatch(view);
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(0);
+  });
+
+  it("findPrevMatch wraps around at the start", () => {
+    const view = makeView("a b a b a");
+    setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+    findPrevMatch(view);
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(2);
+    findPrevMatch(view);
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(1);
+  });
+
+  it("closeBufferSearch clears state and matches", () => {
+    const view = makeView("foo foo");
+    setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+    expect(view.state.field(bufferSearchField).matches.length).toBe(2);
+    closeBufferSearch(view);
+    const s = view.state.field(bufferSearchField);
+    expect(s.matches).toEqual([]);
+    expect(s.activeIndex).toBe(-1);
+    expect(s.query.query).toBe("");
+  });
+});

--- a/packages/desktop/src/components/editor/editor-search/__tests__/search-extension.test.ts
+++ b/packages/desktop/src/components/editor/editor-search/__tests__/search-extension.test.ts
@@ -153,6 +153,15 @@ describe("bufferSearchField", () => {
       setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
       expect(view.state.field(bufferSearchField).activeIndex).toBe(0);
     });
+
+    it("selects the match containing the cursor instead of the next one", () => {
+      // doc "foobar more foobar"; matches at [0,6] and [12,18]. Cursor at 3
+      // sits INSIDE the first match — selecting the second would surprise
+      // the user. The first match should win.
+      const view = makeView("foobar more foobar", 3);
+      setBufferSearchQuery(view, { query: "foobar", caseSensitive: false, regex: false });
+      expect(view.state.field(bufferSearchField).activeIndex).toBe(0);
+    });
   });
 
   describe("document edits while search is open", () => {

--- a/packages/desktop/src/components/editor/editor-search/__tests__/search-extension.test.ts
+++ b/packages/desktop/src/components/editor/editor-search/__tests__/search-extension.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import {
@@ -8,13 +8,20 @@ import {
   closeBufferSearch,
   findNextMatch,
   findPrevMatch,
+  selectActiveMatch,
+  setBufferActiveIndexEffect,
   setBufferSearchQuery,
+  subscribeBufferSearch,
 } from "../search-extension";
 
 const createdViews: EditorView[] = [];
 
-function makeView(doc: string): EditorView {
-  const state = EditorState.create({ doc, extensions: [bufferSearchExtension()] });
+function makeView(doc: string, selection?: number): EditorView {
+  const state = EditorState.create({
+    doc,
+    selection: selection !== undefined ? { anchor: selection } : undefined,
+    extensions: [bufferSearchExtension()],
+  });
   const view = new EditorView({ state });
   createdViews.push(view);
   return view;
@@ -75,6 +82,17 @@ describe("bufferSearchField", () => {
     expect(s.truncated).toBe(true);
   });
 
+  it("clears truncation and error flags when a valid narrower query replaces a broken one", () => {
+    const view = makeView("foo bar");
+    setBufferSearchQuery(view, { query: "[bad", caseSensitive: false, regex: true });
+    expect(view.state.field(bufferSearchField).error).not.toBeNull();
+    setBufferSearchQuery(view, { query: "bar", caseSensitive: false, regex: false });
+    const s = view.state.field(bufferSearchField);
+    expect(s.error).toBeNull();
+    expect(s.truncated).toBe(false);
+    expect(s.matches.length).toBe(1);
+  });
+
   it("findNextMatch wraps around at the end", () => {
     const view = makeView("a b a b a");
     setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
@@ -105,5 +123,120 @@ describe("bufferSearchField", () => {
     expect(s.matches).toEqual([]);
     expect(s.activeIndex).toBe(-1);
     expect(s.query.query).toBe("");
+  });
+
+  it("setBufferActiveIndexEffect wraps any out-of-range integer modularly", () => {
+    const view = makeView("a a a");
+    setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+    view.dispatch({ effects: setBufferActiveIndexEffect.of(-5) });
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(1);
+    view.dispatch({ effects: setBufferActiveIndexEffect.of(7) });
+    expect(view.state.field(bufferSearchField).activeIndex).toBe(1);
+  });
+
+  describe("initial active match selection (pickInitialActive)", () => {
+    it("picks the first match at or after the cursor", () => {
+      const view = makeView("a b a b a", 4);
+      setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+      // Matches at 0, 4, 8; cursor at 4 → active index 1.
+      expect(view.state.field(bufferSearchField).activeIndex).toBe(1);
+    });
+
+    it("wraps to the first match when the cursor sits past the last match", () => {
+      const view = makeView("a b a b a", 9);
+      setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+      expect(view.state.field(bufferSearchField).activeIndex).toBe(0);
+    });
+
+    it("uses the first match when the cursor is before every match", () => {
+      const view = makeView("xx a b a", 0);
+      setBufferSearchQuery(view, { query: "a", caseSensitive: false, regex: false });
+      expect(view.state.field(bufferSearchField).activeIndex).toBe(0);
+    });
+  });
+
+  describe("document edits while search is open", () => {
+    it("re-scans matches when the document changes", () => {
+      const view = makeView("foo bar foo");
+      setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+      expect(view.state.field(bufferSearchField).matches.length).toBe(2);
+      view.dispatch({ changes: { from: 11, insert: " foo" } });
+      expect(view.state.field(bufferSearchField).matches.length).toBe(3);
+    });
+
+    it("keeps the active match aligned with its mapped position after an insertion before it", () => {
+      const view = makeView("foo foo foo");
+      setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+      findNextMatch(view); // activate match #2 at pos 4
+      expect(view.state.field(bufferSearchField).activeIndex).toBe(1);
+      // Insert 4 chars at the very start of the document.
+      view.dispatch({ changes: { from: 0, insert: "AAA " } });
+      // The 2nd "foo" used to be at 4, now at 8. After re-scan, active should
+      // still target the same logical match (now index 1 again).
+      const s = view.state.field(bufferSearchField);
+      expect(s.matches[s.activeIndex].from).toBe(8);
+    });
+
+    it("drops the active match when its underlying text is deleted but other matches survive", () => {
+      const view = makeView("foo bar foo");
+      setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+      findNextMatch(view); // active = match at pos 8
+      // Delete the trailing "foo".
+      view.dispatch({ changes: { from: 7, to: 11, insert: "" } });
+      const s = view.state.field(bufferSearchField);
+      expect(s.matches.length).toBe(1);
+      expect(s.activeIndex).toBeGreaterThanOrEqual(0);
+      expect(s.activeIndex).toBeLessThan(s.matches.length);
+    });
+
+    it("does not run a re-scan when the query is empty", () => {
+      const view = makeView("nothing here");
+      // No query set — doc change should keep matches empty without throwing.
+      view.dispatch({ changes: { from: 0, insert: "x" } });
+      expect(view.state.field(bufferSearchField).matches).toEqual([]);
+    });
+  });
+
+  describe("selectActiveMatch", () => {
+    it("moves the editor selection onto the active match", () => {
+      const view = makeView("foo bar foo");
+      setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+      findNextMatch(view);
+      selectActiveMatch(view);
+      const sel = view.state.selection.main;
+      expect(sel.from).toBe(8);
+      expect(sel.to).toBe(11);
+    });
+
+    it("is a no-op when there is no active match", () => {
+      const view = makeView("hello");
+      const before = view.state.selection.main;
+      selectActiveMatch(view);
+      const after = view.state.selection.main;
+      expect(after.from).toBe(before.from);
+      expect(after.to).toBe(before.to);
+    });
+  });
+
+  describe("subscribeBufferSearch", () => {
+    it("calls the subscriber with the new state when the field changes", () => {
+      const view = makeView("foo foo");
+      const cb = vi.fn();
+      const unsubscribe = subscribeBufferSearch(view, cb);
+      setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+      expect(cb).toHaveBeenCalled();
+      const last = cb.mock.calls.at(-1)?.[0];
+      expect(last?.matches.length).toBe(2);
+      unsubscribe();
+    });
+
+    it("stops firing after unsubscribe", () => {
+      const view = makeView("foo foo");
+      const cb = vi.fn();
+      const unsubscribe = subscribeBufferSearch(view, cb);
+      unsubscribe();
+      setBufferSearchQuery(view, { query: "foo", caseSensitive: false, regex: false });
+      expect(cb).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/desktop/src/components/editor/editor-search/search-cache.ts
+++ b/packages/desktop/src/components/editor/editor-search/search-cache.ts
@@ -19,3 +19,16 @@ export function getPaneSearch(featureId: number, paneId: string): PaneSearchStat
 export function setPaneSearch(featureId: number, paneId: string, state: PaneSearchState): void {
   cache.set(keyOf(featureId, paneId), state);
 }
+
+/** Drop the cached search state for a single pane (called on EditorPane unmount). */
+export function clearPaneSearch(featureId: number, paneId: string): void {
+  cache.delete(keyOf(featureId, paneId));
+}
+
+/** Drop every cached entry for a feature (called when the feature is closed). */
+export function clearFeatureSearch(featureId: number): void {
+  const prefix = `${featureId}:`;
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) cache.delete(key);
+  }
+}

--- a/packages/desktop/src/components/editor/editor-search/search-cache.ts
+++ b/packages/desktop/src/components/editor/editor-search/search-cache.ts
@@ -1,0 +1,21 @@
+export interface PaneSearchState {
+  query: string;
+  caseSensitive: boolean;
+  regex: boolean;
+}
+
+const DEFAULT_STATE: PaneSearchState = { query: "", caseSensitive: false, regex: false };
+
+const cache = new Map<string, PaneSearchState>();
+
+function keyOf(featureId: number, paneId: string): string {
+  return `${featureId}:${paneId}`;
+}
+
+export function getPaneSearch(featureId: number, paneId: string): PaneSearchState {
+  return cache.get(keyOf(featureId, paneId)) ?? DEFAULT_STATE;
+}
+
+export function setPaneSearch(featureId: number, paneId: string, state: PaneSearchState): void {
+  cache.set(keyOf(featureId, paneId), state);
+}

--- a/packages/desktop/src/components/editor/editor-search/search-extension.ts
+++ b/packages/desktop/src/components/editor/editor-search/search-extension.ts
@@ -92,8 +92,22 @@ function scanLiteralMatches(state: EditorState, q: BufferSearchQuery): ScanResul
 }
 
 function scanRegexMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
+  // Wrap both the cursor construction AND the drain in the same try/catch:
+  // RegExpCursor compiles its own internal regex (with the `i` flag when
+  // `ignoreCase` is set) and can throw at construction time for patterns that
+  // `new RegExp(q.query)` would have accepted as-is. Iteration can also throw
+  // for some edge patterns. A leaked exception here would crash the editor
+  // transaction; surfacing it as an error keeps the UI alive.
   try {
-    new RegExp(q.query);
+    const cursor = new RegExpCursor(
+      state.doc,
+      q.query,
+      { ignoreCase: !q.caseSensitive },
+      0,
+      state.doc.length,
+    );
+    const { matches, truncated } = drainCursor(cursor);
+    return { matches, truncated, error: null };
   } catch (err) {
     return {
       matches: [],
@@ -101,15 +115,6 @@ function scanRegexMatches(state: EditorState, q: BufferSearchQuery): ScanResult 
       error: err instanceof Error ? err.message : "Invalid regex",
     };
   }
-  const cursor = new RegExpCursor(
-    state.doc,
-    q.query,
-    { ignoreCase: !q.caseSensitive },
-    0,
-    state.doc.length,
-  );
-  const { matches, truncated } = drainCursor(cursor);
-  return { matches, truncated, error: null };
 }
 
 function scanMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
@@ -119,8 +124,13 @@ function scanMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
 
 function pickInitialActive(matches: BufferMatch[], cursorPos: number): number {
   if (matches.length === 0) return -1;
+  // Prefer the match the cursor is currently inside, otherwise the next match
+  // after the cursor. `match.to > cursorPos` covers both: it is true when the
+  // cursor sits inside the match (from <= cursorPos < to) and when the match
+  // starts after the cursor. Falls back to the first match if the cursor is
+  // past every match.
   for (let i = 0; i < matches.length; i++) {
-    if (matches[i].from >= cursorPos) return i;
+    if (matches[i].to > cursorPos) return i;
   }
   return 0;
 }
@@ -230,18 +240,14 @@ export function getBufferSearchState(view: EditorView): BufferSearchState {
 }
 
 /**
- * Apply a new query / regex / case-sensitivity setting and scroll the active
- * match into view without disturbing the editor selection. The selection is
- * only moved by explicit navigation (`findNextMatch`, `findPrevMatch`,
- * `selectActiveMatch`) so that typing in the search input does not bump the
- * user's cursor inside the buffer.
+ * Apply a new query / regex / case-sensitivity setting. Neither the editor
+ * selection nor the viewport is moved — typing in the search input should not
+ * yank the buffer around on every keystroke. Scrolling and selection only
+ * happen on explicit navigation (`findNextMatch`, `findPrevMatch`,
+ * `selectActiveMatch`).
  */
 export function setBufferSearchQuery(view: EditorView, query: BufferSearchQuery): void {
   view.dispatch({ effects: setBufferSearchQueryEffect.of(query) });
-  const s = view.state.field(bufferSearchField);
-  if (s.activeIndex < 0) return;
-  const m = s.matches[s.activeIndex];
-  view.dispatch({ effects: EditorView.scrollIntoView(m.from, { y: "center" }) });
 }
 
 export function findNextMatch(view: EditorView): void {

--- a/packages/desktop/src/components/editor/editor-search/search-extension.ts
+++ b/packages/desktop/src/components/editor/editor-search/search-extension.ts
@@ -1,0 +1,220 @@
+import { StateEffect, StateField, type EditorState, type Extension } from "@codemirror/state";
+import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
+import { SearchCursor, RegExpCursor } from "@codemirror/search";
+
+export interface BufferSearchQuery {
+  query: string;
+  caseSensitive: boolean;
+  regex: boolean;
+}
+
+export interface BufferMatch {
+  from: number;
+  to: number;
+}
+
+export interface BufferSearchState {
+  query: BufferSearchQuery;
+  matches: BufferMatch[];
+  activeIndex: number;
+  truncated: boolean;
+  error: string | null;
+}
+
+export const MAX_BUFFER_MATCHES = 5000;
+
+const EMPTY_QUERY: BufferSearchQuery = { query: "", caseSensitive: false, regex: false };
+
+const INITIAL_STATE: BufferSearchState = {
+  query: EMPTY_QUERY,
+  matches: [],
+  activeIndex: -1,
+  truncated: false,
+  error: null,
+};
+
+export const setBufferSearchQueryEffect = StateEffect.define<BufferSearchQuery>();
+export const setBufferActiveIndexEffect = StateEffect.define<number>();
+export const closeBufferSearchEffect = StateEffect.define<void>();
+
+const matchMark = Decoration.mark({ class: "cm-buffer-search-match" });
+const activeMatchMark = Decoration.mark({
+  class: "cm-buffer-search-match cm-buffer-search-match-active",
+});
+
+interface ScanResult {
+  matches: BufferMatch[];
+  truncated: boolean;
+  error: string | null;
+}
+
+function scanLiteralMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
+  const matches: BufferMatch[] = [];
+  const normalize = q.caseSensitive ? undefined : (s: string) => s.toLowerCase();
+  const cursor = new SearchCursor(state.doc, q.query, 0, state.doc.length, normalize);
+  while (!cursor.next().done) {
+    const { from, to } = cursor.value;
+    if (from === to) break;
+    matches.push({ from, to });
+    if (matches.length >= MAX_BUFFER_MATCHES) {
+      return { matches, truncated: true, error: null };
+    }
+  }
+  return { matches, truncated: false, error: null };
+}
+
+function scanRegexMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
+  try {
+    new RegExp(q.query);
+  } catch (err) {
+    return {
+      matches: [],
+      truncated: false,
+      error: err instanceof Error ? err.message : "Invalid regex",
+    };
+  }
+  const matches: BufferMatch[] = [];
+  const cursor = new RegExpCursor(
+    state.doc,
+    q.query,
+    { ignoreCase: !q.caseSensitive },
+    0,
+    state.doc.length,
+  );
+  while (!cursor.next().done) {
+    const { from, to } = cursor.value;
+    if (from === to) break;
+    matches.push({ from, to });
+    if (matches.length >= MAX_BUFFER_MATCHES) {
+      return { matches, truncated: true, error: null };
+    }
+  }
+  return { matches, truncated: false, error: null };
+}
+
+function scanMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
+  if (!q.query) return { matches: [], truncated: false, error: null };
+  return q.regex ? scanRegexMatches(state, q) : scanLiteralMatches(state, q);
+}
+
+function pickInitialActive(matches: BufferMatch[], cursorPos: number): number {
+  if (matches.length === 0) return -1;
+  for (let i = 0; i < matches.length; i++) {
+    if (matches[i].from >= cursorPos) return i;
+  }
+  return 0;
+}
+
+function normalizeIndex(idx: number, total: number): number {
+  if (total === 0) return -1;
+  return ((idx % total) + total) % total;
+}
+
+function buildDecorations(state: BufferSearchState): DecorationSet {
+  if (state.matches.length === 0) return Decoration.none;
+  const ranges = state.matches.map((m, i) =>
+    (i === state.activeIndex ? activeMatchMark : matchMark).range(m.from, m.to),
+  );
+  return Decoration.set(ranges, true);
+}
+
+function applyQueryEffect(state: EditorState, query: BufferSearchQuery): BufferSearchState {
+  const scan = scanMatches(state, query);
+  return {
+    query,
+    matches: scan.matches,
+    activeIndex: pickInitialActive(scan.matches, state.selection.main.head),
+    truncated: scan.truncated,
+    error: scan.error,
+  };
+}
+
+export const bufferSearchField = StateField.define<BufferSearchState>({
+  create: () => INITIAL_STATE,
+  update(value, tr) {
+    let next = value;
+    let queryChanged = false;
+    let closed = false;
+    for (const effect of tr.effects) {
+      if (effect.is(setBufferSearchQueryEffect)) {
+        next = applyQueryEffect(tr.state, effect.value);
+        queryChanged = true;
+      } else if (effect.is(setBufferActiveIndexEffect)) {
+        next = { ...next, activeIndex: normalizeIndex(effect.value, next.matches.length) };
+      } else if (effect.is(closeBufferSearchEffect)) {
+        next = INITIAL_STATE;
+        closed = true;
+      }
+    }
+    if (tr.docChanged && !queryChanged && !closed && next.query.query) {
+      const scan = scanMatches(tr.state, next.query);
+      const newActive =
+        scan.matches.length === 0
+          ? -1
+          : Math.min(Math.max(0, next.activeIndex), scan.matches.length - 1);
+      next = {
+        ...next,
+        matches: scan.matches,
+        activeIndex:
+          newActive < 0 ? pickInitialActive(scan.matches, tr.state.selection.main.head) : newActive,
+        truncated: scan.truncated,
+        error: scan.error,
+      };
+    }
+    return next;
+  },
+  provide: (f) => EditorView.decorations.from(f, buildDecorations),
+});
+
+export function bufferSearchExtension(): Extension {
+  return [bufferSearchField];
+}
+
+export function getBufferSearchState(view: EditorView): BufferSearchState {
+  return view.state.field(bufferSearchField);
+}
+
+export function setBufferSearchQuery(view: EditorView, query: BufferSearchQuery): void {
+  view.dispatch({ effects: setBufferSearchQueryEffect.of(query) });
+  revealActiveMatch(view);
+}
+
+export function findNextMatch(view: EditorView): void {
+  const s = view.state.field(bufferSearchField);
+  if (s.matches.length === 0) return;
+  activateMatch(view, s.activeIndex + 1);
+}
+
+export function findPrevMatch(view: EditorView): void {
+  const s = view.state.field(bufferSearchField);
+  if (s.matches.length === 0) return;
+  activateMatch(view, s.activeIndex - 1);
+}
+
+export function closeBufferSearch(view: EditorView): void {
+  view.dispatch({ effects: closeBufferSearchEffect.of() });
+}
+
+function activateMatch(view: EditorView, rawIndex: number): void {
+  const s = view.state.field(bufferSearchField);
+  if (s.matches.length === 0) return;
+  const idx = normalizeIndex(rawIndex, s.matches.length);
+  const m = s.matches[idx];
+  view.dispatch({
+    effects: [
+      setBufferActiveIndexEffect.of(idx),
+      EditorView.scrollIntoView(m.from, { y: "center" }),
+    ],
+    selection: { anchor: m.from, head: m.to },
+  });
+}
+
+function revealActiveMatch(view: EditorView): void {
+  const s = view.state.field(bufferSearchField);
+  if (s.activeIndex < 0 || s.activeIndex >= s.matches.length) return;
+  const m = s.matches[s.activeIndex];
+  view.dispatch({
+    effects: EditorView.scrollIntoView(m.from, { y: "center" }),
+    selection: { anchor: m.from, head: m.to },
+  });
+}

--- a/packages/desktop/src/components/editor/editor-search/search-extension.ts
+++ b/packages/desktop/src/components/editor/editor-search/search-extension.ts
@@ -1,4 +1,10 @@
-import { StateEffect, StateField, type EditorState, type Extension } from "@codemirror/state";
+import {
+  StateEffect,
+  StateField,
+  type EditorState,
+  type Extension,
+  type Transaction,
+} from "@codemirror/state";
 import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
 import { SearchCursor, RegExpCursor } from "@codemirror/search";
 
@@ -42,25 +48,47 @@ const activeMatchMark = Decoration.mark({
   class: "cm-buffer-search-match cm-buffer-search-match-active",
 });
 
+interface CursorLike {
+  next(): { done: boolean };
+  value: { from: number; to: number };
+}
+
 interface ScanResult {
   matches: BufferMatch[];
   truncated: boolean;
   error: string | null;
 }
 
-function scanLiteralMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
+/**
+ * Drain a CodeMirror SearchCursor / RegExpCursor into a match list, capped at
+ * MAX_BUFFER_MATCHES. Zero-width matches (e.g. regex like `\b`, `^`) are kept;
+ * if the cursor ever stalls on the same zero-width position twice in a row we
+ * break to avoid an infinite loop.
+ */
+function drainCursor(cursor: CursorLike): { matches: BufferMatch[]; truncated: boolean } {
   const matches: BufferMatch[] = [];
-  const normalize = q.caseSensitive ? undefined : (s: string) => s.toLowerCase();
-  const cursor = new SearchCursor(state.doc, q.query, 0, state.doc.length, normalize);
+  let lastZeroWidthEnd = -1;
   while (!cursor.next().done) {
     const { from, to } = cursor.value;
-    if (from === to) break;
+    if (from === to) {
+      if (to === lastZeroWidthEnd) break;
+      lastZeroWidthEnd = to;
+    } else {
+      lastZeroWidthEnd = -1;
+    }
     matches.push({ from, to });
     if (matches.length >= MAX_BUFFER_MATCHES) {
-      return { matches, truncated: true, error: null };
+      return { matches, truncated: true };
     }
   }
-  return { matches, truncated: false, error: null };
+  return { matches, truncated: false };
+}
+
+function scanLiteralMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
+  const normalize = q.caseSensitive ? undefined : (s: string) => s.toLowerCase();
+  const cursor = new SearchCursor(state.doc, q.query, 0, state.doc.length, normalize);
+  const { matches, truncated } = drainCursor(cursor);
+  return { matches, truncated, error: null };
 }
 
 function scanRegexMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
@@ -73,7 +101,6 @@ function scanRegexMatches(state: EditorState, q: BufferSearchQuery): ScanResult 
       error: err instanceof Error ? err.message : "Invalid regex",
     };
   }
-  const matches: BufferMatch[] = [];
   const cursor = new RegExpCursor(
     state.doc,
     q.query,
@@ -81,15 +108,8 @@ function scanRegexMatches(state: EditorState, q: BufferSearchQuery): ScanResult 
     0,
     state.doc.length,
   );
-  while (!cursor.next().done) {
-    const { from, to } = cursor.value;
-    if (from === to) break;
-    matches.push({ from, to });
-    if (matches.length >= MAX_BUFFER_MATCHES) {
-      return { matches, truncated: true, error: null };
-    }
-  }
-  return { matches, truncated: false, error: null };
+  const { matches, truncated } = drainCursor(cursor);
+  return { matches, truncated, error: null };
 }
 
 function scanMatches(state: EditorState, q: BufferSearchQuery): ScanResult {
@@ -129,6 +149,24 @@ function applyQueryEffect(state: EditorState, query: BufferSearchQuery): BufferS
   };
 }
 
+function reapplyOnDocChange(prev: BufferSearchState, tr: Transaction): BufferSearchState {
+  const scan = scanMatches(tr.state, prev.query);
+  if (scan.matches.length === 0) {
+    return { ...prev, matches: [], activeIndex: -1, truncated: false, error: scan.error };
+  }
+  const prevActiveMatch = prev.activeIndex >= 0 ? prev.matches[prev.activeIndex] : null;
+  const anchor = prevActiveMatch
+    ? tr.changes.mapPos(prevActiveMatch.from)
+    : tr.state.selection.main.head;
+  return {
+    ...prev,
+    matches: scan.matches,
+    activeIndex: pickInitialActive(scan.matches, anchor),
+    truncated: scan.truncated,
+    error: scan.error,
+  };
+}
+
 export const bufferSearchField = StateField.define<BufferSearchState>({
   create: () => INITIAL_STATE,
   update(value, tr) {
@@ -147,36 +185,63 @@ export const bufferSearchField = StateField.define<BufferSearchState>({
       }
     }
     if (tr.docChanged && !queryChanged && !closed && next.query.query) {
-      const scan = scanMatches(tr.state, next.query);
-      const newActive =
-        scan.matches.length === 0
-          ? -1
-          : Math.min(Math.max(0, next.activeIndex), scan.matches.length - 1);
-      next = {
-        ...next,
-        matches: scan.matches,
-        activeIndex:
-          newActive < 0 ? pickInitialActive(scan.matches, tr.state.selection.main.head) : newActive,
-        truncated: scan.truncated,
-        error: scan.error,
-      };
+      next = reapplyOnDocChange(next, tr);
     }
     return next;
   },
   provide: (f) => EditorView.decorations.from(f, buildDecorations),
 });
 
+type Listener = (state: BufferSearchState) => void;
+const listenersByView = new WeakMap<EditorView, Set<Listener>>();
+
+function notifyListeners(view: EditorView, state: BufferSearchState): void {
+  const set = listenersByView.get(view);
+  if (!set) return;
+  set.forEach((cb) => cb(state));
+}
+
+export function subscribeBufferSearch(view: EditorView, cb: Listener): () => void {
+  let set = listenersByView.get(view);
+  if (!set) {
+    set = new Set();
+    listenersByView.set(view, set);
+  }
+  set.add(cb);
+  return () => {
+    set?.delete(cb);
+  };
+}
+
 export function bufferSearchExtension(): Extension {
-  return [bufferSearchField];
+  return [
+    bufferSearchField,
+    EditorView.updateListener.of((update) => {
+      const prev = update.startState.field(bufferSearchField, false);
+      const next = update.state.field(bufferSearchField, false);
+      if (next === undefined || prev === next) return;
+      notifyListeners(update.view, next);
+    }),
+  ];
 }
 
 export function getBufferSearchState(view: EditorView): BufferSearchState {
   return view.state.field(bufferSearchField);
 }
 
+/**
+ * Apply a new query / regex / case-sensitivity setting and scroll the active
+ * match into view without disturbing the editor selection. The selection is
+ * only moved by explicit navigation (`findNextMatch`, `findPrevMatch`,
+ * `selectActiveMatch`) so that typing in the search input does not bump the
+ * user's cursor inside the buffer.
+ */
 export function setBufferSearchQuery(view: EditorView, query: BufferSearchQuery): void {
   view.dispatch({ effects: setBufferSearchQueryEffect.of(query) });
-  revealActiveMatch(view);
+  const s = view.state.field(bufferSearchField);
+  if (s.activeIndex < 0) return;
+  const m = s.matches[s.activeIndex];
+  view.dispatch({ effects: EditorView.scrollIntoView(m.from, { y: "center" }) });
 }
 
 export function findNextMatch(view: EditorView): void {
@@ -195,6 +260,17 @@ export function closeBufferSearch(view: EditorView): void {
   view.dispatch({ effects: closeBufferSearchEffect.of() });
 }
 
+/** Move the editor selection to the currently-active match without changing it. */
+export function selectActiveMatch(view: EditorView): void {
+  const s = view.state.field(bufferSearchField);
+  if (s.activeIndex < 0) return;
+  const m = s.matches[s.activeIndex];
+  view.dispatch({
+    selection: { anchor: m.from, head: m.to },
+    effects: EditorView.scrollIntoView(m.from, { y: "center" }),
+  });
+}
+
 function activateMatch(view: EditorView, rawIndex: number): void {
   const s = view.state.field(bufferSearchField);
   if (s.matches.length === 0) return;
@@ -205,16 +281,6 @@ function activateMatch(view: EditorView, rawIndex: number): void {
       setBufferActiveIndexEffect.of(idx),
       EditorView.scrollIntoView(m.from, { y: "center" }),
     ],
-    selection: { anchor: m.from, head: m.to },
-  });
-}
-
-function revealActiveMatch(view: EditorView): void {
-  const s = view.state.field(bufferSearchField);
-  if (s.activeIndex < 0 || s.activeIndex >= s.matches.length) return;
-  const m = s.matches[s.activeIndex];
-  view.dispatch({
-    effects: EditorView.scrollIntoView(m.from, { y: "center" }),
     selection: { anchor: m.from, head: m.to },
   });
 }

--- a/packages/desktop/src/components/editor/editor-theme.ts
+++ b/packages/desktop/src/components/editor/editor-theme.ts
@@ -110,6 +110,17 @@ const cadencrChromeTheme = EditorView.theme(
     },
     ".cm-matchingBracket": { color: "var(--editor-green)", fontWeight: "bold" },
     ".cm-lineNumbers .cm-gutterElement": { padding: "0 8px 0 4px" },
+    ".cm-buffer-search-match": {
+      backgroundColor:
+        "var(--editor-search-match-bg, color-mix(in srgb, var(--editor-yellow) 28%, transparent))",
+      borderRadius: "2px",
+      boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--editor-yellow) 55%, transparent)",
+    },
+    ".cm-buffer-search-match-active": {
+      backgroundColor:
+        "var(--editor-search-match-active-bg, color-mix(in srgb, var(--editor-orange) 60%, transparent))",
+      boxShadow: "inset 0 0 0 1px color-mix(in srgb, var(--editor-orange) 100%, transparent)",
+    },
   },
   { dark: true },
 );

--- a/packages/desktop/src/lib/shortcuts/registry.ts
+++ b/packages/desktop/src/lib/shortcuts/registry.ts
@@ -415,6 +415,12 @@ export const SHORTCUTS = [
   // ─── Editor ──────────────────────────────────────────────────────────
   { id: "editor-fuzzy", keys: ["mod", "p"], description: "Fuzzy file search", scope: "editor" },
   {
+    id: "editor-buffer-search",
+    keys: ["mod", "f"],
+    description: "Find in current file",
+    scope: "editor",
+  },
+  {
     id: "editor-toggle-sidebar",
     keys: ["mod", "e"],
     description: "Toggle explorer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@codemirror/merge':
         specifier: ^6.12.1
         version: 6.12.1
+      '@codemirror/search':
+        specifier: ^6.6.0
+        version: 6.6.0
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.6.0


### PR DESCRIPTION
Adds a VS-Code-style find bar to the editor tab. Cmd+F opens a floating
search panel at the top-right of the active buffer, typing highlights
matches live with an N-of-M counter, Enter / Shift+Enter walks
next / previous, Cmd+Enter blurs the input to focus the editor at the
active match, and Escape closes. Case-sensitive and regex modes are
togglable and query state persists per pane across opens and across
file switches inside the same pane.

Built on @codemirror/search via a custom StateField that owns the
match decorations plus an active-match overlay, capped at 5000 matches
with a "5000+" indicator. Invalid regex is surfaced in the input
without throwing. Shared the existing case/regex toggle button with
ContentSearchDialog by extracting SearchToggleButton.