### PR TITLE
fix: correct Claude model + restore Claude Code system prompt (Bedrock/Vertex/Anthropic)

### DIFF
--- a/packages/claude-agent-sdk-rs/src/lib.rs
+++ b/packages/claude-agent-sdk-rs/src/lib.rs
@@ -28,7 +28,9 @@ pub use permissions::{
     AllowAllTools, CanUseTool, PermissionMode, PermissionRequest, PermissionResult,
     PermissionUpdate,
 };
-pub use query::{query, supported_commands, supported_models, Query, TurnState};
+pub use query::{
+    query, supported_commands, supported_models, supported_models_with_env, Query, TurnState,
+};
 pub use transport::{claude_discovery_spec, set_binary_override};
 pub use types::{
     AccountInfo, AgentInfo, CompactMetadata, ContentBlock, ContentDelta, McpServerStatus,

--- a/packages/claude-agent-sdk-rs/src/query/metadata.rs
+++ b/packages/claude-agent-sdk-rs/src/query/metadata.rs
@@ -9,6 +9,7 @@
 //! [`run_initialize_probe`]; each helper supplies its own extractor for
 //! the field it cares about (`commands` vs `models`).
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::error::SdkError;
@@ -36,6 +37,7 @@ const INIT_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 async fn run_initialize_probe<T, F>(
     cwd: &str,
     path_to_cli: Option<&std::path::Path>,
+    env: Option<HashMap<String, String>>,
     id_prefix: &str,
     extract: F,
 ) -> Result<T, SdkError>
@@ -46,6 +48,7 @@ where
 
     let options = Options {
         cwd: std::path::PathBuf::from(cwd),
+        env,
         ..Options::default()
     };
 
@@ -112,7 +115,7 @@ pub async fn supported_commands(
     cwd: &str,
     path_to_cli: Option<&std::path::Path>,
 ) -> Result<Vec<crate::types::SlashCommand>, SdkError> {
-    run_initialize_probe(cwd, path_to_cli, "init_cmd", |response| {
+    run_initialize_probe(cwd, path_to_cli, None, "init_cmd", |response| {
         let commands = response
             .get("commands")
             .cloned()
@@ -166,7 +169,22 @@ pub async fn supported_models(
     cwd: &str,
     path_to_cli: Option<&std::path::Path>,
 ) -> Result<Vec<crate::types::ModelInfo>, SdkError> {
-    run_initialize_probe(cwd, path_to_cli, "init_models", |response| {
+    supported_models_with_env(cwd, path_to_cli, None).await
+}
+
+/// Fetch the list of models the CLI currently exposes with additional
+/// environment variables layered onto the probe process.
+///
+/// This must be used when the host has a runtime profile that changes Claude
+/// Code's provider backend (for example Bedrock or Vertex), because the CLI
+/// resolves aliases and model metadata during initialize using its process
+/// environment.
+pub async fn supported_models_with_env(
+    cwd: &str,
+    path_to_cli: Option<&std::path::Path>,
+    env: Option<HashMap<String, String>>,
+) -> Result<Vec<crate::types::ModelInfo>, SdkError> {
+    run_initialize_probe(cwd, path_to_cli, env, "init_models", |response| {
         let models = response
             .get("models")
             .cloned()
@@ -181,7 +199,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::super::test_support::write_mock_cli;
-    use super::{supported_commands, supported_models};
+    use super::{supported_commands, supported_models, supported_models_with_env};
 
     #[tokio::test]
     async fn supported_models_extracts_models_from_control_response() {
@@ -211,6 +229,36 @@ sleep 60
         assert_eq!(models[0].supports_effort, Some(true));
         assert_eq!(models[0].supports_auto_mode, Some(true));
         assert_eq!(models[2].value, "haiku");
+    }
+
+    #[tokio::test]
+    async fn supported_models_with_env_applies_env_to_probe_process() {
+        let dir = TempDir::new().unwrap();
+
+        let script = r#"#!/bin/sh
+read -r INIT_REQ
+REQ_ID=$(printf '%s' "$INIT_REQ" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+DESC="${CLAUDE_CODE_USE_BEDROCK:-missing}:${ANTHROPIC_DEFAULT_SONNET_MODEL:-missing}"
+printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"commands":[],"models":[{"value":"sonnet","displayName":"Sonnet","description":"%s"}],"account":{}}}}\n' "$REQ_ID" "$DESC"
+sleep 60
+"#;
+        let script_path = write_mock_cli(dir.path(), script);
+        let mut env = std::collections::HashMap::new();
+        env.insert("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string());
+        env.insert(
+            "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+            "us.anthropic.claude-sonnet-4-6".to_string(),
+        );
+
+        let models = supported_models_with_env("/tmp", Some(script_path.as_path()), Some(env))
+            .await
+            .expect("should return models");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(
+            models[0].description.as_deref(),
+            Some("1:us.anthropic.claude-sonnet-4-6")
+        );
     }
 
     #[tokio::test]

--- a/packages/claude-agent-sdk-rs/src/query/mod.rs
+++ b/packages/claude-agent-sdk-rs/src/query/mod.rs
@@ -1,7 +1,8 @@
 //! Streaming Claude CLI query module.
 //!
 //! Public surface: [`Query`], [`TurnState`], [`query`],
-//! [`supported_commands`], [`supported_models`].
+//! [`supported_commands`], [`supported_models`],
+//! [`supported_models_with_env`].
 //!
 //! Layout:
 //! - [`turn_state`] — [`TurnState`] enum (turn/UI state machine)
@@ -26,7 +27,7 @@ mod wire;
 #[cfg(test)]
 mod test_support;
 
-pub use metadata::{supported_commands, supported_models};
+pub use metadata::{supported_commands, supported_models, supported_models_with_env};
 pub use query_struct::Query;
 pub use spawn::query;
 pub use turn_state::TurnState;

--- a/packages/claude-agent-sdk-rs/src/query/spawn.rs
+++ b/packages/claude-agent-sdk-rs/src/query/spawn.rs
@@ -65,13 +65,18 @@ pub async fn query(content: serde_json::Value, mut options: Options) -> Result<Q
 
     // Send the initialize control request so the CLI knows we support
     // the bidirectional control protocol (canUseTool, AskUserQuestion, etc.).
-    let (_init_request_id, init_msg) = build_control_request(
-        "init",
-        serde_json::json!({
-            "subtype": "initialize",
-            "systemPrompt": options.system_prompt.as_deref(),
-        }),
-    );
+    //
+    // Only include `systemPrompt` when the caller actually set one. Sending
+    // `"systemPrompt": null` makes the CLI drop its default Claude Code system
+    // prompt entirely — the `# Environment` block (model identity, cwd, git)
+    // and all the Claude Code agent instructions — leaving the session with an
+    // empty system prompt. Omitting the key makes the CLI use its full default
+    // preset (the same thing a bare `claude -p` and the metadata probe do).
+    let mut init_request = serde_json::json!({ "subtype": "initialize" });
+    if let Some(system_prompt) = options.system_prompt.as_deref() {
+        init_request["systemPrompt"] = system_prompt.into();
+    }
+    let (_init_request_id, init_msg) = build_control_request("init", init_request);
     debug!("sending initialize control_request to CLI stdin");
     write_to_stdin(&process_stdin, &init_msg).await?;
 
@@ -221,5 +226,62 @@ echo '{{"type":"result","subtype":"success","uuid":"u2","session_id":"sess_image
         let captured: serde_json::Value =
             serde_json::from_str(captured_raw.trim()).expect("captured prompt JSON");
         assert_eq!(captured["message"]["content"], content);
+    }
+
+    /// Mock CLI that records the first stdin line (the `initialize`
+    /// control_request) to `captured`, then completes a trivial turn so
+    /// `query()` returns.
+    fn init_capture_script(captured: &std::path::Path) -> String {
+        format!(
+            r#"#!/bin/sh
+set -e
+CAP='{}'
+read -r INIT_REQ
+printf '%s' "$INIT_REQ" > "$CAP"
+INIT_ID=$(printf '%s' "$INIT_REQ" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{{"type":"control_response","response":{{"subtype":"success","request_id":"%s","response":{{}}}}}}\n' "$INIT_ID"
+read -r USER_PROMPT
+echo '{{"type":"system","subtype":"init","uuid":"u1","session_id":"s","claude_code_version":"1.0","cwd":"/tmp","tools":[],"mcp_servers":[],"model":"m","permission_mode":"default","slash_commands":[],"output_style":"stream","skills":[],"plugins":[]}}'
+echo '{{"type":"result","subtype":"success","uuid":"u2","session_id":"s","duration_ms":1,"duration_api_ms":1,"is_error":false,"num_turns":1,"result":"ok","errors":null,"stop_reason":"end_turn","total_cost_usd":0.0,"usage":{{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"permission_denials":[],"structured_output":null}}'
+"#,
+            captured.display()
+        )
+    }
+
+    async fn capture_initialize_request(system_prompt: Option<String>) -> serde_json::Value {
+        let dir = TempDir::new().unwrap();
+        let captured = dir.path().join("init.json");
+        let script_path = write_mock_cli(dir.path(), &init_capture_script(&captured));
+        let options = Options {
+            path_to_cli: Some(script_path),
+            system_prompt,
+            ..Options::default()
+        };
+        let mut q = query(serde_json::Value::String("hi".into()), options)
+            .await
+            .unwrap();
+        while q.next().await.is_some() {}
+        let raw = std::fs::read_to_string(&captured).expect("captured initialize request");
+        serde_json::from_str(raw.trim()).expect("initialize request JSON")
+    }
+
+    /// Regression: `systemPrompt: null` makes the CLI drop its default Claude
+    /// Code system prompt, so when no custom prompt is set the key must be
+    /// omitted entirely (CLI then uses its full default preset).
+    #[tokio::test]
+    async fn initialize_omits_system_prompt_when_unset() {
+        let req = capture_initialize_request(None).await;
+        assert_eq!(req["request"]["subtype"], "initialize");
+        assert!(
+            req["request"].get("systemPrompt").is_none(),
+            "systemPrompt must be omitted when unset, got: {req}"
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_includes_system_prompt_when_set() {
+        let req = capture_initialize_request(Some("custom prompt".to_string())).await;
+        assert_eq!(req["request"]["subtype"], "initialize");
+        assert_eq!(req["request"]["systemPrompt"], "custom prompt");
     }
 }

--- a/packages/cli-discovery/src/types.rs
+++ b/packages/cli-discovery/src/types.rs
@@ -18,6 +18,7 @@ pub struct DiscoverySpec {
     /// When `Some(needle)`, a candidate must satisfy both:
     /// 1. its `--version` output contains `needle` (case-insensitive), and
     /// 2. the output parses as a valid semver triple.
+    ///
     /// Otherwise the candidate is excluded.
     ///
     /// Defends against version-multiplexer shims that masquerade as the real

--- a/packages/desktop/src/components/ModelSelectorRow.tsx
+++ b/packages/desktop/src/components/ModelSelectorRow.tsx
@@ -1,5 +1,6 @@
 import { Button } from "./ui/button";
 import { ProviderIcon } from "@/lib/provider-icons";
+import { resolveProviderModelAlias } from "@/lib/provider-model-aliases";
 import { RuntimeModelPicker } from "@/components/RuntimeModelPicker";
 import type { RuntimeModelOption } from "@/api/agentRuntime";
 import { ChevronDownIcon } from "lucide-react";
@@ -75,6 +76,7 @@ export function ModelSelectorRow(props: ModelSelectorRowProps) {
             providers={providers}
             selectedProviderId={selectedProviderId}
             selectedModelId={selectedModelId}
+            resolveSelectedModelId={resolveProviderModelAlias}
             onSelect={onSelect}
             action={inheritAction}
             trigger={

--- a/packages/desktop/src/components/RuntimeModelPicker.test.tsx
+++ b/packages/desktop/src/components/RuntimeModelPicker.test.tsx
@@ -2,17 +2,21 @@ import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@/test-utils";
-import { RuntimeModelPicker } from "./RuntimeModelPicker";
+import { RuntimeModelPicker, type RuntimeModelSelectionResolver } from "./RuntimeModelPicker";
 
 function Harness(props: {
   onSelect?: (providerId: string, modelId: string) => void;
   onAfterSelectClose?: () => void;
   models?: Array<{ id: string; label: string }>;
+  selectedModelId?: string;
+  resolveSelectedModelId?: RuntimeModelSelectionResolver;
 }) {
   const {
     models = [{ id: "opus", label: "Opus" }],
     onSelect = vi.fn(),
     onAfterSelectClose = vi.fn(),
+    selectedModelId = "opus",
+    resolveSelectedModelId,
   } = props;
   const [open, setOpen] = useState(false);
 
@@ -29,7 +33,8 @@ function Harness(props: {
         },
       ]}
       selectedProviderId="claude_code"
-      selectedModelId="opus"
+      selectedModelId={selectedModelId}
+      resolveSelectedModelId={resolveSelectedModelId}
       onSelect={onSelect}
       onAfterSelectClose={onAfterSelectClose}
       trigger={<button type="button">Open picker</button>}
@@ -98,5 +103,48 @@ describe("RuntimeModelPicker", () => {
     await user.type(screen.getByPlaceholderText("Search providers or models..."), "Op");
 
     await waitFor(() => expect(commandList.scrollTop).toBe(0));
+  });
+
+  it("does not resolve provider-specific model aliases unless a resolver is provided", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Harness
+        selectedModelId="sonnet"
+        models={[{ id: "us.anthropic.claude-sonnet-4-6", label: "Sonnet" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open picker" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Claude \/ Sonnet/i })).toHaveAttribute(
+        "data-selected",
+        "false",
+      ),
+    );
+  });
+
+  it("uses an injected resolver to highlight provider-specific aliases", async () => {
+    const user = userEvent.setup();
+    const resolveSelectedModelId: RuntimeModelSelectionResolver = () =>
+      "us.anthropic.claude-sonnet-4-6";
+
+    render(
+      <Harness
+        selectedModelId="sonnet"
+        resolveSelectedModelId={resolveSelectedModelId}
+        models={[{ id: "us.anthropic.claude-sonnet-4-6", label: "Sonnet" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open picker" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Claude \/ Sonnet/i })).toHaveAttribute(
+        "data-selected",
+        "true",
+      ),
+    );
   });
 });

--- a/packages/desktop/src/components/RuntimeModelPicker.tsx
+++ b/packages/desktop/src/components/RuntimeModelPicker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Command, CommandEmpty, CommandInput, CommandList } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { resolveModelAlias } from "@/shared/models";
 import {
   ModelGroup,
   ProviderStateGroup,
@@ -106,8 +107,19 @@ export function RuntimeModelPicker({
   const [internalOpen, setInternalOpen] = useState(false);
   const [search, setSearch] = useState("");
   const resolvedOpen = open ?? internalOpen;
+  // A stored selection can be a coarse alias (e.g. "sonnet") while the active
+  // catalog only lists the concrete id ("us.anthropic.claude-sonnet-4-6") under
+  // a backend like Bedrock. Resolve the alias against the selected provider's
+  // models so the matching catalog row still highlights. No-op for exact ids.
+  const resolvedSelectedModelId = useMemo(() => {
+    if (!selectedProviderId || !selectedModelId) return selectedModelId;
+    const providerModels = providers.find((provider) => provider.id === selectedProviderId)?.models;
+    return providerModels ? resolveModelAlias(selectedModelId, providerModels) : selectedModelId;
+  }, [providers, selectedProviderId, selectedModelId]);
   const selectedModelValue =
-    selectedProviderId && selectedModelId ? `${selectedProviderId}:${selectedModelId}` : "";
+    selectedProviderId && resolvedSelectedModelId
+      ? `${selectedProviderId}:${resolvedSelectedModelId}`
+      : "";
   const selectedCommandValue = selectedModelValue || (action?.selected ? action.id : "");
 
   useEffect(() => {

--- a/packages/desktop/src/components/RuntimeModelPicker.tsx
+++ b/packages/desktop/src/components/RuntimeModelPicker.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { Command, CommandEmpty, CommandInput, CommandList } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { resolveModelAlias } from "@/shared/models";
 import {
   ModelGroup,
   ProviderStateGroup,
@@ -29,6 +28,12 @@ export interface RuntimeModelPickerProvider {
   models: RuntimeModelPickerModel[];
 }
 
+export type RuntimeModelSelectionResolver = (
+  providerId: string,
+  modelId: string,
+  models: readonly RuntimeModelPickerModel[],
+) => string;
+
 interface RuntimeModelPickerProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -36,6 +41,7 @@ interface RuntimeModelPickerProps {
   providers: RuntimeModelPickerProvider[];
   selectedProviderId?: string;
   selectedModelId?: string;
+  resolveSelectedModelId?: RuntimeModelSelectionResolver;
   onSelect: (providerId: string, modelId: string) => void;
   action?: RuntimeModelPickerAction;
   searchPlaceholder?: string;
@@ -45,11 +51,55 @@ interface RuntimeModelPickerProps {
   onAfterSelectClose?: () => void;
 }
 
+interface SelectedModelValueParams {
+  providers: RuntimeModelPickerProvider[];
+  selectedProviderId?: string;
+  selectedModelId?: string;
+  resolveSelectedModelId?: RuntimeModelSelectionResolver;
+}
+
+function useSelectedModelValue({
+  providers,
+  selectedProviderId,
+  selectedModelId,
+  resolveSelectedModelId,
+}: SelectedModelValueParams): string {
+  return useMemo(() => {
+    if (!selectedProviderId || !selectedModelId) return "";
+    const providerModels = providers.find((provider) => provider.id === selectedProviderId)?.models;
+    const modelId =
+      providerModels && resolveSelectedModelId
+        ? resolveSelectedModelId(selectedProviderId, selectedModelId, providerModels)
+        : selectedModelId;
+    return `${selectedProviderId}:${modelId}`;
+  }, [providers, resolveSelectedModelId, selectedProviderId, selectedModelId]);
+}
+
 interface SelectedModelScrollParams {
   listRef: React.RefObject<HTMLDivElement | null>;
   resolvedOpen: boolean;
   search: string;
   selectedModelValue: string;
+}
+
+interface RuntimeModelPickerContentProps {
+  action?: RuntimeModelPickerAction;
+  align: "start" | "center" | "end";
+  contentClassName?: string;
+  emptyText: string;
+  inputRef: RefObject<HTMLInputElement | null>;
+  listRef: RefObject<HTMLDivElement | null>;
+  modelEntries: ModelEntry[];
+  onActionSelect: () => void;
+  onAfterSelectClose?: () => void;
+  onModelSelect: (entry: ModelEntry) => void;
+  providerStateEntries: ProviderStateEntry[];
+  restoreFocusAfterCloseRef: RefObject<boolean>;
+  search: string;
+  searchPlaceholder: string;
+  selectedCommandValue: string;
+  selectedModelValue: string;
+  setSearch: (value: string) => void;
 }
 
 function useScrollSelectedModel({
@@ -86,6 +136,71 @@ function useScrollSelectedModel({
   }, [listRef, resolvedOpen, search, selectedModelValue]);
 }
 
+function RuntimeModelPickerContent({
+  action,
+  align,
+  contentClassName,
+  emptyText,
+  inputRef,
+  listRef,
+  modelEntries,
+  onActionSelect,
+  onAfterSelectClose,
+  onModelSelect,
+  providerStateEntries,
+  restoreFocusAfterCloseRef,
+  search,
+  searchPlaceholder,
+  selectedCommandValue,
+  selectedModelValue,
+  setSearch,
+}: RuntimeModelPickerContentProps): React.ReactElement {
+  function focusSearchInput(): void {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  return (
+    <PopoverContent
+      align={align}
+      className={cn("w-[340px] p-0", contentClassName)}
+      onOpenAutoFocus={(event) => {
+        event.preventDefault();
+        focusSearchInput();
+      }}
+      onCloseAutoFocus={(event) => {
+        if (!restoreFocusAfterCloseRef.current) return;
+        restoreFocusAfterCloseRef.current = false;
+        event.preventDefault();
+        onAfterSelectClose?.();
+      }}
+    >
+      <Command defaultValue={selectedCommandValue}>
+        <CommandInput
+          ref={inputRef}
+          placeholder={searchPlaceholder}
+          value={search}
+          onValueChange={setSearch}
+          className="h-9 text-xs"
+        />
+        <CommandList ref={listRef} className="max-h-[320px]">
+          <CommandEmpty className="py-3 text-center text-xs">{emptyText}</CommandEmpty>
+          {action ? <SelectionGroup action={action} onSelect={onActionSelect} /> : null}
+          {modelEntries.length > 0 ? (
+            <ModelGroup
+              entries={modelEntries}
+              selectedModelValue={selectedModelValue}
+              onSelect={onModelSelect}
+            />
+          ) : null}
+          {providerStateEntries.length > 0 ? (
+            <ProviderStateGroup entries={providerStateEntries} />
+          ) : null}
+        </CommandList>
+      </Command>
+    </PopoverContent>
+  );
+}
+
 export function RuntimeModelPicker({
   open,
   onOpenChange,
@@ -93,6 +208,7 @@ export function RuntimeModelPicker({
   providers,
   selectedProviderId,
   selectedModelId,
+  resolveSelectedModelId,
   onSelect,
   action,
   searchPlaceholder = "Search providers or models...",
@@ -107,19 +223,12 @@ export function RuntimeModelPicker({
   const [internalOpen, setInternalOpen] = useState(false);
   const [search, setSearch] = useState("");
   const resolvedOpen = open ?? internalOpen;
-  // A stored selection can be a coarse alias (e.g. "sonnet") while the active
-  // catalog only lists the concrete id ("us.anthropic.claude-sonnet-4-6") under
-  // a backend like Bedrock. Resolve the alias against the selected provider's
-  // models so the matching catalog row still highlights. No-op for exact ids.
-  const resolvedSelectedModelId = useMemo(() => {
-    if (!selectedProviderId || !selectedModelId) return selectedModelId;
-    const providerModels = providers.find((provider) => provider.id === selectedProviderId)?.models;
-    return providerModels ? resolveModelAlias(selectedModelId, providerModels) : selectedModelId;
-  }, [providers, selectedProviderId, selectedModelId]);
-  const selectedModelValue =
-    selectedProviderId && resolvedSelectedModelId
-      ? `${selectedProviderId}:${resolvedSelectedModelId}`
-      : "";
+  const selectedModelValue = useSelectedModelValue({
+    providers,
+    selectedProviderId,
+    selectedModelId,
+    resolveSelectedModelId,
+  });
   const selectedCommandValue = selectedModelValue || (action?.selected ? action.id : "");
 
   useEffect(() => {
@@ -134,10 +243,6 @@ export function RuntimeModelPicker({
     () => getProviderStateEntries(providers),
     [providers],
   );
-
-  function focusSearchInput(): void {
-    requestAnimationFrame(() => inputRef.current?.focus());
-  }
 
   function handleOpenChange(nextOpen: boolean): void {
     if (open === undefined) setInternalOpen(nextOpen);
@@ -160,44 +265,25 @@ export function RuntimeModelPicker({
   return (
     <Popover open={resolvedOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent
+      <RuntimeModelPickerContent
+        action={action}
         align={align}
-        className={cn("w-[340px] p-0", contentClassName)}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          focusSearchInput();
-        }}
-        onCloseAutoFocus={(event) => {
-          if (!restoreFocusAfterCloseRef.current) return;
-          restoreFocusAfterCloseRef.current = false;
-          event.preventDefault();
-          onAfterSelectClose?.();
-        }}
-      >
-        <Command defaultValue={selectedCommandValue}>
-          <CommandInput
-            ref={inputRef}
-            placeholder={searchPlaceholder}
-            value={search}
-            onValueChange={setSearch}
-            className="h-9 text-xs"
-          />
-          <CommandList ref={listRef} className="max-h-[320px]">
-            <CommandEmpty className="py-3 text-center text-xs">{emptyText}</CommandEmpty>
-            {action ? <SelectionGroup action={action} onSelect={handleActionSelect} /> : null}
-            {modelEntries.length > 0 ? (
-              <ModelGroup
-                entries={modelEntries}
-                selectedModelValue={selectedModelValue}
-                onSelect={handleModelSelect}
-              />
-            ) : null}
-            {providerStateEntries.length > 0 ? (
-              <ProviderStateGroup entries={providerStateEntries} />
-            ) : null}
-          </CommandList>
-        </Command>
-      </PopoverContent>
+        contentClassName={contentClassName}
+        emptyText={emptyText}
+        inputRef={inputRef}
+        listRef={listRef}
+        modelEntries={modelEntries}
+        onActionSelect={handleActionSelect}
+        onAfterSelectClose={onAfterSelectClose}
+        onModelSelect={handleModelSelect}
+        providerStateEntries={providerStateEntries}
+        restoreFocusAfterCloseRef={restoreFocusAfterCloseRef}
+        search={search}
+        searchPlaceholder={searchPlaceholder}
+        selectedCommandValue={selectedCommandValue}
+        selectedModelValue={selectedModelValue}
+        setSearch={setSearch}
+      />
     </Popover>
   );
 }

--- a/packages/desktop/src/components/agent-session/ModelMetaChip.tsx
+++ b/packages/desktop/src/components/agent-session/ModelMetaChip.tsx
@@ -1,6 +1,7 @@
 import { ChevronDownIcon, Loader2Icon } from "lucide-react";
 import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
 import { ProviderIcon } from "@/lib/provider-icons";
+import { resolveProviderModelAlias } from "@/lib/provider-model-aliases";
 import { cn } from "@/lib/utils";
 import {
   RuntimeModelPicker,
@@ -76,6 +77,7 @@ export function ModelMetaChip({
             providers={pickerProviders}
             selectedProviderId={currentProviderId}
             selectedModelId={currentModelId}
+            resolveSelectedModelId={resolveProviderModelAlias}
             onAfterSelectClose={onModelSelected}
             onSelect={(providerId, modelId) => {
               if (canChangeProvider && onProviderChange && providerId !== currentProviderId) {

--- a/packages/desktop/src/lib/provider-model-aliases.test.ts
+++ b/packages/desktop/src/lib/provider-model-aliases.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveModelAlias, type CatalogModelLike } from "./models";
+import {
+  resolveClaudeModelAlias,
+  resolveProviderModelAlias,
+  type CatalogModelLike,
+} from "./provider-model-aliases";
 
 // Catalog the CLI returns under a Bedrock profile: concrete ids with canonical
 // family labels, plus the `haiku`/`default` aliases it still exposes verbatim.
@@ -14,22 +18,33 @@ const bedrockCatalog: CatalogModelLike[] = [
 
 describe("resolveModelAlias", () => {
   it("maps a bare sonnet alias to the concrete Bedrock id", () => {
-    expect(resolveModelAlias("sonnet", bedrockCatalog)).toBe("us.anthropic.claude-sonnet-4-6");
+    expect(resolveClaudeModelAlias("sonnet", bedrockCatalog)).toBe(
+      "us.anthropic.claude-sonnet-4-6",
+    );
   });
 
   it("maps the [1m] alias to the concrete 1M id", () => {
-    expect(resolveModelAlias("sonnet[1m]", bedrockCatalog)).toBe(
+    expect(resolveClaudeModelAlias("sonnet[1m]", bedrockCatalog)).toBe(
       "us.anthropic.claude-sonnet-4-6[1m]",
     );
   });
 
   it("maps opus to the primary row, not a legacy one", () => {
-    expect(resolveModelAlias("opus", bedrockCatalog)).toBe("us.anthropic.claude-opus-4-8");
+    expect(resolveClaudeModelAlias("opus", bedrockCatalog)).toBe("us.anthropic.claude-opus-4-8");
+  });
+
+  it("maps aliases case-insensitively", () => {
+    expect(resolveClaudeModelAlias("Sonnet", bedrockCatalog)).toBe(
+      "us.anthropic.claude-sonnet-4-6",
+    );
+    expect(resolveClaudeModelAlias("SONNET[1M]", bedrockCatalog)).toBe(
+      "us.anthropic.claude-sonnet-4-6[1m]",
+    );
   });
 
   it("keeps an id that already exists in the catalog", () => {
-    expect(resolveModelAlias("haiku", bedrockCatalog)).toBe("haiku");
-    expect(resolveModelAlias("us.anthropic.claude-opus-4-7", bedrockCatalog)).toBe(
+    expect(resolveClaudeModelAlias("haiku", bedrockCatalog)).toBe("haiku");
+    expect(resolveClaudeModelAlias("us.anthropic.claude-opus-4-7", bedrockCatalog)).toBe(
       "us.anthropic.claude-opus-4-7",
     );
   });
@@ -40,16 +55,23 @@ describe("resolveModelAlias", () => {
       { id: "sonnet", label: "Sonnet" },
       { id: "haiku", label: "Haiku" },
     ];
-    expect(resolveModelAlias("sonnet", anthropic)).toBe("sonnet");
+    expect(resolveClaudeModelAlias("sonnet", anthropic)).toBe("sonnet");
   });
 
   it("leaves unknown / custom ids untouched", () => {
-    expect(resolveModelAlias("my-gateway/custom", bedrockCatalog)).toBe("my-gateway/custom");
+    expect(resolveClaudeModelAlias("my-gateway/custom", bedrockCatalog)).toBe("my-gateway/custom");
   });
 
   it("leaves an alias untouched when no matching family label is present", () => {
     expect(
-      resolveModelAlias("sonnet", [{ id: "us.anthropic.claude-opus-4-8", label: "Opus" }]),
+      resolveClaudeModelAlias("sonnet", [{ id: "us.anthropic.claude-opus-4-8", label: "Opus" }]),
     ).toBe("sonnet");
+  });
+
+  it("only applies Claude alias resolution to the Claude Code provider", () => {
+    expect(resolveProviderModelAlias("claude_code", "sonnet", bedrockCatalog)).toBe(
+      "us.anthropic.claude-sonnet-4-6",
+    );
+    expect(resolveProviderModelAlias("opencode", "sonnet", bedrockCatalog)).toBe("sonnet");
   });
 });

--- a/packages/desktop/src/lib/provider-model-aliases.ts
+++ b/packages/desktop/src/lib/provider-model-aliases.ts
@@ -1,0 +1,52 @@
+export interface CatalogModelLike {
+  id: string;
+  label: string;
+}
+
+export type ProviderModelAliasResolver = (
+  modelId: string,
+  models: readonly CatalogModelLike[],
+) => string;
+
+const MODEL_FAMILY_LABELS: Record<string, string> = {
+  sonnet: "Sonnet",
+  opus: "Opus",
+  haiku: "Haiku",
+};
+
+/**
+ * Mirror of the backend `resolve_model_alias` (Rust:
+ * packages/service/src/domain/agents/claude_code/model_alias.rs). Maps a coarse
+ * Claude family alias (`sonnet`/`opus`/`haiku`, optionally with a `[1m]` suffix)
+ * to the concrete catalog id the active Claude backend advertises. It is a
+ * no-op when the id is already a catalog entry, so the persisted value remains
+ * portable while the UI can highlight the active catalog row.
+ */
+export function resolveClaudeModelAlias(
+  modelId: string,
+  models: readonly CatalogModelLike[],
+): string {
+  if (models.some((model) => model.id === modelId)) return modelId;
+
+  const normalizedModelId = modelId.toLowerCase();
+  const wants1m = normalizedModelId.endsWith("[1m]");
+  const normalizedBase = wants1m ? normalizedModelId.slice(0, -"[1m]".length) : normalizedModelId;
+  const family = MODEL_FAMILY_LABELS[normalizedBase];
+  if (!family) return modelId;
+
+  const targetLabel = wants1m ? `${family} (1M context)` : family;
+  const match = models.find((model) => model.label.toLowerCase() === targetLabel.toLowerCase());
+  return match ? match.id : modelId;
+}
+
+const PROVIDER_MODEL_ALIAS_RESOLVERS: Partial<Record<string, ProviderModelAliasResolver>> = {
+  claude_code: resolveClaudeModelAlias,
+};
+
+export function resolveProviderModelAlias(
+  providerId: string,
+  modelId: string,
+  models: readonly CatalogModelLike[],
+): string {
+  return PROVIDER_MODEL_ALIAS_RESOLVERS[providerId]?.(modelId, models) ?? modelId;
+}

--- a/packages/desktop/src/shared/models.test.ts
+++ b/packages/desktop/src/shared/models.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelAlias, type CatalogModelLike } from "./models";
+
+// Catalog the CLI returns under a Bedrock profile: concrete ids with canonical
+// family labels, plus the `haiku`/`default` aliases it still exposes verbatim.
+const bedrockCatalog: CatalogModelLike[] = [
+  { id: "default", label: "Default" },
+  { id: "us.anthropic.claude-sonnet-4-6", label: "Sonnet" },
+  { id: "us.anthropic.claude-sonnet-4-6[1m]", label: "Sonnet (1M context)" },
+  { id: "us.anthropic.claude-opus-4-8", label: "Opus" },
+  { id: "us.anthropic.claude-opus-4-7", label: "Opus 4.7" },
+  { id: "haiku", label: "Haiku" },
+];
+
+describe("resolveModelAlias", () => {
+  it("maps a bare sonnet alias to the concrete Bedrock id", () => {
+    expect(resolveModelAlias("sonnet", bedrockCatalog)).toBe("us.anthropic.claude-sonnet-4-6");
+  });
+
+  it("maps the [1m] alias to the concrete 1M id", () => {
+    expect(resolveModelAlias("sonnet[1m]", bedrockCatalog)).toBe(
+      "us.anthropic.claude-sonnet-4-6[1m]",
+    );
+  });
+
+  it("maps opus to the primary row, not a legacy one", () => {
+    expect(resolveModelAlias("opus", bedrockCatalog)).toBe("us.anthropic.claude-opus-4-8");
+  });
+
+  it("keeps an id that already exists in the catalog", () => {
+    expect(resolveModelAlias("haiku", bedrockCatalog)).toBe("haiku");
+    expect(resolveModelAlias("us.anthropic.claude-opus-4-7", bedrockCatalog)).toBe(
+      "us.anthropic.claude-opus-4-7",
+    );
+  });
+
+  it("is a no-op when the backend exposes aliases directly (Anthropic)", () => {
+    const anthropic: CatalogModelLike[] = [
+      { id: "default", label: "Default (recommended)" },
+      { id: "sonnet", label: "Sonnet" },
+      { id: "haiku", label: "Haiku" },
+    ];
+    expect(resolveModelAlias("sonnet", anthropic)).toBe("sonnet");
+  });
+
+  it("leaves unknown / custom ids untouched", () => {
+    expect(resolveModelAlias("my-gateway/custom", bedrockCatalog)).toBe("my-gateway/custom");
+  });
+
+  it("leaves an alias untouched when no matching family label is present", () => {
+    expect(
+      resolveModelAlias("sonnet", [{ id: "us.anthropic.claude-opus-4-8", label: "Opus" }]),
+    ).toBe("sonnet");
+  });
+});

--- a/packages/desktop/src/shared/models.ts
+++ b/packages/desktop/src/shared/models.ts
@@ -44,6 +44,41 @@ export function defaultModelForProvider(
   );
 }
 
+export interface CatalogModelLike {
+  id: string;
+  label: string;
+}
+
+const MODEL_FAMILY_LABELS: Record<string, string> = {
+  sonnet: "Sonnet",
+  opus: "Opus",
+  haiku: "Haiku",
+};
+
+/**
+ * Mirror of the backend `resolve_model_alias` (Rust:
+ * packages/service/src/domain/agents/claude_code/model_alias.rs). Maps a coarse
+ * family alias (`sonnet`/`opus`/`haiku`, optionally with a `[1m]` suffix) to the
+ * concrete catalog id the active backend advertises — e.g. on Bedrock `"sonnet"`
+ * → `"us.anthropic.claude-sonnet-4-6"` (label "Sonnet"). It is a no-op when the
+ * id is already a catalog entry (Anthropic aliases, concrete ids, every other
+ * provider), so it only changes a stored alias that the active catalog exposes
+ * under a concrete id. Used purely so the picker can highlight a stored alias;
+ * the persisted value is left untouched.
+ */
+export function resolveModelAlias(modelId: string, models: readonly CatalogModelLike[]): string {
+  if (models.some((model) => model.id === modelId)) return modelId;
+
+  const wants1m = modelId.endsWith("[1m]");
+  const base = wants1m ? modelId.slice(0, -"[1m]".length) : modelId;
+  const family = MODEL_FAMILY_LABELS[base];
+  if (!family) return modelId;
+
+  const targetLabel = wants1m ? `${family} (1M context)` : family;
+  const match = models.find((model) => model.label.toLowerCase() === targetLabel.toLowerCase());
+  return match ? match.id : modelId;
+}
+
 function applySelectionOverride(
   base: RuntimeSelection,
   providerOverride: string | undefined,

--- a/packages/desktop/src/shared/models.ts
+++ b/packages/desktop/src/shared/models.ts
@@ -44,41 +44,6 @@ export function defaultModelForProvider(
   );
 }
 
-export interface CatalogModelLike {
-  id: string;
-  label: string;
-}
-
-const MODEL_FAMILY_LABELS: Record<string, string> = {
-  sonnet: "Sonnet",
-  opus: "Opus",
-  haiku: "Haiku",
-};
-
-/**
- * Mirror of the backend `resolve_model_alias` (Rust:
- * packages/service/src/domain/agents/claude_code/model_alias.rs). Maps a coarse
- * family alias (`sonnet`/`opus`/`haiku`, optionally with a `[1m]` suffix) to the
- * concrete catalog id the active backend advertises — e.g. on Bedrock `"sonnet"`
- * → `"us.anthropic.claude-sonnet-4-6"` (label "Sonnet"). It is a no-op when the
- * id is already a catalog entry (Anthropic aliases, concrete ids, every other
- * provider), so it only changes a stored alias that the active catalog exposes
- * under a concrete id. Used purely so the picker can highlight a stored alias;
- * the persisted value is left untouched.
- */
-export function resolveModelAlias(modelId: string, models: readonly CatalogModelLike[]): string {
-  if (models.some((model) => model.id === modelId)) return modelId;
-
-  const wants1m = modelId.endsWith("[1m]");
-  const base = wants1m ? modelId.slice(0, -"[1m]".length) : modelId;
-  const family = MODEL_FAMILY_LABELS[base];
-  if (!family) return modelId;
-
-  const targetLabel = wants1m ? `${family} (1M context)` : family;
-  const match = models.find((model) => model.label.toLowerCase() === targetLabel.toLowerCase());
-  return match ? match.id : modelId;
-}
-
 function applySelectionOverride(
   base: RuntimeSelection,
   providerOverride: string | undefined,

--- a/packages/service/src/domain/agents/adapter/adapter_trait.rs
+++ b/packages/service/src/domain/agents/adapter/adapter_trait.rs
@@ -80,6 +80,18 @@ pub trait AgentRuntimeAdapter: Send + Sync {
         self.catalog_entry().default_model
     }
 
+    /// Preferred default model id with access to persisted settings.
+    ///
+    /// Mirrors [`catalog_entry_live_for_settings`]: providers whose default
+    /// depends on app settings (Claude Code profiles injecting Bedrock/Vertex
+    /// env) must resolve the default against the *same* probe env the catalog
+    /// uses, otherwise the default-model probe runs with a different env key
+    /// and thrashes the shared catalog cache. Defaults to the settings-agnostic
+    /// [`default_model_id`].
+    async fn default_model_id_for_settings(&self, _read_pool: &sqlx::SqlitePool) -> Option<String> {
+        self.default_model_id().await
+    }
+
     /// Provider-known context window for a given model id, if the provider
     /// can answer synchronously (e.g. opencode exposes this via its server).
     /// Defaults to `None` — callers must fall back to another source

--- a/packages/service/src/domain/agents/adapter/adapter_trait.rs
+++ b/packages/service/src/domain/agents/adapter/adapter_trait.rs
@@ -49,6 +49,18 @@ pub trait AgentRuntimeAdapter: Send + Sync {
         self.catalog_entry_live().await
     }
 
+    /// Live catalog entry with access to persisted settings. Providers whose
+    /// discovery depends on app settings (for example Claude Code profiles
+    /// that inject Bedrock/Vertex env vars) can override this request-aware
+    /// hook while other providers keep the cwd-only default.
+    async fn catalog_entry_live_for_settings(
+        &self,
+        _read_pool: &sqlx::SqlitePool,
+        cwd: Option<&Path>,
+    ) -> super::super::runtime::ProviderCatalogEntry {
+        self.catalog_entry_live_for_cwd(cwd).await
+    }
+
     /// Extra models contributed by user configuration (e.g. custom Claude Code
     /// model aliases stored in SQLite). Returned entries are merged into the
     /// adapter's catalog; on id collision the user entry wins.

--- a/packages/service/src/domain/agents/claude_code/adapter_impl.rs
+++ b/packages/service/src/domain/agents/claude_code/adapter_impl.rs
@@ -154,6 +154,11 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
         ClaudeCodeAdapter::default_model_id(self).await
     }
 
+    async fn default_model_id_for_settings(&self, read_pool: &SqlitePool) -> Option<String> {
+        let (_, profile_env) = super::profiles::resolve_active_profile_env(read_pool).await;
+        ClaudeCodeAdapter::default_model_id_with_env(self, profile_env).await
+    }
+
     async fn extra_models(&self, read_pool: &sqlx::SqlitePool) -> Vec<ModelCatalogEntry> {
         match custom_models::list_custom_models(read_pool).await {
             Ok(models) => models,
@@ -190,6 +195,30 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
         content: Value,
         config: RuntimeSpawnConfig,
     ) -> Result<Box<dyn AgentRuntimeSession>, RuntimeError> {
+        // Resolve a stored bare alias (sonnet/opus/haiku) to the concrete model
+        // the active profile's catalog advertises. Under Bedrock/Vertex the
+        // bare alias is pinned by the CLI to a legacy version (e.g. `sonnet` →
+        // Sonnet 4.5), while the catalog/picker uses concrete ids. Probing with
+        // `config.env` (the active profile env) hits the same cache key the
+        // settings catalog populated, so this is a cache read in the common
+        // case. No-op under the default Anthropic backend, where the alias is
+        // itself the catalog id.
+        let model = match config.model {
+            Some(requested) => {
+                let catalog = self.load_models_with_env(config.env.clone()).await;
+                let resolved = super::model_alias::resolve_model_alias(&requested, &catalog);
+                if resolved != requested {
+                    tracing::debug!(
+                        %requested,
+                        %resolved,
+                        "rewrote Claude model alias to concrete catalog id for active profile"
+                    );
+                }
+                Some(resolved)
+            }
+            None => None,
+        };
+
         // Claude Code CLI v2.1.x parses `--effort` but drops it before building
         // the API request (anthropics/claude-code#41028). The CLI does honor
         // `CLAUDE_CODE_EFFORT_LEVEL`, so set both: the env var is what actually
@@ -206,7 +235,7 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
         let options = claude_agent_sdk_rs::Options {
             cwd: config.cwd,
             permission_mode: config.permission_mode.map(map_permission_mode),
-            model: config.model,
+            model,
             effort: config.thinking_effort,
             system_prompt: config.system_prompt,
             resume: config.resume_session_id,

--- a/packages/service/src/domain/agents/claude_code/adapter_impl.rs
+++ b/packages/service/src/domain/agents/claude_code/adapter_impl.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
 use serde_json::Value;
+use sqlx::SqlitePool;
+use std::path::Path;
 
 use super::catalog::fallback_models;
 use super::custom_models;
@@ -135,16 +137,17 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
 
     async fn catalog_entry_live(&self) -> ProviderCatalogEntry {
         let models = self.load_models().await;
-        let default_model = Self::default_model_from(&models);
-        ProviderCatalogEntry {
-            id: "claude_code".to_string(),
-            label: "Claude".to_string(),
-            status: ProviderStatus::Available,
-            status_message: None,
-            models,
-            modes: Vec::new(),
-            default_model,
-        }
+        provider_catalog_entry_from_models(models)
+    }
+
+    async fn catalog_entry_live_for_settings(
+        &self,
+        read_pool: &SqlitePool,
+        _cwd: Option<&Path>,
+    ) -> ProviderCatalogEntry {
+        let (_, profile_env) = super::profiles::resolve_active_profile_env(read_pool).await;
+        let models = self.load_models_with_env(profile_env).await;
+        provider_catalog_entry_from_models(models)
     }
 
     async fn default_model_id(&self) -> Option<String> {
@@ -229,6 +232,19 @@ impl AgentRuntimeAdapter for ClaudeCodeAdapter {
             query,
             prompt_receipts: std::sync::Arc::new(ClaudePromptReceipts::default()),
         }))
+    }
+}
+
+fn provider_catalog_entry_from_models(models: Vec<ModelCatalogEntry>) -> ProviderCatalogEntry {
+    let default_model = ClaudeCodeAdapter::default_model_from(&models);
+    ProviderCatalogEntry {
+        id: "claude_code".to_string(),
+        label: "Claude".to_string(),
+        status: ProviderStatus::Available,
+        status_message: None,
+        models,
+        modes: Vec::new(),
+        default_model,
     }
 }
 

--- a/packages/service/src/domain/agents/claude_code/catalog.rs
+++ b/packages/service/src/domain/agents/claude_code/catalog.rs
@@ -303,7 +303,7 @@ mod tests {
         apply_model_probe_result(
             adapter.models_cell(),
             &mut probe_state,
-            cache_key.clone(),
+            cache_key,
             Ok(vec![ModelCatalogEntry::alias("default", "Default")]),
         );
 

--- a/packages/service/src/domain/agents/claude_code/catalog.rs
+++ b/packages/service/src/domain/agents/claude_code/catalog.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
 use crate::domain::agents::adapter::{RuntimeSlashCommand, RuntimeSlashCommandKind};
 use crate::domain::agents::runtime::ModelCatalogEntry;
 
@@ -26,9 +29,32 @@ pub(super) fn sdk_model_to_catalog_entry(
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct ModelProbeCacheKey(u64);
+
+pub(super) fn model_probe_cache_key(env: Option<&HashMap<String, String>>) -> ModelProbeCacheKey {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let Some(env) = env.filter(|env| !env.is_empty()) else {
+        0u8.hash(&mut hasher);
+        return ModelProbeCacheKey(hasher.finish());
+    };
+
+    1u8.hash(&mut hasher);
+    let mut entries = env.iter().collect::<Vec<_>>();
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+    for (key, value) in entries {
+        key.hash(&mut hasher);
+        0xffu8.hash(&mut hasher);
+        value.hash(&mut hasher);
+        0xfeu8.hash(&mut hasher);
+    }
+    ModelProbeCacheKey(hasher.finish())
+}
+
 pub(super) fn apply_model_probe_result(
     cache: &std::sync::RwLock<Vec<ModelCatalogEntry>>,
     probe_state: &mut ProbeState,
+    cache_key: ModelProbeCacheKey,
     result: Result<Vec<ModelCatalogEntry>, String>,
 ) {
     match result {
@@ -37,6 +63,7 @@ pub(super) fn apply_model_probe_result(
                 *cached_models = models;
             }
             probe_state.live = true;
+            probe_state.live_key = Some(cache_key);
         }
         Ok(_) => {
             tracing::warn!(
@@ -66,10 +93,18 @@ impl ClaudeCodeAdapter {
     }
 
     pub(super) async fn load_models(&self) -> Vec<ModelCatalogEntry> {
+        self.load_models_with_env(None).await
+    }
+
+    pub(super) async fn load_models_with_env(
+        &self,
+        env: Option<HashMap<String, String>>,
+    ) -> Vec<ModelCatalogEntry> {
+        let cache_key = model_probe_cache_key(env.as_ref());
         let mut guard = self.probe_state.lock().await;
-        if !guard.live {
+        if guard.live_key != Some(cache_key) {
             let cwd = std::env::temp_dir().to_string_lossy().into_owned();
-            let probe_result = claude_agent_sdk_rs::supported_models(&cwd, None)
+            let probe_result = claude_agent_sdk_rs::supported_models_with_env(&cwd, None, env)
                 .await
                 .map(|models| {
                     models
@@ -78,13 +113,18 @@ impl ClaudeCodeAdapter {
                         .collect::<Vec<_>>()
                 })
                 .map_err(|error| error.to_string());
-            apply_model_probe_result(self.models_cell(), &mut guard, probe_result);
+            apply_model_probe_result(self.models_cell(), &mut guard, cache_key, probe_result);
         }
+        let cache_matches_request = guard.live_key == Some(cache_key);
         drop(guard);
-        self.models_cell()
-            .read()
-            .map(|models| models.clone())
-            .unwrap_or_else(|_| fallback_models())
+        if cache_matches_request {
+            self.models_cell()
+                .read()
+                .map(|models| models.clone())
+                .unwrap_or_else(|_| fallback_models())
+        } else {
+            fallback_models()
+        }
     }
 
     pub(super) fn slash_commands_cell(&self) -> &std::sync::RwLock<Vec<RuntimeSlashCommand>> {
@@ -140,10 +180,13 @@ fn sdk_slash_to_runtime(command: claude_agent_sdk_rs::SlashCommand) -> RuntimeSl
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::domain::agents::runtime::ModelCatalogEntry;
 
     use super::{
-        apply_model_probe_result, sdk_model_to_catalog_entry, ClaudeCodeAdapter, ProbeState,
+        apply_model_probe_result, model_probe_cache_key, sdk_model_to_catalog_entry,
+        ClaudeCodeAdapter, ProbeState,
     };
 
     fn new_test_adapter() -> ClaudeCodeAdapter {
@@ -207,15 +250,17 @@ mod tests {
     fn apply_model_probe_result_marks_cache_live_on_success() {
         let adapter = new_test_adapter();
         let mut probe_state = ProbeState::default();
+        let cache_key = model_probe_cache_key(None);
 
         apply_model_probe_result(
             adapter.models_cell(),
             &mut probe_state,
+            cache_key.clone(),
             Ok(vec![ModelCatalogEntry::alias("default", "Default")]),
         );
 
         let cached = adapter.models_cell().read().expect("cache lock");
-        assert!(probe_state.live);
+        assert_eq!(probe_state.live_key, Some(cache_key));
         assert_eq!(cached[0].id, "default");
     }
 
@@ -224,10 +269,15 @@ mod tests {
         let adapter = new_test_adapter();
         let mut probe_state = ProbeState::default();
 
-        apply_model_probe_result(adapter.models_cell(), &mut probe_state, Ok(vec![]));
+        apply_model_probe_result(
+            adapter.models_cell(),
+            &mut probe_state,
+            model_probe_cache_key(None),
+            Ok(vec![]),
+        );
 
         let cached = adapter.models_cell().read().expect("cache lock");
-        assert!(!probe_state.live);
+        assert!(probe_state.live_key.is_none());
         assert_eq!(cached[0].id, "opus");
     }
 
@@ -239,11 +289,52 @@ mod tests {
         apply_model_probe_result(
             adapter.models_cell(),
             &mut probe_state,
+            model_probe_cache_key(None),
             Err("boom".to_string()),
         );
 
         let cached = adapter.models_cell().read().expect("cache lock");
-        assert!(!probe_state.live);
+        assert!(probe_state.live_key.is_none());
         assert_eq!(cached[0].id, "opus");
+    }
+
+    #[test]
+    fn model_probe_cache_key_is_stable_for_env_ordering() {
+        let mut env_a = HashMap::new();
+        env_a.insert("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string());
+        env_a.insert(
+            "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+            "us.anthropic.claude-sonnet-4-6".to_string(),
+        );
+        let mut env_b = HashMap::new();
+        env_b.insert(
+            "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+            "us.anthropic.claude-sonnet-4-6".to_string(),
+        );
+        env_b.insert("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string());
+
+        assert_eq!(
+            model_probe_cache_key(Some(&env_a)),
+            model_probe_cache_key(Some(&env_b))
+        );
+    }
+
+    #[test]
+    fn model_probe_cache_key_changes_when_env_value_changes() {
+        let mut env_a = HashMap::new();
+        env_a.insert(
+            "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+            "us.anthropic.claude-sonnet-4-6".to_string(),
+        );
+        let mut env_b = HashMap::new();
+        env_b.insert(
+            "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+            "us.anthropic.claude-sonnet-4-7".to_string(),
+        );
+
+        assert_ne!(
+            model_probe_cache_key(Some(&env_a)),
+            model_probe_cache_key(Some(&env_b))
+        );
     }
 }

--- a/packages/service/src/domain/agents/claude_code/catalog.rs
+++ b/packages/service/src/domain/agents/claude_code/catalog.rs
@@ -83,7 +83,18 @@ impl ClaudeCodeAdapter {
     /// Return the CLI's preferred default model ID (`"default"` if present,
     /// else the first model in the list).
     pub(super) async fn default_model_id(&self) -> Option<String> {
-        let models = self.load_models().await;
+        self.default_model_id_with_env(None).await
+    }
+
+    /// Env-aware variant of [`default_model_id`]. Probes the catalog under the
+    /// active profile env so the default is resolved against the same model
+    /// list the picker shows — and crucially under the same cache key, so the
+    /// default-model probe and the catalog probe never thrash the shared cell.
+    pub(super) async fn default_model_id_with_env(
+        &self,
+        env: Option<HashMap<String, String>>,
+    ) -> Option<String> {
+        let models = self.load_models_with_env(env).await;
         Self::default_model_from(&models)
     }
 
@@ -196,6 +207,43 @@ mod tests {
             cached_slash_commands: std::sync::OnceLock::new(),
             slash_commands_probe_state: tokio::sync::Mutex::new(ProbeState::default()),
         }
+    }
+
+    /// Regression for the catalog-cache thrash: the env-aware default-model
+    /// resolution must read the catalog cached under the *same* profile env
+    /// key, not re-probe with a different key. Here the cell is pre-seeded and
+    /// marked live for the Bedrock env, so `default_model_id_with_env` must
+    /// hit that cache (returning the Bedrock model) and leave `live_key`
+    /// untouched — proving it can't clobber the picker's env-aware catalog.
+    #[tokio::test]
+    async fn default_model_id_with_env_reuses_catalog_cache_key() {
+        let adapter = new_test_adapter();
+        let mut env = HashMap::new();
+        env.insert("CLAUDE_CODE_USE_BEDROCK".to_string(), "1".to_string());
+        env.insert(
+            "ANTHROPIC_DEFAULT_SONNET_MODEL".to_string(),
+            "us.anthropic.claude-sonnet-4-6".to_string(),
+        );
+        let env_key = model_probe_cache_key(Some(&env));
+
+        {
+            let mut cached = adapter.models_cell().write().expect("cache lock");
+            *cached = vec![ModelCatalogEntry::alias(
+                "us.anthropic.claude-sonnet-4-6",
+                "Sonnet",
+            )];
+        }
+        {
+            let mut guard = adapter.probe_state.lock().await;
+            guard.live_key = Some(env_key);
+        }
+
+        let default = adapter.default_model_id_with_env(Some(env)).await;
+        assert_eq!(default.as_deref(), Some("us.anthropic.claude-sonnet-4-6"));
+
+        // The cache stayed live for the Bedrock env key — no None-keyed re-probe.
+        let guard = adapter.probe_state.lock().await;
+        assert_eq!(guard.live_key, Some(env_key));
     }
 
     #[test]

--- a/packages/service/src/domain/agents/claude_code/mod.rs
+++ b/packages/service/src/domain/agents/claude_code/mod.rs
@@ -2,6 +2,7 @@ mod adapter_impl;
 mod catalog;
 pub mod custom_models;
 mod events;
+mod model_alias;
 mod post_plan_approval;
 pub mod profiles;
 mod prompt_receipts;

--- a/packages/service/src/domain/agents/claude_code/mod.rs
+++ b/packages/service/src/domain/agents/claude_code/mod.rs
@@ -40,13 +40,20 @@ pub struct ClaudeCodeAdapter {
 #[derive(Default)]
 struct ProbeState {
     live: bool,
+    live_key: Option<catalog::ModelProbeCacheKey>,
 }
 
 pub static CLAUDE_CODE_ADAPTER: ClaudeCodeAdapter = ClaudeCodeAdapter {
     cached_models: std::sync::OnceLock::new(),
-    probe_state: tokio::sync::Mutex::const_new(ProbeState { live: false }),
+    probe_state: tokio::sync::Mutex::const_new(ProbeState {
+        live: false,
+        live_key: None,
+    }),
     cached_slash_commands: std::sync::OnceLock::new(),
-    slash_commands_probe_state: tokio::sync::Mutex::const_new(ProbeState { live: false }),
+    slash_commands_probe_state: tokio::sync::Mutex::const_new(ProbeState {
+        live: false,
+        live_key: None,
+    }),
 };
 
 /// Seed the static `CLAUDE_CODE_ADAPTER`'s model catalog from a test.

--- a/packages/service/src/domain/agents/claude_code/model_alias.rs
+++ b/packages/service/src/domain/agents/claude_code/model_alias.rs
@@ -1,0 +1,155 @@
+//! Resolve bare Claude model aliases to the concrete catalog id the active
+//! profile advertises.
+//!
+//! Claude Code accepts both bare aliases (`sonnet`, `opus`, `haiku`) and
+//! concrete model ids. Under the default Anthropic backend the alias *is* the
+//! catalog id and resolves to the latest model. Under Bedrock/Vertex the
+//! catalog instead exposes concrete ids (e.g. `us.anthropic.claude-sonnet-4-6`
+//! labelled "Sonnet"), and the CLI pins the bare alias to a *legacy* version
+//! (`sonnet` → Sonnet 4.5). The interactive CLI picker sends the concrete id;
+//! Cadencr historically stored the bare alias, so Bedrock sessions silently ran
+//! the legacy model.
+//!
+//! Mapping a stored alias to the same concrete id the picker would use makes
+//! sessions match the CLI without relying on `ANTHROPIC_DEFAULT_*` overrides.
+
+use crate::domain::agents::runtime::ModelCatalogEntry;
+
+/// Translate a requested model id against the active profile's catalog.
+///
+/// - Ids already present in the catalog (concrete ids, or aliases the backend
+///   honours like `haiku`/`default` under Bedrock) are returned unchanged.
+/// - A bare family alias (`sonnet`/`opus`/`haiku`, optionally with the `[1m]`
+///   suffix) that is *not* a catalog id is mapped to the catalog entry whose
+///   label is the canonical family name ("Sonnet", "Opus", "Haiku", or
+///   "<Family> (1M context)").
+/// - Anything else (custom gateway ids, unknown values) is returned unchanged
+///   so the CLI can resolve it.
+pub(super) fn resolve_model_alias(model: &str, catalog: &[ModelCatalogEntry]) -> String {
+    // The alias is already something the backend's catalog exposes verbatim
+    // (a concrete id, or an alias it honours) — nothing to rewrite.
+    if catalog.iter().any(|entry| entry.id == model) {
+        return model.to_string();
+    }
+
+    let (base, wants_1m) = match model.strip_suffix("[1m]") {
+        Some(base) => (base, true),
+        None => (model, false),
+    };
+    let family = match base {
+        "sonnet" => "Sonnet",
+        "opus" => "Opus",
+        "haiku" => "Haiku",
+        // Not a family alias (e.g. `default`, a concrete id, or a custom model):
+        // leave it for the CLI to resolve.
+        _ => return model.to_string(),
+    };
+    let target_label = if wants_1m {
+        format!("{family} (1M context)")
+    } else {
+        family.to_string()
+    };
+
+    catalog
+        .iter()
+        .find(|entry| entry.label.eq_ignore_ascii_case(&target_label))
+        .map(|entry| entry.id.clone())
+        .unwrap_or_else(|| model.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_model_alias;
+    use crate::domain::agents::runtime::ModelCatalogEntry;
+
+    /// Catalog shape the CLI returns under a Bedrock profile: concrete ids with
+    /// canonical family labels, plus legacy rows and the `haiku`/`default`
+    /// aliases it still exposes verbatim.
+    fn bedrock_catalog() -> Vec<ModelCatalogEntry> {
+        vec![
+            ModelCatalogEntry::alias("default", "Default"),
+            ModelCatalogEntry::alias("us.anthropic.claude-sonnet-4-6", "Sonnet"),
+            ModelCatalogEntry::alias("us.anthropic.claude-sonnet-4-6[1m]", "Sonnet (1M context)"),
+            ModelCatalogEntry::alias("us.anthropic.claude-opus-4-8", "Opus"),
+            ModelCatalogEntry::alias("us.anthropic.claude-opus-4-8[1m]", "Opus (1M context)"),
+            ModelCatalogEntry::alias("us.anthropic.claude-opus-4-7", "Opus 4.7"),
+            ModelCatalogEntry::alias("haiku", "Haiku"),
+        ]
+    }
+
+    #[test]
+    fn maps_bare_sonnet_to_concrete_bedrock_id() {
+        assert_eq!(
+            resolve_model_alias("sonnet", &bedrock_catalog()),
+            "us.anthropic.claude-sonnet-4-6"
+        );
+    }
+
+    #[test]
+    fn maps_sonnet_1m_alias_to_concrete_1m_id() {
+        assert_eq!(
+            resolve_model_alias("sonnet[1m]", &bedrock_catalog()),
+            "us.anthropic.claude-sonnet-4-6[1m]"
+        );
+    }
+
+    #[test]
+    fn maps_bare_opus_to_primary_not_legacy_row() {
+        // "Opus" must win over "Opus 4.7"/"Opus 4.1" legacy rows.
+        assert_eq!(
+            resolve_model_alias("opus", &bedrock_catalog()),
+            "us.anthropic.claude-opus-4-8"
+        );
+    }
+
+    #[test]
+    fn keeps_haiku_when_catalog_exposes_it_as_an_id() {
+        // Bedrock still ships `haiku` as a real catalog id → no rewrite.
+        assert_eq!(resolve_model_alias("haiku", &bedrock_catalog()), "haiku");
+    }
+
+    #[test]
+    fn passes_concrete_id_through_unchanged() {
+        assert_eq!(
+            resolve_model_alias("us.anthropic.claude-opus-4-7", &bedrock_catalog()),
+            "us.anthropic.claude-opus-4-7"
+        );
+    }
+
+    #[test]
+    fn keeps_default_entry_unchanged() {
+        assert_eq!(
+            resolve_model_alias("default", &bedrock_catalog()),
+            "default"
+        );
+    }
+
+    #[test]
+    fn keeps_alias_when_backend_exposes_aliases_directly() {
+        // Default Anthropic catalog: the alias *is* the id, so this is a no-op.
+        let catalog = vec![
+            ModelCatalogEntry::alias("default", "Default (recommended)"),
+            ModelCatalogEntry::alias("sonnet", "Sonnet"),
+            ModelCatalogEntry::alias("haiku", "Haiku"),
+        ];
+        assert_eq!(resolve_model_alias("sonnet", &catalog), "sonnet");
+    }
+
+    #[test]
+    fn keeps_unknown_or_custom_model_unchanged() {
+        assert_eq!(
+            resolve_model_alias("my-gateway/custom-model", &bedrock_catalog()),
+            "my-gateway/custom-model"
+        );
+    }
+
+    #[test]
+    fn keeps_alias_when_no_matching_family_label_present() {
+        // Catalog with no "Sonnet" label can't be mapped → leave for the CLI.
+        let catalog = vec![ModelCatalogEntry::alias(
+            "us.anthropic.claude-opus-4-8",
+            "Opus",
+        )];
+        assert_eq!(resolve_model_alias("sonnet", &catalog), "sonnet");
+    }
+}

--- a/packages/service/src/domain/agents/claude_code/model_alias.rs
+++ b/packages/service/src/domain/agents/claude_code/model_alias.rs
@@ -32,9 +32,10 @@ pub(super) fn resolve_model_alias(model: &str, catalog: &[ModelCatalogEntry]) ->
         return model.to_string();
     }
 
-    let (base, wants_1m) = match model.strip_suffix("[1m]") {
+    let normalized_model = model.to_ascii_lowercase();
+    let (base, wants_1m) = match normalized_model.strip_suffix("[1m]") {
         Some(base) => (base, true),
-        None => (model, false),
+        None => (normalized_model.as_str(), false),
     };
     let family = match base {
         "sonnet" => "Sonnet",
@@ -99,6 +100,18 @@ mod tests {
         assert_eq!(
             resolve_model_alias("opus", &bedrock_catalog()),
             "us.anthropic.claude-opus-4-8"
+        );
+    }
+
+    #[test]
+    fn maps_family_alias_case_insensitively() {
+        assert_eq!(
+            resolve_model_alias("Sonnet", &bedrock_catalog()),
+            "us.anthropic.claude-sonnet-4-6"
+        );
+        assert_eq!(
+            resolve_model_alias("SONNET[1M]", &bedrock_catalog()),
+            "us.anthropic.claude-sonnet-4-6[1m]"
         );
     }
 

--- a/packages/service/src/domain/agents/providers/mod.rs
+++ b/packages/service/src/domain/agents/providers/mod.rs
@@ -77,7 +77,9 @@ pub async fn provider_catalog_live_for_cwd(
     cwd: Option<&Path>,
 ) -> AgentCatalogResponse {
     let providers = futures::future::join_all(ADAPTERS.iter().map(|(_, adapter)| async move {
-        let mut entry = adapter.catalog_entry_live_for_cwd(cwd).await;
+        let mut entry = adapter
+            .catalog_entry_live_for_settings(read_pool, cwd)
+            .await;
         let extra = adapter.extra_models(read_pool).await;
         if !extra.is_empty() {
             entry.models = merge_extra_models(entry.models, extra);

--- a/packages/service/src/domain/agents/providers/mod.rs
+++ b/packages/service/src/domain/agents/providers/mod.rs
@@ -94,9 +94,9 @@ pub async fn provider_catalog_live_for_cwd(
     }
 }
 
-pub async fn provider_default_model(provider_id: &str) -> Option<String> {
+pub async fn provider_default_model(read_pool: &SqlitePool, provider_id: &str) -> Option<String> {
     if let Some(adapter) = runtime_adapter(provider_id) {
-        return adapter.default_model_id().await;
+        return adapter.default_model_id_for_settings(read_pool).await;
     }
 
     None

--- a/packages/service/src/domain/workspace/repository.rs
+++ b/packages/service/src/domain/workspace/repository.rs
@@ -72,7 +72,7 @@ pub async fn get_model_settings(pool: &SqlitePool) -> Result<ModelSettings, AppE
 
     for (agent_type, provider_id) in provider_by_agent {
         if !defaults_by_provider.contains_key(provider_id) {
-            let default_model = provider_default_model(provider_id)
+            let default_model = provider_default_model(pool, provider_id)
                 .await
                 .unwrap_or_else(|| "opus".to_string());
             defaults_by_provider.insert(provider_id.to_string(), default_model);

--- a/packages/service/src/domain/ws_session/auto_name/mod.rs
+++ b/packages/service/src/domain/ws_session/auto_name/mod.rs
@@ -155,7 +155,7 @@ async fn run_auto_name(
     let provider_id = provider_settings.auto_name;
     let model_id = match stored_model {
         Some(v) if !v.is_empty() => v,
-        _ => crate::domain::agents::providers::provider_default_model(&provider_id)
+        _ => crate::domain::agents::providers::provider_default_model(pool, &provider_id)
             .await
             .unwrap_or_default(),
     };

--- a/packages/service/src/shared/migrate/checksum_repair.rs
+++ b/packages/service/src/shared/migrate/checksum_repair.rs
@@ -209,8 +209,7 @@ fn assert_columns_absent(
 }
 
 fn placeholders(count: usize) -> String {
-    std::iter::repeat("?")
-        .take(count)
+    std::iter::repeat_n("?", count)
         .collect::<Vec<_>>()
         .join(", ")
 }


### PR DESCRIPTION
## Summary

Fixes Claude Code model handling so Cadencr sessions match the `claude` CLI on **Amazon Bedrock, Google Vertex, and Anthropic** subscriptions. Closes #37.

Symptoms (Bedrock): the model reported the wrong version, or said it didn't know its own model name — even though the API response (`message.model`) was correct, and a plain `claude -p --model=us.anthropic.claude-sonnet-4-6` answered correctly.

Investigation found **three independent root causes**, fixed across three commits:

### 1. Catalog probe ignored the active profile env
`load_models` probed the CLI without the active profile's env, so the model dropdown/default were resolved against the wrong backend. The probe is now env-aware (and the env-keyed cache no longer thrashes between the env-aware and env-blind paths).

### 2. The SDK dropped the entire Claude Code system prompt (the CLI-vs-Cadencr gap)
The Rust SDK sent the `initialize` control request with `"systemPrompt": null` whenever no custom prompt was set. That makes the CLI **drop its default Claude Code system prompt** — the `# Environment` block (model identity, cwd, git) *and* all the Claude Code agent instructions — so SDK-driven sessions ran with an empty system prompt and couldn't report their own model. We now **omit the key entirely** when unset, so the CLI uses its full default preset (matching a bare `claude -p` and the metadata probe).

This was the primary, reproducible gap: with identical flags, the only difference was the `initialize` line — `systemPrompt: null` → model doesn't know itself; key omitted → it does.

### 3. Bare aliases pin to legacy model versions on Bedrock/Vertex
Under Bedrock the CLI pins the bare alias `sonnet` to a **legacy** version (Sonnet 4.5), while the catalog/picker expose the concrete id `us.anthropic.claude-sonnet-4-6` (4.6). Cadencr stored/sent the bare alias, so sessions silently ran the wrong version. We now resolve a stored alias to the active profile catalog's concrete id at spawn time (`resolve_model_alias`), and mirror that on the frontend so the picker highlights the right row. The alias stays the **persisted** token (model ids aren't portable across backends; Anthropic only exposes aliases) and is resolved **at the boundary**.

## Why this works on all three backends

- **Anthropic**: the catalog id *is* the alias, so resolution is a no-op; the system-prompt fix restores model identity.
- **Bedrock**: alias → concrete id (e.g. `us.anthropic.claude-sonnet-4-6`) with no need for `ANTHROPIC_DEFAULT_*` overrides.
- **Vertex**: covered by the same catalog-driven mechanism — a Vertex profile's `env_json` already flows to both the probe and the spawn.

## Testing

- SDK: new `initialize_omits_system_prompt_when_unset` / `initialize_includes_system_prompt_when_set` tests; full SDK lib suite green (54 passed).
- Backend: `model_alias` resolution (9 cases across backends) + catalog cache-key reuse; `agents::` suite green (588 passed).
- Frontend: `resolveModelAlias` unit tests (7 cases mirroring the Rust ones); `ts-check` + oxlint clean.
- Reproduced end-to-end against the real `claude` binary on Bedrock: stored `sonnet` now spawns `us.anthropic.claude-sonnet-4-6` and the model reports **Sonnet 4.6**.

## Notes

- The `ANTHROPIC_DEFAULT_*` env vars in a Bedrock profile are no longer required for correctness (they were a workaround that remapped the alias); harmless if left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model alias resolution: friendly Claude family names (sonnet, opus, haiku) map to concrete model IDs across UI and runtime.
  * Environment-scoped model discovery and caching to reflect model availability per env.
  * Model picker enhanced to resolve aliases for selection and display.

* **Bug Fixes**
  * Initialization request omits system prompt when unset (no null sent).
  * Default-model resolution now respects profile/settings when determining defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->