### PR TITLE
Fix sub-agent window stuck when close event carries parent_tool_use_id

### DIFF
--- a/packages/service/src/domain/runtime_stream/subagent_window.rs
+++ b/packages/service/src/domain/runtime_stream/subagent_window.rs
@@ -48,10 +48,12 @@ impl SubagentWindow {
         }
     }
 
-    /// Walks a root user message for tool_result blocks and removes any id
-    /// it closes. Same `parent_tool_use_id` guard as `record_starts`.
+    /// Walks a user message for tool_result blocks and removes any id it
+    /// closes. We intentionally do NOT require `parent_tool_use_id` to be
+    /// absent because some provider transcripts attach it to the root close
+    /// event; if we skip that event, the fallback window can get stuck open.
     pub(super) fn record_ends(&mut self, runtime_event: &RuntimeEvent) {
-        if self.active.is_empty() || runtime_event.parent_tool_use_id().is_some() {
+        if self.active.is_empty() {
             return;
         }
         let Some(msg) = runtime_event.user_message() else {
@@ -204,6 +206,33 @@ mod tests {
 
         win.record_starts(&assistant_with_tool_use("toolu_1", "Task", None));
         assert!(win.carries_lifecycle_block(&user_with_tool_result("toolu_1")));
+    }
+
+    #[test]
+    fn record_ends_accepts_tool_result_with_parent_tool_use_id() {
+        let mut win = SubagentWindow::new();
+        win.record_starts(&assistant_with_tool_use("toolu_1", "Task", None));
+        let event = RuntimeEvent::new(
+            RuntimeEventMetadata {
+                session_id: Some("root-1".into()),
+                usage: None,
+                context_window: None,
+                raw: json!({ "type": "user" }),
+            },
+            RuntimeEventKind::UserMessage {
+                message: RuntimeUserMessage {
+                    content: vec![RuntimeUserContentBlock::ToolResult {
+                        tool_use_id: Some("toolu_1".into()),
+                        is_error: false,
+                        content: json!("ok"),
+                    }],
+                },
+                parent_tool_use_id: Some("toolu_1".into()),
+            },
+        );
+
+        win.record_ends(&event);
+        assert!(!win.is_active());
     }
 
     #[test]

--- a/packages/service/src/domain/runtime_stream/usage_state.rs
+++ b/packages/service/src/domain/runtime_stream/usage_state.rs
@@ -87,6 +87,11 @@ impl RuntimeUsageState {
         runtime_event: &RuntimeEvent,
     ) -> RuntimeUsageUpdate {
         if self.is_subagent_event(runtime_event) {
+            // Even when usage is ignored, a root tool_result can still carry
+            // `parent_tool_use_id` in some provider transcripts. Record the
+            // close so the fallback window does not get stuck open.
+            self.subagent_window.record_ends(runtime_event);
+
             return RuntimeUsageUpdate {
                 snapshot: self.snapshot,
                 changed: false,
@@ -225,7 +230,11 @@ mod tests {
         )
     }
 
-    fn make_user_with_tool_result(session_id: &str, tool_use_id: &str) -> RuntimeEvent {
+    fn make_user_with_tool_result_with_parent(
+        session_id: &str,
+        tool_use_id: &str,
+        parent_tool_use_id: Option<&str>,
+    ) -> RuntimeEvent {
         RuntimeEvent::new(
             RuntimeEventMetadata {
                 session_id: Some(session_id.into()),
@@ -241,9 +250,13 @@ mod tests {
                         content: json!("ok"),
                     }],
                 },
-                parent_tool_use_id: None,
+                parent_tool_use_id: parent_tool_use_id.map(ToOwned::to_owned),
             },
         )
+    }
+
+    fn make_user_with_tool_result(session_id: &str, tool_use_id: &str) -> RuntimeEvent {
+        make_user_with_tool_result_with_parent(session_id, tool_use_id, None)
     }
 
     fn make_result_with_context_window(session_id: &str, context_window: u64) -> RuntimeEvent {
@@ -437,6 +450,43 @@ mod tests {
         assert!(update.changed);
         assert_eq!(update.snapshot.input_tokens, 6000);
         assert_eq!(update.snapshot.output_tokens, 900);
+    }
+
+    #[test]
+    fn task_tool_result_with_parent_tool_use_id_still_closes_window() {
+        // Some transcripts include parent_tool_use_id on the root tool_result
+        // that closes a Task. We still must close the fallback window, or
+        // later root events will be misclassified as sub-agent traffic.
+        let mut state = RuntimeUsageState::new(None);
+        state.set_root_session_id("root-1");
+        state.apply_event(
+            None,
+            &make_assistant_with_tool_use("root-1", "toolu_1", "Task", None),
+        );
+
+        // While the window is active, leaked same-session events are filtered.
+        let update = state.apply_event(None, &make_message_start("root-1", 150_000, None));
+        assert!(!update.changed);
+
+        // Close event includes parent_tool_use_id and should still close.
+        state.apply_event(
+            None,
+            &make_user_with_tool_result_with_parent("root-1", "toolu_1", Some("toolu_1")),
+        );
+
+        let update = state.apply_event(
+            None,
+            &make_assistant_usage(
+                "root-1",
+                RuntimeUsage {
+                    input_tokens: 6000,
+                    output_tokens: 900,
+                },
+                None,
+            ),
+        );
+        assert!(update.changed);
+        assert_eq!(update.snapshot.input_tokens, 6000);
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/merkr-software/CadencR/issues/22
### Motivation
- Prevent the sub-agent fallback window from remaining active when a root tool-result close event includes `parent_tool_use_id`, which caused later root events to be misclassified as sub-agent traffic.

### Description
- Call `self.subagent_window.record_ends(runtime_event)` from `RuntimeUsageState::apply_event` even for events classified as sub-agent so close-paths are recorded and the fallback window can close. 
- Relax `SubagentWindow::record_ends` so it does not require `parent_tool_use_id` to be absent, because some provider transcripts attach it to the root close event. 
- Add helper and regression tests covering the close-event path that carries `parent_tool_use_id` in `usage_state` and `subagent_window` unit tests. 
- Modified test utilities to allow constructing user close events with an explicit `parent_tool_use_id`.

### Testing
- Ran `cargo test runtime_stream:: -- --nocapture` from `packages/service` and the `runtime_stream` unit tests passed. 
- Ran the package-level `cargo test` for `packages/service` and all new/related unit tests passed. 
- `pnpm --filter @cadencr/desktop ts-check` (frontend TypeScript check) failed due to an unrelated pre-existing TypeScript error in `src/components/diff/PatchDiffView.tsx` and was not addressed by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d794e33c833093d6c16e629d02b9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where sub-agent windows could remain stuck open, preventing proper cleanup of completed operations.

* **Tests**
  * Improved test coverage for tool-result event handling to prevent regression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/merkr-software/CadencR/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->