### PR TITLE
fix(desktop): preserve buffer content on Cmd+Z immediately after opening a file

### DIFF
--- a/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
+++ b/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback, useState, useMemo } from "react";
 import { EditorView } from "@codemirror/view";
 import { Compartment } from "@codemirror/state";
+import { Loader2Icon } from "lucide-react";
 import { useReadFile, useWriteFile, useGetBlame } from "@/api/generated";
 import { useEditorStore } from "@/stores/editor-store";
 import { useDebouncedSetting } from "@/hooks/useDebouncedSetting";
@@ -97,7 +98,7 @@ export default function CodeMirrorEditor({
         ?.pendingGoToLine,
   );
 
-  const { data, isLoading, error } = useReadFile(
+  const { data, error } = useReadFile(
     { project_id: projectId, feature_id: featureId, file_path: filePath },
     {
       query: {
@@ -212,20 +213,6 @@ export default function CodeMirrorEditor({
     };
   }, []);
 
-  // Update editor content when data loads
-  useEffect(() => {
-    const view = viewRef.current;
-    if (!view || !data) return;
-
-    const currentContent = view.state.doc.toString();
-    if (currentContent !== data.content) {
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: data.content },
-      });
-      setDirty(featureId, paneId, filePath, false);
-    }
-  }, [data, filePath, featureId, paneId, setDirty]);
-
   // Scroll to pending go-to line after content is loaded
   useEffect(() => {
     const view = viewRef.current;
@@ -243,23 +230,26 @@ export default function CodeMirrorEditor({
     clearPendingGoToLine(featureId, paneId, filePath);
   }, [data, pendingGoToLine, featureId, paneId, filePath, clearPendingGoToLine]);
 
-  const overlay = isLoading ? (
-    <div className="absolute inset-0 flex flex-col gap-2 p-4 animate-pulse z-10 bg-background">
-      <div className="h-4 w-3/4 rounded bg-muted" />
-      <div className="h-4 w-1/2 rounded bg-muted" />
-      <div className="h-4 w-5/6 rounded bg-muted" />
-      <div className="h-4 w-2/3 rounded bg-muted" />
-    </div>
-  ) : error ? (
-    <div className="absolute inset-0 flex items-center justify-center z-10 bg-background text-destructive text-sm px-6 text-center">
-      {error instanceof Error ? error.message : "Failed to load file"}
-    </div>
-  ) : null;
+  if (error) {
+    return (
+      <div className="h-full flex items-center justify-center bg-background text-destructive text-sm px-6 text-center">
+        {error instanceof Error ? error.message : "Failed to load file"}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="h-full flex items-center justify-center bg-background">
+        <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
   return (
-    <div className="h-full flex flex-col relative">
-      {overlay}
+    <div className="h-full flex flex-col">
       <BaseCodeMirrorEditor
+        initialContent={data.content}
         language={langExt}
         vimMode={isVimEnabled}
         onChange={handleChange}

--- a/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
+++ b/packages/desktop/src/components/editor/CodeMirrorEditor.tsx
@@ -178,13 +178,15 @@ export default function CodeMirrorEditor({
 
   const langExt = useMemo(() => getLanguageExtension(filePath), [filePath]);
 
-  // Hot-swap blame extension when data or setting changes
+  // Hot-swap blame extension when data or setting changes.
+  // `data` is in deps so the effect re-runs once the editor mounts after the file loads;
+  // otherwise an early-arriving blameData would be lost when viewRef is still null.
   useEffect(() => {
     const view = viewRef.current;
     if (!view) return;
     const ext = isBlameEnabled && blameData ? gitBlameExtension(blameData.lines) : [];
     view.dispatch({ effects: blameCompartment.current.reconfigure(ext) });
-  }, [isBlameEnabled, blameData]);
+  }, [isBlameEnabled, blameData, data]);
 
   const cursorExtension = useMemo(() => {
     return EditorView.updateListener.of((update) => {

--- a/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@/test-utils";
 import CodeMirrorEditor, { clampEditorLineNumber } from "../CodeMirrorEditor";
+import { gitBlameExtension } from "../git-blame-extension";
 
 vi.mock("@codemirror/state", () => ({
   Compartment: class {
@@ -73,10 +74,12 @@ let mockReadFileReturn: { data: unknown; isLoading: boolean; error: Error | null
   error: null,
 };
 
+let mockBlameReturn: { data: unknown } = { data: undefined };
+
 vi.mock("@/api/generated", () => ({
   useReadFile: vi.fn(() => mockReadFileReturn),
   useWriteFile: vi.fn(() => ({ mutateAsync: vi.fn() })),
-  useGetBlame: vi.fn(() => ({ data: undefined })),
+  useGetBlame: vi.fn(() => mockBlameReturn),
 }));
 
 vi.mock("@/stores/editor-store", () => ({
@@ -97,8 +100,12 @@ vi.mock("@/stores/editor-store", () => ({
   ),
 }));
 
+const mockDebouncedSettings: Record<string, string> = {};
+
 vi.mock("@/hooks/useDebouncedSetting", () => ({
-  useDebouncedSetting: vi.fn(() => ({ value: "false" })),
+  useDebouncedSetting: vi.fn((key: string) => ({
+    value: mockDebouncedSettings[key] ?? "false",
+  })),
 }));
 
 const defaultProps = {
@@ -110,7 +117,10 @@ const defaultProps = {
 
 beforeEach(() => {
   mockReadFileReturn = { data: undefined, isLoading: true, error: null };
+  mockBlameReturn = { data: undefined };
+  for (const k of Object.keys(mockDebouncedSettings)) delete mockDebouncedSettings[k];
   baseEditorProps.mockClear();
+  vi.mocked(gitBlameExtension).mockClear();
 });
 
 describe("CodeMirrorEditor", () => {
@@ -150,6 +160,30 @@ describe("CodeMirrorEditor", () => {
     expect(screen.getByText("Ln 1, Col 1")).toBeInTheDocument();
     expect(screen.getByText("TypeScript")).toBeInTheDocument();
     expect(screen.getByText("UTF-8")).toBeInTheDocument();
+  });
+
+  it("applies the blame extension once the editor mounts even if blame data arrived earlier", () => {
+    // Blame is enabled and blame data is already available, but the file content
+    // hasn't loaded yet — so the editor isn't mounted on the first render.
+    mockDebouncedSettings["editor_git_blame"] = "true";
+    mockBlameReturn = { data: { lines: [{ line: 1, sha: "abc", author: "x", date: "now" }] } };
+    mockReadFileReturn = { data: undefined, isLoading: true, error: null };
+
+    const { rerender } = render(<CodeMirrorEditor {...defaultProps} />);
+
+    // Spinner state: editor not mounted, blame extension not constructed.
+    expect(screen.queryByTestId("base-editor")).not.toBeInTheDocument();
+    expect(gitBlameExtension).not.toHaveBeenCalled();
+
+    // File content arrives → editor mounts → blame effect must re-run.
+    mockReadFileReturn = { data: { content: "hello" }, isLoading: false, error: null };
+    rerender(<CodeMirrorEditor {...defaultProps} />);
+
+    expect(screen.getByTestId("base-editor")).toBeInTheDocument();
+    expect(gitBlameExtension).toHaveBeenCalledWith(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockBlameReturn.data as any).lines,
+    );
   });
 
   it("clamps invalid pending go-to lines to the document range", () => {

--- a/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
+++ b/packages/desktop/src/components/editor/__tests__/CodeMirrorEditor.test.tsx
@@ -27,15 +27,20 @@ vi.mock("@codemirror/view", () => {
   };
 });
 
+const baseEditorProps = vi.fn();
+
 // Mock BaseCodeMirrorEditor to render a simple div with the className
 vi.mock("../BaseCodeMirrorEditor", () => ({
   default: ({
     className,
+    initialContent,
     editorViewRef,
   }: {
     className?: string;
+    initialContent?: string;
     editorViewRef?: React.MutableRefObject<unknown>;
   }) => {
+    baseEditorProps({ className, initialContent });
     if (editorViewRef) {
       editorViewRef.current = {
         state: { doc: { toString: () => "", length: 0 } },
@@ -43,7 +48,9 @@ vi.mock("../BaseCodeMirrorEditor", () => ({
         destroy: vi.fn(),
       };
     }
-    return <div className={className} data-testid="base-editor" />;
+    return (
+      <div className={className} data-testid="base-editor" data-initial-content={initialContent} />
+    );
   },
 }));
 
@@ -103,42 +110,37 @@ const defaultProps = {
 
 beforeEach(() => {
   mockReadFileReturn = { data: undefined, isLoading: true, error: null };
+  baseEditorProps.mockClear();
 });
 
 describe("CodeMirrorEditor", () => {
-  it("renders container div even while loading", () => {
+  it("renders a spinner and does not mount the editor while loading", () => {
     mockReadFileReturn = { data: undefined, isLoading: true, error: null };
     const { container } = render(<CodeMirrorEditor {...defaultProps} />);
 
-    // The container div for CodeMirror should always be present
-    const editorContainer = container.querySelector(".flex-1.overflow-auto");
-    expect(editorContainer).toBeInTheDocument();
-
-    // Loading overlay should also be present
-    const overlay = container.querySelector(".animate-pulse");
-    expect(overlay).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-editor")).not.toBeInTheDocument();
+    expect(baseEditorProps).not.toHaveBeenCalled();
   });
 
-  it("renders container div when there is an error", () => {
+  it("renders an error message and does not mount the editor on error", () => {
     mockReadFileReturn = { data: undefined, isLoading: false, error: new Error("Not found") };
-    const { container } = render(<CodeMirrorEditor {...defaultProps} />);
-
-    const editorContainer = container.querySelector(".flex-1.overflow-auto");
-    expect(editorContainer).toBeInTheDocument();
+    render(<CodeMirrorEditor {...defaultProps} />);
 
     expect(screen.getByText("Not found")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-editor")).not.toBeInTheDocument();
+    expect(baseEditorProps).not.toHaveBeenCalled();
   });
 
-  it("renders container div when data is loaded", () => {
+  it("mounts the editor with initialContent once data is loaded", () => {
     mockReadFileReturn = { data: { content: "hello" }, isLoading: false, error: null };
     const { container } = render(<CodeMirrorEditor {...defaultProps} />);
 
-    const editorContainer = container.querySelector(".flex-1.overflow-auto");
-    expect(editorContainer).toBeInTheDocument();
-
-    // No overlay when data is loaded
-    const overlay = container.querySelector(".animate-pulse");
-    expect(overlay).not.toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).not.toBeInTheDocument();
+    expect(screen.getByTestId("base-editor")).toBeInTheDocument();
+    expect(baseEditorProps).toHaveBeenCalledWith(
+      expect.objectContaining({ initialContent: "hello" }),
+    );
   });
 
   it("renders status bar with language and position", () => {


### PR DESCRIPTION
The editor previously mounted with an empty doc and a `history()` extension,
then dispatched the file content once `useReadFile` resolved. That dispatch
landed in the undo stack, so pressing Cmd+Z right after opening reverted to
the empty doc and emptied the buffer.

Defer mounting `BaseCodeMirrorEditor` until the file content is available
and pass `data.content` as `initialContent`, so the content is part of the
initial `EditorState` and never enters the history. Show a centered spinner
while loading instead of the skeleton overlay.