### PR TITLE
Fix unified agent image drop routing to prompt-specific targets

### DIFF
--- a/packages/desktop/electron/preload/index.ts
+++ b/packages/desktop/electron/preload/index.ts
@@ -83,6 +83,27 @@ function onIpc<T>(channel: string, cb: (payload: T) => void): () => void {
   return () => ipcRenderer.removeListener(channel, handler);
 }
 
+function resolvePromptIdFromEvent(event: DragEvent): string | undefined {
+  // composedPath() walks through shadow DOM and gives us the actual elements
+  // under the cursor. Prefer that; fall back to climbing from `event.target`
+  // when composedPath is empty (jsdom, older WebView).
+  const path = typeof event.composedPath === "function" ? event.composedPath() : [];
+  for (const node of path) {
+    if (node instanceof Element && node.hasAttribute("data-agent-prompt-id")) {
+      return node.getAttribute("data-agent-prompt-id") ?? undefined;
+    }
+  }
+  const fromTarget =
+    event.target instanceof Element
+      ? event.target
+      : event.target instanceof Node
+        ? event.target.parentElement
+        : null;
+  return (
+    fromTarget?.closest("[data-agent-prompt-id]")?.getAttribute("data-agent-prompt-id") ?? undefined
+  );
+}
+
 function onFileDrop(cb: (payload: FileDropPayload) => void): () => void {
   let dragDepth = 0;
   const onDragOver = (event: DragEvent): void => event.preventDefault();
@@ -99,11 +120,11 @@ function onFileDrop(cb: (payload: FileDropPayload) => void): () => void {
   const onDrop = (event: DragEvent): void => {
     event.preventDefault();
     dragDepth = 0;
-    const targetPromptId =
-      event.target instanceof Element
-        ? (event.target.closest("[data-agent-prompt-id]")?.getAttribute("data-agent-prompt-id") ??
-          undefined)
-        : undefined;
+    // `event.target` is occasionally a non-Element Node (e.g. a Text node when
+    // the drop lands directly on text inside the prompt editor). Walk the
+    // composedPath first so shadow-DOM hosts are handled, then fall back to
+    // the parent element of a Node target so we don't lose valid prompt drops.
+    const targetPromptId = resolvePromptIdFromEvent(event);
     const files = Array.from(event.dataTransfer?.files ?? []);
     const paths = files.map((file) => webUtils.getPathForFile(file)).filter(Boolean);
     void ipcRenderer

--- a/packages/desktop/electron/preload/index.ts
+++ b/packages/desktop/electron/preload/index.ts
@@ -39,6 +39,7 @@ interface FileDropItem {
 interface FileDropPayload {
   type: "enter" | "leave" | "drop" | "error";
   files: FileDropItem[];
+  targetPromptId?: string;
   message?: string;
 }
 
@@ -98,12 +99,17 @@ function onFileDrop(cb: (payload: FileDropPayload) => void): () => void {
   const onDrop = (event: DragEvent): void => {
     event.preventDefault();
     dragDepth = 0;
+    const targetPromptId =
+      event.target instanceof Element
+        ? (event.target.closest("[data-agent-prompt-id]")?.getAttribute("data-agent-prompt-id") ??
+          undefined)
+        : undefined;
     const files = Array.from(event.dataTransfer?.files ?? []);
     const paths = files.map((file) => webUtils.getPathForFile(file)).filter(Boolean);
     void ipcRenderer
       .invoke("fs:register-file-paths", paths)
       .then((registered: FileDropItem[]) => {
-        cb({ type: "drop", files: registered });
+        cb({ type: "drop", files: registered, targetPromptId });
       })
       .catch((error: unknown) => {
         cb({

--- a/packages/desktop/src/components/AgentPromptBar.tsx
+++ b/packages/desktop/src/components/AgentPromptBar.tsx
@@ -1,13 +1,4 @@
-import {
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-  useImperativeHandle,
-  forwardRef,
-  useMemo,
-} from "react";
-import { promptDropTargetIdOf } from "@/lib/prompt-drop-target";
+import { useState, useCallback, useEffect, useRef, useImperativeHandle, forwardRef } from "react";
 import { useScopedShortcut } from "@/hooks/useShortcut";
 import { useShortcut } from "@/hooks/useShortcut";
 import { Loader2, Send, Pause } from "lucide-react";
@@ -22,7 +13,7 @@ import { SplitSendActions } from "./SplitSendActions";
 import { PromptEditor } from "./prompt-editor/PromptEditor";
 import type { PromptEditorHandle } from "./prompt-editor/PromptEditor";
 import { shouldFocusPromptFromSurfaceClick } from "./agent-prompt-focus";
-import { useImageAttachments } from "@/hooks/useImageAttachments";
+import { usePromptAttachments } from "@/hooks/usePromptAttachments";
 import { usePromptDraft } from "@/hooks/usePromptDraft";
 import { draftScope } from "@/lib/draft-scope";
 import { usePromptEditorRestore } from "@/hooks/usePromptEditorRestore";
@@ -123,13 +114,6 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       requestAnimationFrame(() => editorRef.current?.focus());
     }, [hasSpecialState]);
     const history = usePromptHistory(projectId ?? 0, wsSessionId);
-    // Must match the id stamped on the enclosing agent `<section>` in
-    // `WebSocketSessionFeatureBlock` — the section is the actual drop zone,
-    // and this hook only accepts drops whose `targetPromptId` matches.
-    const promptDropTargetId = useMemo(
-      () => promptDropTargetIdOf({ wsSessionId, dbSessionId: sessionId, featureId }),
-      [wsSessionId, sessionId, featureId],
-    );
     const {
       attachments,
       addFiles,
@@ -137,7 +121,7 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       clearAttachments,
       restoreAttachments,
       dragHandlers,
-    } = useImageAttachments(promptDropTargetId);
+    } = usePromptAttachments({ wsSessionId, sessionId, featureId });
     const filesQuery = useListFiles(
       { feature_id: featureId! },
       { query: { enabled: !!featureId && agentTabActive && !disabled } },

--- a/packages/desktop/src/components/AgentPromptBar.tsx
+++ b/packages/desktop/src/components/AgentPromptBar.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useImperativeHandle,
   forwardRef,
+  useId,
   useMemo,
 } from "react";
 import { useScopedShortcut } from "@/hooks/useShortcut";
@@ -122,12 +123,18 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       requestAnimationFrame(() => editorRef.current?.focus());
     }, [hasSpecialState]);
     const history = usePromptHistory(projectId ?? 0, wsSessionId);
+    // Drop-routing id — must be unique per mounted prompt bar so a desktop drop
+    // resolves to exactly one `useImageAttachments` consumer in the unified
+    // grid. Prefer the session/feature identity so the same prompt across
+    // remounts keeps the same id; fall back to `useId()` to guarantee
+    // uniqueness if no IDs are available yet.
+    const fallbackPromptId = useId();
     const promptDropTargetId = useMemo(() => {
       if (wsSessionId) return `ws:${wsSessionId}`;
       if (sessionId) return `db:${sessionId}`;
       if (featureId) return `feature:${featureId}`;
-      return "prompt:default";
-    }, [wsSessionId, sessionId, featureId]);
+      return `prompt:${fallbackPromptId}`;
+    }, [wsSessionId, sessionId, featureId, fallbackPromptId]);
     const {
       attachments,
       addFiles,
@@ -331,7 +338,15 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
         {planApprovalDeferred && <AgentPromptPendingIndicator kind="plan" />}
         {questionsDeferred && <AgentPromptPendingIndicator kind="question" />}
         {specialPrompt && (
-          <div data-permission-area={!!visiblePermission} data-question-area>
+          <div
+            data-permission-area={!!visiblePermission}
+            data-question-area
+            // Mirror the prompt-bar's id so a desktop drop while a permission /
+            // plan / question gate is showing still routes to this prompt
+            // (the main wrapper is `hidden` in that state so `closest()` won't
+            // see it).
+            data-agent-prompt-id={promptDropTargetId}
+          >
             {specialPrompt}
           </div>
         )}

--- a/packages/desktop/src/components/AgentPromptBar.tsx
+++ b/packages/desktop/src/components/AgentPromptBar.tsx
@@ -5,9 +5,9 @@ import {
   useRef,
   useImperativeHandle,
   forwardRef,
-  useId,
   useMemo,
 } from "react";
+import { promptDropTargetIdOf } from "@/lib/prompt-drop-target";
 import { useScopedShortcut } from "@/hooks/useShortcut";
 import { useShortcut } from "@/hooks/useShortcut";
 import { Loader2, Send, Pause } from "lucide-react";
@@ -123,18 +123,13 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       requestAnimationFrame(() => editorRef.current?.focus());
     }, [hasSpecialState]);
     const history = usePromptHistory(projectId ?? 0, wsSessionId);
-    // Drop-routing id — must be unique per mounted prompt bar so a desktop drop
-    // resolves to exactly one `useImageAttachments` consumer in the unified
-    // grid. Prefer the session/feature identity so the same prompt across
-    // remounts keeps the same id; fall back to `useId()` to guarantee
-    // uniqueness if no IDs are available yet.
-    const fallbackPromptId = useId();
-    const promptDropTargetId = useMemo(() => {
-      if (wsSessionId) return `ws:${wsSessionId}`;
-      if (sessionId) return `db:${sessionId}`;
-      if (featureId) return `feature:${featureId}`;
-      return `prompt:${fallbackPromptId}`;
-    }, [wsSessionId, sessionId, featureId, fallbackPromptId]);
+    // Must match the id stamped on the enclosing agent `<section>` in
+    // `WebSocketSessionFeatureBlock` — the section is the actual drop zone,
+    // and this hook only accepts drops whose `targetPromptId` matches.
+    const promptDropTargetId = useMemo(
+      () => promptDropTargetIdOf({ wsSessionId, dbSessionId: sessionId, featureId }),
+      [wsSessionId, sessionId, featureId],
+    );
     const {
       attachments,
       addFiles,
@@ -142,7 +137,6 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       clearAttachments,
       restoreAttachments,
       dragHandlers,
-      isDragging,
     } = useImageAttachments(promptDropTargetId);
     const filesQuery = useListFiles(
       { feature_id: featureId! },
@@ -338,28 +332,23 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
         {planApprovalDeferred && <AgentPromptPendingIndicator kind="plan" />}
         {questionsDeferred && <AgentPromptPendingIndicator kind="question" />}
         {specialPrompt && (
-          <div
-            data-permission-area={!!visiblePermission}
-            data-question-area
-            // Mirror the prompt-bar's id so a desktop drop while a permission /
-            // plan / question gate is showing still routes to this prompt
-            // (the main wrapper is `hidden` in that state so `closest()` won't
-            // see it).
-            data-agent-prompt-id={promptDropTargetId}
-          >
+          <div data-permission-area={!!visiblePermission} data-question-area>
             {specialPrompt}
           </div>
         )}
         <div
           ref={wrapperRef}
           data-agent-prompt-bar="true"
-          data-agent-prompt-id={promptDropTargetId}
           hidden={hasSpecialState}
           aria-hidden={hasSpecialState}
           className={cn(
             "flex flex-col px-3 pb-4",
             noTopPadding ? "pt-0" : "pt-3",
-            isDragging && "ring-2 ring-primary/50 ring-inset",
+            // The drop zone is the agent `<section>` above; it toggles
+            // `data-agent-dragover` while a file is dragged over this card,
+            // and that drives the primary ring here without needing React
+            // state to cross component boundaries.
+            "group-data-[agent-dragover]/agent-section:ring-2 group-data-[agent-dragover]/agent-section:ring-inset group-data-[agent-dragover]/agent-section:ring-primary/50",
           )}
           {...dragHandlers}
         >

--- a/packages/desktop/src/components/AgentPromptBar.tsx
+++ b/packages/desktop/src/components/AgentPromptBar.tsx
@@ -1,4 +1,12 @@
-import { useState, useCallback, useEffect, useRef, useImperativeHandle, forwardRef } from "react";
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+  useMemo,
+} from "react";
 import { useScopedShortcut } from "@/hooks/useShortcut";
 import { useShortcut } from "@/hooks/useShortcut";
 import { Loader2, Send, Pause } from "lucide-react";
@@ -114,6 +122,12 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       requestAnimationFrame(() => editorRef.current?.focus());
     }, [hasSpecialState]);
     const history = usePromptHistory(projectId ?? 0, wsSessionId);
+    const promptDropTargetId = useMemo(() => {
+      if (wsSessionId) return `ws:${wsSessionId}`;
+      if (sessionId) return `db:${sessionId}`;
+      if (featureId) return `feature:${featureId}`;
+      return "prompt:default";
+    }, [wsSessionId, sessionId, featureId]);
     const {
       attachments,
       addFiles,
@@ -122,7 +136,7 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
       restoreAttachments,
       dragHandlers,
       isDragging,
-    } = useImageAttachments();
+    } = useImageAttachments(promptDropTargetId);
     const filesQuery = useListFiles(
       { feature_id: featureId! },
       { query: { enabled: !!featureId && agentTabActive && !disabled } },
@@ -324,6 +338,7 @@ export const AgentPromptBar = forwardRef<AgentPromptBarHandle, AgentPromptBarPro
         <div
           ref={wrapperRef}
           data-agent-prompt-bar="true"
+          data-agent-prompt-id={promptDropTargetId}
           hidden={hasSpecialState}
           aria-hidden={hasSpecialState}
           className={cn(

--- a/packages/desktop/src/components/WebSocketSessionFeatureBlock.test.tsx
+++ b/packages/desktop/src/components/WebSocketSessionFeatureBlock.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@/test-utils";
+import { act, fireEvent, render } from "@/test-utils";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketSessionFeatureBlock } from "./WebSocketSessionFeatureBlock";
@@ -315,6 +315,40 @@ describe("WebSocketSessionFeatureBlock", () => {
     expect(mocks.useSessionTabs).toHaveBeenLastCalledWith(
       expect.objectContaining({ nonAgentTabsEnabled: true }),
     );
+  });
+
+  it("stamps the agent section as the drop zone and highlights only on file drags", () => {
+    const { container } = render(
+      <WebSocketSessionFeatureBlock
+        sessionId="ws-feature-1"
+        cwd="/repo"
+        featureId={1}
+        projectId={2}
+      />,
+    );
+    const section = container.querySelector<HTMLElement>(
+      'section[data-agent-prompt-id="ws:ws-feature-1"]',
+    );
+    expect(section).not.toBeNull();
+    if (!section) throw new Error("section missing");
+
+    // Text drags must not toggle the highlight — only File drags do.
+    act(() => {
+      fireEvent.dragEnter(section, { dataTransfer: { types: ["text/plain"] } });
+    });
+    expect(section.getAttribute("data-agent-dragover")).toBeNull();
+
+    // A real file drag flips on the highlight via `data-agent-dragover`.
+    act(() => {
+      fireEvent.dragEnter(section, { dataTransfer: { types: ["Files"] } });
+    });
+    expect(section.getAttribute("data-agent-dragover")).toBe("true");
+
+    // Leaving the section entirely (relatedTarget outside) clears it.
+    act(() => {
+      fireEvent.dragLeave(section, { dataTransfer: { types: ["Files"] } });
+    });
+    expect(section.getAttribute("data-agent-dragover")).toBeNull();
   });
 
   it("hydrates an embedded non-agent tab only when that tab is focused", () => {

--- a/packages/desktop/src/components/WebSocketSessionFeatureBlock.tsx
+++ b/packages/desktop/src/components/WebSocketSessionFeatureBlock.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useRef, type ReactElement } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { EditorFuzzyShortcut } from "@/components/editor/EditorFuzzyShortcut";
+import { promptDropTargetIdOf } from "@/lib/prompt-drop-target";
 import { OpenDiffInEditorProvider } from "@/components/diff/OpenDiffInEditorContext";
 import { FeatureContentSearchShortcut } from "@/components/FeatureContentSearchShortcut";
 import { FeatureTopBar } from "@/components/FeatureTopBar";
@@ -149,6 +150,15 @@ function WebSocketSessionFeatureBody(
   ]);
   useWsSessionShortcuts({ controls, hotkeysEnabled });
 
+  // The whole feature/card area is the drop zone — drops on history, meta
+  // bar, or any tab content route to this agent's prompt. The id must match
+  // what `AgentPromptBar` computes so `useImageAttachments` accepts the drop.
+  const promptDropTargetId = useMemo(
+    () => promptDropTargetIdOf({ wsSessionId: sessionId, featureId }),
+    [sessionId, featureId],
+  );
+  const agentDropZone = useAgentDropZone();
+
   const tabs = useFeatureBlockTabs({
     sessionId,
     featureId,
@@ -169,7 +179,18 @@ function WebSocketSessionFeatureBody(
         tabIndex={0}
         onFocusCapture={onActivate}
         onPointerDownCapture={onActivate}
-        className="flex h-full min-h-0 flex-col outline-none"
+        // `data-agent-prompt-id` tags this whole agent area as the drop
+        // target — the Electron preload walks `closest()` to find it. The
+        // `group/agent-section` + `data-agent-dragover` pair lets the prompt
+        // bar paint its primary ring via CSS, with no React state crossing
+        // component boundaries — so in the unified grid only the card under
+        // the cursor highlights, not every mounted prompt.
+        data-agent-prompt-id={promptDropTargetId}
+        data-agent-dragover={agentDropZone.isDragging ? "true" : undefined}
+        onDragEnter={agentDropZone.onDragEnter}
+        onDragLeave={agentDropZone.onDragLeave}
+        onDrop={agentDropZone.onDrop}
+        className="group/agent-section flex h-full min-h-0 flex-col outline-none"
       >
         {!embedded && (
           <FeatureContentSearchShortcut
@@ -238,6 +259,45 @@ function useOpenDiffFileInEditor({
     },
     [featureId, layoutFeatureId, refs.editor, rootPath],
   );
+}
+
+interface AgentDropZone {
+  isDragging: boolean;
+  onDragEnter: (e: React.DragEvent<HTMLElement>) => void;
+  onDragLeave: (e: React.DragEvent<HTMLElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLElement>) => void;
+}
+
+function useAgentDropZone(): AgentDropZone {
+  const [isDragging, setIsDragging] = useState(false);
+  // `dragenter`/`dragleave` bubble from child elements, so moving the cursor
+  // between two children of the section would normally flicker isDragging
+  // off then back on. We disambiguate by checking `relatedTarget` — only flip
+  // to false when the cursor genuinely leaves the section.
+  const onDragEnter = useCallback((event: React.DragEvent<HTMLElement>): void => {
+    if (!isFileDragEvent(event)) return;
+    setIsDragging(true);
+  }, []);
+  const onDragLeave = useCallback((event: React.DragEvent<HTMLElement>): void => {
+    if (!isFileDragEvent(event)) return;
+    const next = event.relatedTarget as Node | null;
+    if (next && event.currentTarget.contains(next)) return;
+    setIsDragging(false);
+  }, []);
+  const onDrop = useCallback((): void => setIsDragging(false), []);
+  return { isDragging, onDragEnter, onDragLeave, onDrop };
+}
+
+function isFileDragEvent(event: React.DragEvent<HTMLElement>): boolean {
+  // Filter out text/link drags so the ring only lights up for actual file
+  // attachments. `types` is a DOMStringList in older specs but behaves like
+  // an array in Chromium.
+  const types = event.dataTransfer?.types;
+  if (!types) return false;
+  for (const type of types) {
+    if (type === "Files") return true;
+  }
+  return false;
 }
 
 function focusTabTrigger(container: HTMLElement, layoutFeatureId: number, tab: TabKind): void {

--- a/packages/desktop/src/hooks/useImageAttachments.test.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.test.ts
@@ -6,8 +6,13 @@ import {
 } from "@/lib/desktop-bridge";
 import type { CadencrDesktopBridge } from "@/lib/desktop-bridge";
 import { useImageAttachments } from "./useImageAttachments";
+import { toast } from "sonner";
 
-const mockOnFileDrop = vi.fn(() => () => undefined);
+const dropSubscribers: Array<(payload: unknown) => void> = [];
+const mockOnFileDrop = vi.fn((cb: (payload: unknown) => void) => {
+  dropSubscribers.push(cb);
+  return () => undefined;
+});
 
 function bridge(): CadencrDesktopBridge {
   return {
@@ -48,9 +53,14 @@ function createMockFile(name: string, type: string, size = 100): File {
 }
 
 describe("useImageAttachments", () => {
+  const readFileBase64 = vi.fn(async () => "abc123");
   beforeEach(() => {
     mockOnFileDrop.mockClear();
-    setDesktopBridgeOverrideForTests(bridge());
+    dropSubscribers.length = 0;
+    readFileBase64.mockReset();
+    readFileBase64.mockResolvedValue("abc123");
+    setDesktopBridgeOverrideForTests({ ...bridge(), readFileBase64 });
+    vi.spyOn(toast, "error").mockImplementation(() => "" as never);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 
@@ -149,6 +159,43 @@ describe("useImageAttachments", () => {
   it("registers desktop file-drop listener on mount", () => {
     renderHook(() => useImageAttachments());
     expect(mockOnFileDrop).toHaveBeenCalled();
+  });
+
+  it("routes a desktop drop to only the matching prompt id", async () => {
+    const { result: first } = renderHook(() => useImageAttachments("ws:first"));
+    const { result: second } = renderHook(() => useImageAttachments("ws:second"));
+
+    const firstCallback = dropSubscribers[0];
+    const secondCallback = dropSubscribers[1];
+
+    const payload = {
+      type: "drop" as const,
+      files: [{ handle: "h-1", name: "one.png" }],
+      targetPromptId: "ws:first",
+    };
+
+    act(() => {
+      firstCallback(payload);
+      secondCallback(payload);
+    });
+
+    await waitFor(() => {
+      expect(first.current.attachments).toHaveLength(1);
+    });
+
+    expect(second.current.attachments).toHaveLength(0);
+  });
+
+  it("ignores ambiguous desktop drops without a prompt target", async () => {
+    const { result } = renderHook(() => useImageAttachments("ws:first"));
+    const callback = dropSubscribers[0];
+
+    act(() => {
+      callback({ type: "drop", files: [{ handle: "h-1", name: "one.png" }] });
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.attachments).toHaveLength(0);
   });
 
   afterEach(() => clearDesktopBridgeOverrideForTests());

--- a/packages/desktop/src/hooks/useImageAttachments.test.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.test.ts
@@ -212,7 +212,7 @@ describe("useImageAttachments", () => {
     // Each subscriber still calls toast.error, but it must share a stable id so
     // sonner collapses them to a single visible toast — assert the id is set.
     expect(toast.error).toHaveBeenCalledWith(
-      "Drop an image directly on an agent prompt.",
+      "Drop the image on an agent to attach it.",
       expect.objectContaining({ id: "image-drop-missing-target" }),
     );
   });

--- a/packages/desktop/src/hooks/useImageAttachments.test.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.test.ts
@@ -4,12 +4,12 @@ import {
   clearDesktopBridgeOverrideForTests,
   setDesktopBridgeOverrideForTests,
 } from "@/lib/desktop-bridge";
-import type { CadencrDesktopBridge } from "@/lib/desktop-bridge";
+import type { CadencrDesktopBridge, FileDropPayload } from "@/lib/desktop-bridge";
 import { useImageAttachments } from "./useImageAttachments";
 import { toast } from "sonner";
 
-const dropSubscribers: Array<(payload: unknown) => void> = [];
-const mockOnFileDrop = vi.fn((cb: (payload: unknown) => void) => {
+const dropSubscribers: Array<(payload: FileDropPayload) => void> = [];
+const mockOnFileDrop = vi.fn((cb: (payload: FileDropPayload) => void) => {
   dropSubscribers.push(cb);
   return () => undefined;
 });
@@ -60,6 +60,7 @@ describe("useImageAttachments", () => {
     readFileBase64.mockReset();
     readFileBase64.mockResolvedValue("abc123");
     setDesktopBridgeOverrideForTests({ ...bridge(), readFileBase64 });
+    vi.mocked(toast.error).mockReset?.();
     vi.spyOn(toast, "error").mockImplementation(() => "" as never);
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock-url");
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
@@ -196,6 +197,34 @@ describe("useImageAttachments", () => {
 
     await new Promise((r) => setTimeout(r, 10));
     expect(result.current.attachments).toHaveLength(0);
+  });
+
+  it("dedupes the missing-target toast across mounted hooks", () => {
+    renderHook(() => useImageAttachments("ws:first"));
+    renderHook(() => useImageAttachments("ws:second"));
+
+    const payload = { type: "drop" as const, files: [{ handle: "h-1", name: "one.png" }] };
+    act(() => {
+      dropSubscribers[0](payload);
+      dropSubscribers[1](payload);
+    });
+
+    // Each subscriber still calls toast.error, but it must share a stable id so
+    // sonner collapses them to a single visible toast — assert the id is set.
+    expect(toast.error).toHaveBeenCalledWith(
+      "Drop an image directly on an agent prompt.",
+      expect.objectContaining({ id: "image-drop-missing-target" }),
+    );
+  });
+
+  it("does not toast for empty drops (e.g. text drags)", () => {
+    renderHook(() => useImageAttachments("ws:first"));
+
+    act(() => {
+      dropSubscribers[0]({ type: "drop", files: [] });
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   afterEach(() => clearDesktopBridgeOverrideForTests());

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -26,7 +26,7 @@ function getMimeFromExtension(fileName: string): string | undefined {
   return EXTENSION_TO_MIME[ext];
 }
 
-export function useImageAttachments() {
+export function useImageAttachments(promptId?: string) {
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const attachmentsRef = useRef(attachments);
@@ -114,6 +114,11 @@ export function useImageAttachments() {
         setIsDragging(false);
       } else if (event.type === "drop") {
         setIsDragging(false);
+        if (!event.targetPromptId) {
+          toast.error("Drop an image directly on an agent prompt.");
+          return;
+        }
+        if (promptId && event.targetPromptId !== promptId) return;
         void addDroppedFilesRef.current(event.files);
       } else if (event.type === "error") {
         setIsDragging(false);
@@ -122,7 +127,7 @@ export function useImageAttachments() {
         });
       }
     });
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [promptId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => {

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -28,9 +28,16 @@ function getMimeFromExtension(fileName: string): string | undefined {
 
 export function useImageAttachments(promptId?: string) {
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
-  const [isDragging, setIsDragging] = useState(false);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
+  // `isDragging` used to be driven from the preload's document-level
+  // `enter`/`leave` events, which fired for every mounted prompt bar at once
+  // — so a drag anywhere in the window lit up every card in the unified grid.
+  // The drag highlight now lives on the agent `<section>` (via React drag
+  // handlers + a `data-agent-dragover` attribute) so only the card under the
+  // cursor highlights. We keep this field for back-compat with existing
+  // mocks; new consumers should read drag state from the section.
+  const isDragging = false;
 
   const addAttachment = useCallback((attachment: ImageAttachment) => {
     setAttachments((prev) => {
@@ -105,23 +112,22 @@ export function useImageAttachments(promptId?: string) {
   const addDroppedFilesRef = useRef(addDroppedFiles);
   addDroppedFilesRef.current = addDroppedFiles;
 
-  // Listen for OS-level file drops (e.g. from Finder).
+  // Listen for OS-level file drops (e.g. from Finder). The agent `<section>`
+  // owns the visual drop-zone state; this effect only routes the file payload
+  // to the prompt under the cursor.
   useEffect(() => {
     return desktopBridge.onFileDrop((event) => {
-      if (event.type === "enter") {
-        setIsDragging(true);
-      } else if (event.type === "leave") {
-        setIsDragging(false);
-      } else if (event.type === "drop") {
-        setIsDragging(false);
-        // Non-file drags (text, links) still produce a drop event with no files;
-        // bail before the user-facing toast so we don't nag for inert drops.
+      if (event.type === "drop") {
+        // Non-file drags (text, links) still produce a drop event with no
+        // files — bail so we don't surface any user-facing noise for inert
+        // drops.
         if (event.files.length === 0) return;
+        // No matching prompt under the cursor (e.g. the drop landed on the
+        // sidebar or empty grid space). Surface one toast — sonner's `id`
+        // collapses concurrent calls from every mounted subscriber into a
+        // single visible toast.
         if (!event.targetPromptId) {
-          // Toast `id` dedupes across every mounted prompt bar — the same drop
-          // fires this listener on every subscriber, but sonner collapses calls
-          // that share an id into a single visible toast.
-          toast.error("Drop an image directly on an agent prompt.", {
+          toast.error("Drop the image on an agent to attach it.", {
             id: "image-drop-missing-target",
           });
           return;
@@ -129,13 +135,13 @@ export function useImageAttachments(promptId?: string) {
         if (promptId && event.targetPromptId !== promptId) return;
         void addDroppedFilesRef.current(event.files);
       } else if (event.type === "error") {
-        setIsDragging(false);
-        // Same dedup rationale as the missing-target toast above.
         toast.error("Couldn't read dropped files.", {
           id: "image-drop-read-error",
           description: event.message ?? "The desktop shell rejected the dropped file paths.",
         });
       }
+      // `enter` / `leave` are intentionally ignored — the per-section React
+      // drag handlers in `WebSocketSessionFeatureBlock` own the highlight.
     });
   }, [promptId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -160,16 +166,17 @@ export function useImageAttachments(promptId?: string) {
     setAttachments(next);
   }, []);
 
-  // React-level handlers — still needed for visual drag feedback.
-  // Note: Desktop shell intercepts OS file drops, so onDrop won't receive files
-  // from Finder. But we preventDefault to avoid browser default behavior.
+  // React-level handlers — kept for back-compat. The Electron preload now
+  // calls `preventDefault()` on dragover at the document level, and the
+  // section owns the visual feedback; these are no-ops left in the API so
+  // callers spreading `dragHandlers` onto the prompt-bar wrapper keep
+  // working.
   const onDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
   }, []);
 
   const onDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
-    setIsDragging(false);
   }, []);
 
   const dragHandlers = useMemo(() => ({ onDragOver, onDrop }), [onDragOver, onDrop]);

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -10,6 +10,27 @@ export interface ImageAttachment {
   previewUrl: string;
 }
 
+export interface ImageAttachmentDragHandlers {
+  onDragOver: (event: React.DragEvent) => void;
+  onDrop: (event: React.DragEvent) => void;
+}
+
+export interface UseImageAttachmentsResult {
+  attachments: ImageAttachment[];
+  addFiles: (files: FileList | File[]) => void;
+  removeAttachment: (id: string) => void;
+  clearAttachments: (options?: { revokeObjectUrls?: boolean }) => void;
+  restoreAttachments: (next: ImageAttachment[]) => void;
+  dragHandlers: ImageAttachmentDragHandlers;
+  /**
+   * Always `false`. The visual drag highlight is now owned by the agent
+   * `<section>` in `WebSocketSessionFeatureBlock` (via `data-agent-dragover`);
+   * the hook keeps this field for back-compat with consumer mocks but no
+   * longer drives any UI.
+   */
+  isDragging: boolean;
+}
+
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 const EXTENSION_TO_MIME: Record<string, string> = {
   png: "image/png",
@@ -26,7 +47,7 @@ function getMimeFromExtension(fileName: string): string | undefined {
   return EXTENSION_TO_MIME[ext];
 }
 
-export function useImageAttachments(promptId?: string) {
+export function useImageAttachments(promptId?: string): UseImageAttachmentsResult {
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -114,15 +114,25 @@ export function useImageAttachments(promptId?: string) {
         setIsDragging(false);
       } else if (event.type === "drop") {
         setIsDragging(false);
+        // Non-file drags (text, links) still produce a drop event with no files;
+        // bail before the user-facing toast so we don't nag for inert drops.
+        if (event.files.length === 0) return;
         if (!event.targetPromptId) {
-          toast.error("Drop an image directly on an agent prompt.");
+          // Toast `id` dedupes across every mounted prompt bar — the same drop
+          // fires this listener on every subscriber, but sonner collapses calls
+          // that share an id into a single visible toast.
+          toast.error("Drop an image directly on an agent prompt.", {
+            id: "image-drop-missing-target",
+          });
           return;
         }
         if (promptId && event.targetPromptId !== promptId) return;
         void addDroppedFilesRef.current(event.files);
       } else if (event.type === "error") {
         setIsDragging(false);
+        // Same dedup rationale as the missing-target toast above.
         toast.error("Couldn't read dropped files.", {
+          id: "image-drop-read-error",
           description: event.message ?? "The desktop shell rejected the dropped file paths.",
         });
       }

--- a/packages/desktop/src/hooks/usePromptAttachments.test.ts
+++ b/packages/desktop/src/hooks/usePromptAttachments.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDesktopBridgeOverrideForTests,
+  setDesktopBridgeOverrideForTests,
+} from "@/lib/desktop-bridge";
+import type { CadencrDesktopBridge } from "@/lib/desktop-bridge";
+import { usePromptAttachments } from "./usePromptAttachments";
+
+function bridge(): CadencrDesktopBridge {
+  return {
+    isElectron: true,
+    runtimeConfig: vi.fn(),
+    readFileBase64: vi.fn(),
+    onFileDrop: vi.fn(() => () => undefined),
+    revealInFinder: vi.fn(),
+    openExternal: vi.fn(),
+    pickDirectory: vi.fn(),
+    showSaveDialog: vi.fn(),
+    notifyPermission: vi.fn(),
+    notify: vi.fn(),
+    notifyTest: vi.fn(),
+    onNotificationClicked: vi.fn(() => () => undefined),
+    onNotificationFailed: vi.fn(() => () => undefined),
+    onNotificationFallback: vi.fn(() => () => undefined),
+    onCloseRequested: vi.fn(() => () => undefined),
+    confirmClose: vi.fn(),
+    requestQuit: vi.fn(),
+    setZoom: vi.fn(),
+    currentTheme: vi.fn(),
+    onThemeChange: vi.fn(() => () => undefined),
+    setBusy: vi.fn(() => Promise.resolve()),
+    onPowerSuspend: vi.fn(() => () => undefined),
+    onPowerResume: vi.fn(() => () => undefined),
+    checkForUpdates: vi.fn(() => Promise.resolve()),
+    fetchChangelog: vi.fn(() => Promise.resolve(null)),
+    installUpdate: vi.fn(() => Promise.resolve()),
+    onUpdateEvent: vi.fn(() => () => undefined),
+  };
+}
+
+describe("usePromptAttachments", () => {
+  beforeEach(() => {
+    // Wire a no-op bridge so the underlying `useImageAttachments` effect
+    // can subscribe without throwing in the test environment.
+    setDesktopBridgeOverrideForTests(bridge());
+  });
+  afterEach(() => clearDesktopBridgeOverrideForTests());
+
+  it("derives the prompt drop target id from wsSessionId first", () => {
+    const { result } = renderHook(() =>
+      usePromptAttachments({ wsSessionId: "feature-7", sessionId: 5, featureId: 9 }),
+    );
+    expect(result.current.promptDropTargetId).toBe("ws:feature-7");
+  });
+
+  it("falls back to dbSessionId, then featureId, then a stable unknown id", () => {
+    const { result: db } = renderHook(() => usePromptAttachments({ sessionId: 42, featureId: 9 }));
+    expect(db.current.promptDropTargetId).toBe("db:42");
+
+    const { result: feat } = renderHook(() => usePromptAttachments({ featureId: 9 }));
+    expect(feat.current.promptDropTargetId).toBe("feature:9");
+
+    const { result: none } = renderHook(() => usePromptAttachments({}));
+    expect(none.current.promptDropTargetId).toBe("prompt:unknown");
+  });
+
+  it("exposes the underlying useImageAttachments API", () => {
+    const { result } = renderHook(() => usePromptAttachments({ wsSessionId: "feature-1" }));
+    expect(result.current.attachments).toEqual([]);
+    expect(typeof result.current.addFiles).toBe("function");
+    expect(typeof result.current.removeAttachment).toBe("function");
+    expect(typeof result.current.clearAttachments).toBe("function");
+    expect(typeof result.current.restoreAttachments).toBe("function");
+    expect(result.current.dragHandlers).toEqual({
+      onDragOver: expect.any(Function),
+      onDrop: expect.any(Function),
+    });
+  });
+});

--- a/packages/desktop/src/hooks/usePromptAttachments.ts
+++ b/packages/desktop/src/hooks/usePromptAttachments.ts
@@ -1,0 +1,38 @@
+import { useMemo } from "react";
+import { useImageAttachments, type UseImageAttachmentsResult } from "@/hooks/useImageAttachments";
+import { promptDropTargetIdOf } from "@/lib/prompt-drop-target";
+
+export interface PromptAttachmentsArgs {
+  wsSessionId?: string | null;
+  sessionId?: number | null;
+  featureId?: number | null;
+}
+
+export interface UsePromptAttachmentsResult extends UseImageAttachmentsResult {
+  /**
+   * Stable id the agent `<section>` stamps via `data-agent-prompt-id`. The
+   * preload's drop handler reads it back so the OS drop is routed to the
+   * matching `useImageAttachments` consumer.
+   */
+  promptDropTargetId: string;
+}
+
+/**
+ * Wires up image attachments for a prompt bar — derives the drop-routing id
+ * from the session/feature identity and forwards the rest of the
+ * `useImageAttachments` API. Lives in its own hook so the (already-large)
+ * `AgentPromptBar` component doesn't need to know about drop-target wiring.
+ */
+export function usePromptAttachments(args: PromptAttachmentsArgs): UsePromptAttachmentsResult {
+  const promptDropTargetId = useMemo(
+    () =>
+      promptDropTargetIdOf({
+        wsSessionId: args.wsSessionId,
+        dbSessionId: args.sessionId,
+        featureId: args.featureId,
+      }),
+    [args.wsSessionId, args.sessionId, args.featureId],
+  );
+  const attachments = useImageAttachments(promptDropTargetId);
+  return useMemo(() => ({ ...attachments, promptDropTargetId }), [attachments, promptDropTargetId]);
+}

--- a/packages/desktop/src/lib/desktop-bridge.ts
+++ b/packages/desktop/src/lib/desktop-bridge.ts
@@ -42,6 +42,7 @@ export interface FileDropItem {
 export interface FileDropPayload {
   type: "enter" | "leave" | "drop" | "error";
   files: FileDropItem[];
+  targetPromptId?: string;
   message?: string;
 }
 

--- a/packages/desktop/src/lib/prompt-drop-target.ts
+++ b/packages/desktop/src/lib/prompt-drop-target.ts
@@ -1,0 +1,21 @@
+// Drop-target id shared by the agent's outer container (which owns the
+// drop zone) and `useImageAttachments` inside `AgentPromptBar`. Both must
+// derive the same string from the same inputs — otherwise a drop on the
+// section would resolve to one id while the hook listens for another and
+// the file silently never attaches.
+
+export interface PromptDropTargetArgs {
+  wsSessionId?: string | null;
+  dbSessionId?: number | null;
+  featureId?: number | null;
+}
+
+export function promptDropTargetIdOf(args: PromptDropTargetArgs): string {
+  if (args.wsSessionId) return `ws:${args.wsSessionId}`;
+  if (args.dbSessionId) return `db:${args.dbSessionId}`;
+  if (args.featureId) return `feature:${args.featureId}`;
+  // Defensive: every real call site has at least one of the three above,
+  // but if a future caller drops in without one we still emit a stable id
+  // so the section and the hook agree on "no real target".
+  return "prompt:unknown";
+}

--- a/packages/service/src/domain/ws_session/handler/mod.rs
+++ b/packages/service/src/domain/ws_session/handler/mod.rs
@@ -2249,6 +2249,7 @@ mod tests {
                     env: None,
                 },
                 manual_compact_cancel: Arc::new(AtomicBool::new(false)),
+                manual_compact_spawn_pending: Arc::new(AtomicBool::new(false)),
             },
         );
 


### PR DESCRIPTION
Closes https://github.com/merkr-software/CadencR/issues/25
### Motivation
- Desktop file-drops were being broadcast to all mounted prompt bars, causing a single Finder/Explorer drop to attach images to every prompt instance instead of the intended one.
- The change scopes OS-level drops to a concrete prompt target so only the prompt the user dropped onto consumes the files.

### Description
- Preload: include `targetPromptId` on the `onFileDrop` payload by resolving the closest `[data-agent-prompt-id]` from the DOM drop target.
- Bridge typings: extend `FileDropPayload` with optional `targetPromptId` so renderer consumers can filter safely.
- AgentPromptBar: generate a stable per-prompt id (`ws:<wsSessionId>`, `db:<sessionId>`, or `feature:<featureId>` fallback), expose it as `data-agent-prompt-id`, and pass it into `useImageAttachments`.
- useImageAttachments: accept an optional `promptId` and only consume `drop` events when `event.targetPromptId` matches the instance's `promptId`; show a toast for ambiguous (no-target) drops to guide the user.
- Tests: add regression tests to `useImageAttachments.test.ts` proving that multiple mounted hook instances only accept drops addressed to their prompt id and that drops without a prompt target are ignored.

### Testing
- Ran formatter: `pnpm --filter @cadencr/desktop format` which succeeded. 
- Ran unit tests: `pnpm --filter @cadencr/desktop test src/hooks/useImageAttachments.test.ts` and the file-level suite passed (8 tests). 
- Typecheck: `pnpm --filter @cadencr/desktop ts-check` surfaced a pre-existing type error in `src/components/diff/PatchDiffView.tsx` unrelated to these changes; that error was not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d7b8f2648330bb9a2c905c3f39ab)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File drop events now include the prompt target so attachments are delivered to the correct prompt.

* **Improvements**
  * Drop zones highlight only for real file drags (reduces flicker).
  * Drop handling is scoped and stays stable as context changes.
  * Error toasts for missing/failed drops are deduped.

* **Bug Fixes**
  * Inert/text drags and empty drops are ignored.

* **Tests**
  * Expanded coverage for scoped drops, ignored inert drops, and deduped toasts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/merkr-software/CadencR/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->