### PR TITLE
fix(desktop): restart terminal in place when last pane is closed

### DIFF
--- a/packages/desktop/src/components/FeatureTerminalTab.tsx
+++ b/packages/desktop/src/components/FeatureTerminalTab.tsx
@@ -110,17 +110,25 @@ export const FeatureTerminalTab = memo(
       { enabled: hotkeysEnabled && !hidden },
     );
 
+    // Track whether any pane exists. Closing the last pane (Cmd+W or the X
+    // button) sets `root` to null. Including this flag in the effects below
+    // makes them re-run the instant the pane count drops to zero — without it,
+    // the auto-open effect only fires when `isTerminalVisible` *changes*, so
+    // killing the only terminal left a blank panel until the user switched
+    // tabs and back. Reacting to `hasPanes` restarts a fresh terminal in place.
+    const hasPanes = terminalState.root != null;
+
     // Auto-create a pane and open if none exist when the terminal tab is visible,
     // but only move real DOM focus there when this pane is the focused one.
     useEffect(() => {
       if (hidden || !isTerminalVisible) return;
       ensureTerminalOpen();
-    }, [hidden, ensureTerminalOpen, isTerminalVisible]);
+    }, [hidden, ensureTerminalOpen, isTerminalVisible, hasPanes]);
 
     useEffect(() => {
       if (hidden || !isTerminalFocused) return;
       activate();
-    }, [hidden, activate, isTerminalFocused]);
+    }, [hidden, activate, isTerminalFocused, hasPanes]);
 
     return (
       <div className={hidden ? "hidden" : "h-full"}>


### PR DESCRIPTION
## Summary
- Closing the only terminal pane with **Cmd+W** (or the X button) left a blank terminal panel until the user switched tabs and back. Now the terminal restarts in place: a fresh, focused terminal spawns immediately so the section is never blank.
- Implemented by tracking `hasPanes` in `FeatureTerminalTab` and adding it to the dependency arrays of the existing auto-open and focus effects, so `ensureTerminalOpen()` / `activate()` re-run the instant the pane count drops to zero. Reuses existing, StrictMode-safe helpers — no store changes.

## Behavior notes
- Closing one of several split panes still just removes that pane (no spurious respawn); only closing the **last** pane restarts in place.
- The "second Cmd+W with no terminals closes the window" path no longer fires from the terminal tab (root never stays null while visible). Window close via Cmd+W still works from other tabs; `shouldBypassAppClose`/`useAppClose` are untouched.

## Test plan
- [x] `pnpm --filter @cadencr/desktop ts-check`
- [x] `pnpm --filter @cadencr/desktop test` — `useTerminalState` + `useAppClose` pass (34/34); they operate on the store directly, which still sets `root: null`
- [x] Manual QA in-app:
  - Cmd+W on the only pane → pane count stays 1, fresh pane ID, focused (no blank panel, no tab switch)
  - Repeated Cmd+W → a terminal is always present; window never closes
  - Split (Cmd+D) → Cmd+W closes one pane (down to 1), Cmd+W again restarts the last one in place

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed terminal tab to automatically recreate and reopen when the last pane is closed, improving responsiveness without requiring manual intervention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/merkr-software/CadencR/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->