### PR TITLE
feat(desktop): attach CSV and text files in the agent composer

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -87,6 +87,7 @@
     "lexical": "^0.42.0",
     "lowlight": "^3.3.0",
     "lucide-react": "^0.563.0",
+    "pdfjs-dist": "^5.7.284",
     "qrcode.react": "^4.2.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.4",

--- a/packages/desktop/src/components/AgentPromptBar.test.tsx
+++ b/packages/desktop/src/components/AgentPromptBar.test.tsx
@@ -194,7 +194,7 @@ describe("AgentPromptBar", () => {
     );
     const textbox = screen.getByRole("textbox");
     screen.getByTestId("outside").focus();
-    fireEvent.click(screen.getByLabelText("Attach images"));
+    fireEvent.click(screen.getByLabelText("Attach files"));
     expect(document.activeElement).not.toBe(textbox);
   });
 

--- a/packages/desktop/src/components/ImageAttachmentButton.test.tsx
+++ b/packages/desktop/src/components/ImageAttachmentButton.test.tsx
@@ -5,7 +5,7 @@ import { ImageAttachmentButton } from "./ImageAttachmentButton";
 describe("ImageAttachmentButton", () => {
   it("renders a button with paperclip icon", () => {
     render(<ImageAttachmentButton onFilesSelected={vi.fn()} />);
-    expect(screen.getByRole("button", { name: /attach images/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /attach files/i })).toBeInTheDocument();
   });
 
   it("is disabled when disabled prop is true", () => {
@@ -28,12 +28,13 @@ describe("ImageAttachmentButton", () => {
     expect(onFilesSelected).toHaveBeenCalled();
   });
 
-  it("renders hidden file input with image accept types", () => {
+  it("renders hidden file input accepting images and text files", () => {
     const { container } = render(<ImageAttachmentButton onFilesSelected={vi.fn()} />);
     const input = container.querySelector("input[type='file']");
     expect(input).toBeInTheDocument();
     expect(input).toHaveClass("hidden");
     expect(input).toHaveAttribute("accept", expect.stringContaining("image/"));
+    expect(input).toHaveAttribute("accept", expect.stringContaining(".csv"));
     expect(input).toHaveAttribute("multiple");
   });
 });

--- a/packages/desktop/src/components/ImageAttachmentButton.tsx
+++ b/packages/desktop/src/components/ImageAttachmentButton.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
-import { ImageIcon } from "lucide-react";
+import { Paperclip } from "lucide-react";
+import { ATTACHMENT_ACCEPT } from "@/lib/prompt-attachments";
 
 interface ImageAttachmentButtonProps {
   onFilesSelected: (files: FileList | File[]) => void;
@@ -26,7 +27,7 @@ export function ImageAttachmentButton({ onFilesSelected, disabled }: ImageAttach
       <input
         ref={inputRef}
         type="file"
-        accept="image/png,image/jpeg,image/gif,image/webp"
+        accept={ATTACHMENT_ACCEPT}
         multiple
         className="hidden"
         onChange={handleChange}
@@ -35,10 +36,10 @@ export function ImageAttachmentButton({ onFilesSelected, disabled }: ImageAttach
         type="button"
         onClick={handleClick}
         disabled={disabled}
-        aria-label="Attach images"
+        aria-label="Attach files"
         className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
       >
-        <ImageIcon className="size-4" />
+        <Paperclip className="size-4" />
       </button>
     </>
   );

--- a/packages/desktop/src/components/ImageAttachmentPreview.test.tsx
+++ b/packages/desktop/src/components/ImageAttachmentPreview.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test-utils";
 import { ImageAttachmentPreview } from "./ImageAttachmentPreview";
-import type { ImageAttachment } from "@/hooks/useImageAttachments";
+import type { ImageAttachment, TextAttachment } from "@/hooks/useImageAttachments";
 
 function makeAttachment(overrides: Partial<ImageAttachment> = {}): ImageAttachment {
   return {
@@ -10,6 +10,16 @@ function makeAttachment(overrides: Partial<ImageAttachment> = {}): ImageAttachme
     previewUrl: "data:image/png;base64,abc123",
     base64: "abc123",
     mimeType: "image/png",
+    ...overrides,
+  };
+}
+
+function makeTextAttachment(overrides: Partial<TextAttachment> = {}): TextAttachment {
+  return {
+    id: "txt-1",
+    fileName: "data.csv",
+    text: "a,b\n1,2",
+    sizeBytes: 7,
     ...overrides,
   };
 }
@@ -27,6 +37,13 @@ describe("ImageAttachmentPreview", () => {
     ];
     render(<ImageAttachmentPreview attachments={attachments} onRemove={vi.fn()} />);
     expect(screen.getAllByRole("img")).toHaveLength(2);
+  });
+
+  it("renders a file chip (not an image) for text attachments", () => {
+    render(<ImageAttachmentPreview attachments={[makeTextAttachment()]} onRemove={vi.fn()} />);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.getByText("data.csv")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /remove data\.csv/i })).toBeInTheDocument();
   });
 
   it("renders remove button for each attachment", () => {

--- a/packages/desktop/src/components/ImageAttachmentPreview.tsx
+++ b/packages/desktop/src/components/ImageAttachmentPreview.tsx
@@ -1,11 +1,24 @@
-import { X } from "lucide-react";
+import { FileText, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { ImageAttachment } from "@/hooks/useImageAttachments";
+import { isImageAttachment, type PromptAttachment } from "@/lib/prompt-attachments";
 
 interface ImageAttachmentPreviewProps {
-  attachments: ImageAttachment[];
+  attachments: PromptAttachment[];
   onRemove: (id: string) => void;
   className?: string;
+}
+
+function RemoveButton({ fileName, onRemove }: { fileName: string; onRemove: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onRemove}
+      className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+      aria-label={`Remove ${fileName}`}
+    >
+      <X className="w-2.5 h-2.5" />
+    </button>
+  );
 }
 
 export function ImageAttachmentPreview({
@@ -19,19 +32,22 @@ export function ImageAttachmentPreview({
     <div className={cn("flex flex-wrap gap-2 p-2", className)}>
       {attachments.map((attachment) => (
         <div key={attachment.id} className="relative group">
-          <img
-            src={attachment.previewUrl}
-            alt={attachment.fileName}
-            className="w-12 h-12 rounded object-cover border border-border"
-          />
-          <button
-            type="button"
-            onClick={() => onRemove(attachment.id)}
-            className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-            aria-label={`Remove ${attachment.fileName}`}
-          >
-            <X className="w-2.5 h-2.5" />
-          </button>
+          {isImageAttachment(attachment) ? (
+            <img
+              src={attachment.previewUrl}
+              alt={attachment.fileName}
+              className="w-12 h-12 rounded object-cover border border-border"
+            />
+          ) : (
+            <div
+              className="flex h-12 max-w-[12rem] items-center gap-2 rounded border border-border bg-muted/40 px-2.5"
+              title={attachment.fileName}
+            >
+              <FileText className="size-4 shrink-0 text-muted-foreground" />
+              <span className="truncate text-xs text-foreground">{attachment.fileName}</span>
+            </div>
+          )}
+          <RemoveButton fileName={attachment.fileName} onRemove={() => onRemove(attachment.id)} />
         </div>
       ))}
     </div>

--- a/packages/desktop/src/components/agent-prompt-send.ts
+++ b/packages/desktop/src/components/agent-prompt-send.ts
@@ -20,7 +20,12 @@
  */
 import { useCallback, useMemo, useState } from "react";
 import type { RefObject } from "react";
-import type { ImageAttachment } from "@/hooks/useImageAttachments";
+import {
+  formatTextAttachmentsForPrompt,
+  isImageAttachment,
+  isTextAttachment,
+  type PromptAttachment,
+} from "@/lib/prompt-attachments";
 import type { PromptEditorHandle } from "./prompt-editor/PromptEditor";
 
 export type SendFn = (
@@ -32,10 +37,10 @@ export interface RunSendDeps {
   editorRef: RefObject<PromptEditorHandle | null>;
   setText: (text: string) => void;
   clearAttachments: (options?: { revokeObjectUrls?: boolean }) => void;
-  restoreAttachments: (attachments: ImageAttachment[]) => void;
+  restoreAttachments: (attachments: PromptAttachment[]) => void;
   saveDraft: (text: string | null) => void;
   addHistoryEntry: (text: string) => void;
-  getAttachments: () => ImageAttachment[];
+  getAttachments: () => PromptAttachment[];
 }
 
 export interface AgentPromptSendApi {
@@ -64,10 +69,15 @@ export function useAgentPromptSend(deps: RunSendDeps): AgentPromptSendApi {
   const runSend = useCallback(
     async (send: SendFn, trimmed: string): Promise<void> => {
       const attachments = getAttachments();
+      // Images travel as base64 blocks; text files are inlined into the
+      // prompt text so every provider sees them as plain text.
+      const imageAttachments = attachments.filter(isImageAttachment);
+      const textAttachments = attachments.filter(isTextAttachment);
       const images =
-        attachments.length > 0
-          ? attachments.map((a) => ({ base64: a.base64, mimeType: a.mimeType }))
+        imageAttachments.length > 0
+          ? imageAttachments.map((a) => ({ base64: a.base64, mimeType: a.mimeType }))
           : undefined;
+      const sendText = formatTextAttachmentsForPrompt(trimmed, textAttachments);
       // Optimistically clear the visible textarea so the user sees their
       // submission "in flight". On failure we restore it below.
       setText("");
@@ -75,9 +85,9 @@ export function useAgentPromptSend(deps: RunSendDeps): AgentPromptSendApi {
       clearAttachments({ revokeObjectUrls: false });
       setSending(true);
       try {
-        await send(trimmed, images);
+        await send(sendText, images);
         // Success: drop the persisted draft, record history, refocus.
-        attachments.forEach((attachment) => URL.revokeObjectURL(attachment.previewUrl));
+        imageAttachments.forEach((attachment) => URL.revokeObjectURL(attachment.previewUrl));
         addHistoryEntry(trimmed);
         saveDraft(null);
         requestAnimationFrame(() => editorRef.current?.focus());

--- a/packages/desktop/src/components/prompt-editor/plugins/ImagePastePlugin.tsx
+++ b/packages/desktop/src/components/prompt-editor/plugins/ImagePastePlugin.tsx
@@ -1,25 +1,30 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { COMMAND_PRIORITY_NORMAL, PASTE_COMMAND } from "lexical";
-import { ALLOWED_IMAGE_TYPES } from "@/hooks/useImageAttachments";
+import { classifyAttachment } from "@/lib/prompt-attachments";
 
 interface ImagePastePluginProps {
+  /** Receives attachable files (images or text) pasted as file items. */
   onPasteImages?: (files: File[]) => void;
 }
 
-function extractImageFiles(clipboardData: DataTransfer | null): File[] {
+function extractAttachableFiles(clipboardData: DataTransfer | null): File[] {
   if (!clipboardData) return [];
   const files: File[] = [];
   for (const item of clipboardData.items) {
     if (item.kind !== "file") continue;
-    if (!ALLOWED_IMAGE_TYPES.includes(item.type)) continue;
     const file = item.getAsFile();
-    if (file) files.push(file);
+    if (!file) continue;
+    if (classifyAttachment(file.name, file.type).kind === "unsupported") continue;
+    files.push(file);
   }
   return files;
 }
 
-/** Forwards image files from clipboard pastes to `onPasteImages`; text-only pastes fall through. */
+/**
+ * Forwards attachable files (images, CSV/text) from clipboard pastes to
+ * `onPasteImages`; plain-text pastes (no file items) fall through to the editor.
+ */
 export function ImagePastePlugin({ onPasteImages }: ImagePastePluginProps) {
   const [editor] = useLexicalComposerContext();
 
@@ -29,10 +34,10 @@ export function ImagePastePlugin({ onPasteImages }: ImagePastePluginProps) {
       PASTE_COMMAND,
       (event) => {
         if (!event || !("clipboardData" in event)) return false;
-        const images = extractImageFiles(event.clipboardData);
-        if (images.length === 0) return false;
+        const attachable = extractAttachableFiles(event.clipboardData);
+        if (attachable.length === 0) return false;
         event.preventDefault();
-        onPasteImages(images);
+        onPasteImages(attachable);
         return true;
       },
       COMMAND_PRIORITY_NORMAL,

--- a/packages/desktop/src/hooks/useImageAttachments.test.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.test.ts
@@ -8,6 +8,12 @@ import type { CadencrDesktopBridge, FileDropPayload } from "@/lib/desktop-bridge
 import { isImageAttachment, isTextAttachment, useImageAttachments } from "./useImageAttachments";
 import { toast } from "sonner";
 
+// PDF parsing is exercised in pdf-text.test.ts; here we just assert the
+// hook turns a PDF into a text attachment, so stub the extractor.
+vi.mock("@/lib/pdf-text", () => ({
+  extractPdfText: vi.fn(async () => "PDF TEXT FROM MOCK"),
+}));
+
 const dropSubscribers: Array<(payload: FileDropPayload) => void> = [];
 const mockOnFileDrop = vi.fn((cb: (payload: FileDropPayload) => void) => {
   dropSubscribers.push(cb);
@@ -134,9 +140,32 @@ describe("useImageAttachments", () => {
     }
   });
 
+  it("extracts a PDF into a text attachment", async () => {
+    const { result } = renderHook(() => useImageAttachments());
+    const file = createMockFile("report.pdf", "application/pdf");
+    // jsdom's File may not implement arrayBuffer(); provide a stub since
+    // the extractor itself is mocked and ignores the bytes.
+    Object.defineProperty(file, "arrayBuffer", { value: async () => new ArrayBuffer(8) });
+
+    act(() => {
+      result.current.addFiles([file]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.attachments).toHaveLength(1);
+    });
+
+    const att = result.current.attachments[0];
+    expect(isTextAttachment(att)).toBe(true);
+    if (isTextAttachment(att)) {
+      expect(att.fileName).toBe("report.pdf");
+      expect(att.text).toBe("PDF TEXT FROM MOCK");
+    }
+  });
+
   it("rejects unsupported file types", async () => {
     const { result } = renderHook(() => useImageAttachments());
-    const file = createMockFile("doc.pdf", "application/pdf");
+    const file = createMockFile("archive.zip", "application/zip");
 
     act(() => {
       result.current.addFiles([file]);

--- a/packages/desktop/src/hooks/useImageAttachments.test.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.test.ts
@@ -5,7 +5,7 @@ import {
   setDesktopBridgeOverrideForTests,
 } from "@/lib/desktop-bridge";
 import type { CadencrDesktopBridge, FileDropPayload } from "@/lib/desktop-bridge";
-import { useImageAttachments } from "./useImageAttachments";
+import { isImageAttachment, isTextAttachment, useImageAttachments } from "./useImageAttachments";
 import { toast } from "sonner";
 
 const dropSubscribers: Array<(payload: FileDropPayload) => void> = [];
@@ -69,12 +69,16 @@ describe("useImageAttachments", () => {
     vi.stubGlobal(
       "FileReader",
       class {
+        private cb: ((e: { target: { result: string } }) => void) | null = null;
         addEventListener(event: string, cb: (e: { target: { result: string } }) => void) {
-          if (event === "load") {
-            setTimeout(() => cb({ target: { result: "data:image/png;base64,abc123" } }), 0);
-          }
+          if (event === "load") this.cb = cb;
         }
-        readAsDataURL() {}
+        readAsDataURL() {
+          setTimeout(() => this.cb?.({ target: { result: "data:image/png;base64,abc123" } }), 0);
+        }
+        readAsText() {
+          setTimeout(() => this.cb?.({ target: { result: "col1,col2\n1,2" } }), 0);
+        }
       },
     );
 
@@ -102,8 +106,32 @@ describe("useImageAttachments", () => {
       expect(result.current.attachments).toHaveLength(1);
     });
 
-    expect(result.current.attachments[0].mimeType).toBe("image/png");
-    expect(result.current.attachments[0].base64).toBe("abc123");
+    const att = result.current.attachments[0];
+    expect(isImageAttachment(att)).toBe(true);
+    if (isImageAttachment(att)) {
+      expect(att.mimeType).toBe("image/png");
+      expect(att.base64).toBe("abc123");
+    }
+  });
+
+  it("adds a text file as a text attachment", async () => {
+    const { result } = renderHook(() => useImageAttachments());
+    const file = createMockFile("data.csv", "text/csv");
+
+    act(() => {
+      result.current.addFiles([file]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.attachments).toHaveLength(1);
+    });
+
+    const att = result.current.attachments[0];
+    expect(isTextAttachment(att)).toBe(true);
+    if (isTextAttachment(att)) {
+      expect(att.fileName).toBe("data.csv");
+      expect(att.text).toBe("col1,col2\n1,2");
+    }
   });
 
   it("rejects unsupported file types", async () => {
@@ -213,8 +241,8 @@ describe("useImageAttachments", () => {
     // Each subscriber still calls toast.error, but it must share a stable id so
     // sonner collapses them to a single visible toast — assert the id is set.
     expect(toast.error).toHaveBeenCalledWith(
-      "Drop the image on an agent to attach it.",
-      expect.objectContaining({ id: "image-drop-missing-target" }),
+      "Drop the file on an agent to attach it.",
+      expect.objectContaining({ id: "attachment-drop-missing-target" }),
     );
   });
 

--- a/packages/desktop/src/hooks/useImageAttachments.test.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.test.ts
@@ -220,6 +220,27 @@ describe("useImageAttachments", () => {
     expect(mockOnFileDrop).toHaveBeenCalled();
   });
 
+  it("rejects an oversized dropped text file", async () => {
+    // ~1.5 MB once decoded — over the 1 MB text cap.
+    readFileBase64.mockResolvedValue("A".repeat(2 * 1024 * 1024));
+    const { result } = renderHook(() => useImageAttachments("ws:first"));
+
+    act(() => {
+      dropSubscribers[0]({
+        type: "drop",
+        files: [{ handle: "h-1", name: "big.csv" }],
+        targetPromptId: "ws:first",
+      });
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.attachments).toHaveLength(0);
+    expect(toast.error).toHaveBeenCalledWith(
+      "big.csv is too large to attach",
+      expect.objectContaining({ description: expect.stringContaining("1 MB") }),
+    );
+  });
+
   it("routes a desktop drop to only the matching prompt id", async () => {
     const { result: first } = renderHook(() => useImageAttachments("ws:first"));
     const { result: second } = renderHook(() => useImageAttachments("ws:second"));

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -145,7 +145,7 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
             sizeBytes: file.size,
           });
         });
-        reader.readAsText(file);
+        reader.readAsText(file, "utf-8");
       });
     },
     [addAttachment, attachPdf],
@@ -186,12 +186,21 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
             }
             await attachPdf(file.name, async () => bytes);
           } else {
-            const text = decodeBase64Utf8(base64);
+            // Enforce the same limit as browser-picked text files. Estimate
+            // the decoded size from the base64 length so a huge dropped file
+            // is rejected before it's decoded into a string.
+            const sizeBytes = Math.floor((base64.length * 3) / 4);
+            if (sizeBytes > MAX_TEXT_BYTES) {
+              toast.error(`${file.name} is too large to attach`, {
+                description: "Text attachments must be under 1 MB.",
+              });
+              continue;
+            }
             addAttachment({
               id: crypto.randomUUID(),
               fileName: file.name,
-              text,
-              sizeBytes: text.length,
+              text: decodeBase64Utf8(base64),
+              sizeBytes,
             });
           }
         } catch (e) {
@@ -222,9 +231,13 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
         // collapses concurrent calls from every mounted subscriber into a
         // single visible toast.
         if (!event.targetPromptId) {
-          toast.error("Drop the file on an agent to attach it.", {
-            id: "attachment-drop-missing-target",
-          });
+          const many = event.files.length > 1;
+          toast.error(
+            many
+              ? "Drop the files on an agent to attach them."
+              : "Drop the file on an agent to attach it.",
+            { id: "attachment-drop-missing-target" },
+          );
           return;
         }
         if (promptId && event.targetPromptId !== promptId) return;

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -1,14 +1,22 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { toast } from "sonner";
 import { desktopBridge, type FileDropItem } from "@/lib/desktop-bridge";
+import {
+  ATTACHMENT_SUPPORT_HINT,
+  MAX_ATTACHMENT_FILES,
+  MAX_IMAGE_BYTES,
+  MAX_TEXT_BYTES,
+  classifyAttachment,
+  decodeBase64Utf8,
+  isImageAttachment,
+  type PromptAttachment,
+} from "@/lib/prompt-attachments";
 
-export interface ImageAttachment {
-  id: string;
-  fileName: string;
-  base64: string;
-  mimeType: string;
-  previewUrl: string;
-}
+// Re-exported so existing importers (`@/hooks/useImageAttachments`) keep
+// working; the canonical home for attachment types/guards is
+// `@/lib/prompt-attachments`.
+export type { ImageAttachment, TextAttachment, PromptAttachment } from "@/lib/prompt-attachments";
+export { isImageAttachment, isTextAttachment } from "@/lib/prompt-attachments";
 
 export interface ImageAttachmentDragHandlers {
   onDragOver: (event: React.DragEvent) => void;
@@ -16,11 +24,11 @@ export interface ImageAttachmentDragHandlers {
 }
 
 export interface UseImageAttachmentsResult {
-  attachments: ImageAttachment[];
+  attachments: PromptAttachment[];
   addFiles: (files: FileList | File[]) => void;
   removeAttachment: (id: string) => void;
   clearAttachments: (options?: { revokeObjectUrls?: boolean }) => void;
-  restoreAttachments: (next: ImageAttachment[]) => void;
+  restoreAttachments: (next: PromptAttachment[]) => void;
   dragHandlers: ImageAttachmentDragHandlers;
   /**
    * Always `false`. The visual drag highlight is now owned by the agent
@@ -31,24 +39,8 @@ export interface UseImageAttachmentsResult {
   isDragging: boolean;
 }
 
-export const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
-const EXTENSION_TO_MIME: Record<string, string> = {
-  png: "image/png",
-  jpg: "image/jpeg",
-  jpeg: "image/jpeg",
-  gif: "image/gif",
-  webp: "image/webp",
-};
-const MAX_FILES = 10;
-const MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
-
-function getMimeFromExtension(fileName: string): string | undefined {
-  const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
-  return EXTENSION_TO_MIME[ext];
-}
-
 export function useImageAttachments(promptId?: string): UseImageAttachmentsResult {
-  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const [attachments, setAttachments] = useState<PromptAttachment[]>([]);
   const attachmentsRef = useRef(attachments);
   attachmentsRef.current = attachments;
   // `isDragging` used to be driven from the preload's document-level
@@ -60,9 +52,9 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
   // mocks; new consumers should read drag state from the section.
   const isDragging = false;
 
-  const addAttachment = useCallback((attachment: ImageAttachment) => {
+  const addAttachment = useCallback((attachment: PromptAttachment) => {
     setAttachments((prev) => {
-      if (prev.length >= MAX_FILES) return prev;
+      if (prev.length >= MAX_ATTACHMENT_FILES) return prev;
       return [...prev, attachment];
     });
   }, []);
@@ -70,27 +62,50 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
   const addFiles = useCallback(
     (files: FileList | File[]) => {
       const fileArray = Array.from(files);
-      const remaining = MAX_FILES - attachmentsRef.current.length;
+      const remaining = MAX_ATTACHMENT_FILES - attachmentsRef.current.length;
       if (remaining <= 0) return;
 
       fileArray.slice(0, remaining).forEach((file) => {
-        if (!ALLOWED_IMAGE_TYPES.includes(file.type)) return;
-        if (file.size > MAX_SIZE_BYTES) return;
+        const classification = classifyAttachment(file.name, file.type);
+        if (classification.kind === "unsupported") return;
 
+        if (classification.kind === "image") {
+          if (file.size > MAX_IMAGE_BYTES) return;
+          const reader = new FileReader();
+          reader.addEventListener("load", (e) => {
+            const dataUrl = e.target?.result as string;
+            const base64 = dataUrl.split(",")[1];
+            const previewUrl = URL.createObjectURL(file);
+            addAttachment({
+              id: crypto.randomUUID(),
+              fileName: file.name,
+              base64,
+              mimeType: classification.mimeType,
+              previewUrl,
+            });
+          });
+          reader.readAsDataURL(file);
+          return;
+        }
+
+        // Text file: inline its contents into the prompt at send time.
+        if (file.size > MAX_TEXT_BYTES) {
+          toast.error(`${file.name} is too large to attach`, {
+            description: "Text attachments must be under 1 MB.",
+          });
+          return;
+        }
         const reader = new FileReader();
         reader.addEventListener("load", (e) => {
-          const dataUrl = e.target?.result as string;
-          const base64 = dataUrl.split(",")[1];
-          const previewUrl = URL.createObjectURL(file);
+          const text = (e.target?.result as string) ?? "";
           addAttachment({
             id: crypto.randomUUID(),
             fileName: file.name,
-            base64,
-            mimeType: file.type,
-            previewUrl,
+            text,
+            sizeBytes: file.size,
           });
         });
-        reader.readAsDataURL(file);
+        reader.readAsText(file);
       });
     },
     [addAttachment],
@@ -98,28 +113,38 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
 
   const addDroppedFiles = useCallback(
     async (files: FileDropItem[]) => {
-      const remaining = MAX_FILES - attachmentsRef.current.length;
+      const remaining = MAX_ATTACHMENT_FILES - attachmentsRef.current.length;
       if (remaining <= 0) return;
 
       for (const file of files.slice(0, remaining)) {
-        const mimeType = getMimeFromExtension(file.name);
-        if (!mimeType) {
+        const classification = classifyAttachment(file.name);
+        if (classification.kind === "unsupported") {
           toast.error(`Unsupported file: ${file.name}`, {
-            description: "Only PNG, JPEG, GIF, and WebP images can be attached.",
+            description: ATTACHMENT_SUPPORT_HINT,
           });
           continue;
         }
 
         try {
           const base64 = await desktopBridge.readFileBase64(file.handle);
-          const previewUrl = `data:${mimeType};base64,${base64}`;
-          addAttachment({
-            id: crypto.randomUUID(),
-            fileName: file.name,
-            base64,
-            mimeType,
-            previewUrl,
-          });
+          if (classification.kind === "image") {
+            const previewUrl = `data:${classification.mimeType};base64,${base64}`;
+            addAttachment({
+              id: crypto.randomUUID(),
+              fileName: file.name,
+              base64,
+              mimeType: classification.mimeType,
+              previewUrl,
+            });
+          } else {
+            const text = decodeBase64Utf8(base64);
+            addAttachment({
+              id: crypto.randomUUID(),
+              fileName: file.name,
+              text,
+              sizeBytes: text.length,
+            });
+          }
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e);
           toast.error(`Couldn't attach ${file.name}`, { description: message });
@@ -148,8 +173,8 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
         // collapses concurrent calls from every mounted subscriber into a
         // single visible toast.
         if (!event.targetPromptId) {
-          toast.error("Drop the image on an agent to attach it.", {
-            id: "image-drop-missing-target",
+          toast.error("Drop the file on an agent to attach it.", {
+            id: "attachment-drop-missing-target",
           });
           return;
         }
@@ -169,7 +194,7 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => {
       const target = prev.find((a) => a.id === id);
-      if (target) URL.revokeObjectURL(target.previewUrl);
+      if (target && isImageAttachment(target)) URL.revokeObjectURL(target.previewUrl);
       return prev.filter((a) => a.id !== id);
     });
   }, []);
@@ -177,13 +202,15 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
   const clearAttachments = useCallback((options?: { revokeObjectUrls?: boolean }) => {
     setAttachments((prev) => {
       if (options?.revokeObjectUrls !== false) {
-        prev.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+        prev.forEach((a) => {
+          if (isImageAttachment(a)) URL.revokeObjectURL(a.previewUrl);
+        });
       }
       return [];
     });
   }, []);
 
-  const restoreAttachments = useCallback((next: ImageAttachment[]) => {
+  const restoreAttachments = useCallback((next: PromptAttachment[]) => {
     setAttachments(next);
   }, []);
 

--- a/packages/desktop/src/hooks/useImageAttachments.ts
+++ b/packages/desktop/src/hooks/useImageAttachments.ts
@@ -5,12 +5,15 @@ import {
   ATTACHMENT_SUPPORT_HINT,
   MAX_ATTACHMENT_FILES,
   MAX_IMAGE_BYTES,
+  MAX_PDF_BYTES,
   MAX_TEXT_BYTES,
+  base64ToBytes,
   classifyAttachment,
   decodeBase64Utf8,
   isImageAttachment,
   type PromptAttachment,
 } from "@/lib/prompt-attachments";
+import { extractPdfText } from "@/lib/pdf-text";
 
 // Re-exported so existing importers (`@/hooks/useImageAttachments`) keep
 // working; the canonical home for attachment types/guards is
@@ -59,6 +62,32 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
     });
   }, []);
 
+  // Parse a PDF's text in-app, then attach it like any other text file.
+  // Extraction is async and can be slow, so a loading toast covers the
+  // wait; the attachment chip appearing is the success signal.
+  const attachPdf = useCallback(
+    async (fileName: string, readBytes: () => Promise<ArrayBuffer | Uint8Array>): Promise<void> => {
+      const toastId = `pdf-extract-${fileName}`;
+      toast.loading(`Reading ${fileName}…`, { id: toastId });
+      try {
+        const text = (await extractPdfText(await readBytes())).trim();
+        if (!text) {
+          toast.error(`Couldn't extract text from ${fileName}`, {
+            id: toastId,
+            description: "It may be a scanned or image-only PDF.",
+          });
+          return;
+        }
+        toast.dismiss(toastId);
+        addAttachment({ id: crypto.randomUUID(), fileName, text, sizeBytes: text.length });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        toast.error(`Couldn't read ${fileName}`, { id: toastId, description: message });
+      }
+    },
+    [addAttachment],
+  );
+
   const addFiles = useCallback(
     (files: FileList | File[]) => {
       const fileArray = Array.from(files);
@@ -88,6 +117,17 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
           return;
         }
 
+        if (classification.kind === "pdf") {
+          if (file.size > MAX_PDF_BYTES) {
+            toast.error(`${file.name} is too large to attach`, {
+              description: "PDF attachments must be under 20 MB.",
+            });
+            return;
+          }
+          void attachPdf(file.name, () => file.arrayBuffer());
+          return;
+        }
+
         // Text file: inline its contents into the prompt at send time.
         if (file.size > MAX_TEXT_BYTES) {
           toast.error(`${file.name} is too large to attach`, {
@@ -108,7 +148,7 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
         reader.readAsText(file);
       });
     },
-    [addAttachment],
+    [addAttachment, attachPdf],
   );
 
   const addDroppedFiles = useCallback(
@@ -136,6 +176,15 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
               mimeType: classification.mimeType,
               previewUrl,
             });
+          } else if (classification.kind === "pdf") {
+            const bytes = base64ToBytes(base64);
+            if (bytes.byteLength > MAX_PDF_BYTES) {
+              toast.error(`${file.name} is too large to attach`, {
+                description: "PDF attachments must be under 20 MB.",
+              });
+              continue;
+            }
+            await attachPdf(file.name, async () => bytes);
           } else {
             const text = decodeBase64Utf8(base64);
             addAttachment({
@@ -151,7 +200,7 @@ export function useImageAttachments(promptId?: string): UseImageAttachmentsResul
         }
       }
     },
-    [addAttachment],
+    [addAttachment, attachPdf],
   );
 
   // Stable ref so the effect doesn't re-register on every render

--- a/packages/desktop/src/lib/pdf-text.test.ts
+++ b/packages/desktop/src/lib/pdf-text.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getDocument = vi.fn();
+
+// pdf.js and its worker are heavy and browser-only; mock both so the
+// extraction logic can be tested in jsdom without loading the real lib.
+vi.mock("pdfjs-dist/build/pdf.worker.min.mjs?url", () => ({ default: "blob:worker" }));
+vi.mock("pdfjs-dist", () => ({
+  GlobalWorkerOptions: { workerSrc: "" },
+  getDocument,
+}));
+
+import { extractPdfText } from "./pdf-text";
+
+/** Build a fake PDFDocumentProxy whose pages yield the given text items. */
+function fakeDoc(pages: string[][]) {
+  return {
+    numPages: pages.length,
+    getPage: vi.fn(async (pageNumber: number) => ({
+      getTextContent: vi.fn(async () => ({
+        items: pages[pageNumber - 1].map((str) => ({ str })),
+      })),
+    })),
+    destroy: vi.fn(async () => {}),
+  };
+}
+
+function mockPdf(pages: string[][]): void {
+  getDocument.mockReturnValue({ promise: Promise.resolve(fakeDoc(pages)) });
+}
+
+describe("extractPdfText", () => {
+  beforeEach(() => getDocument.mockReset());
+
+  it("joins page text, with a blank line between pages", async () => {
+    mockPdf([
+      ["Hello", "world"],
+      ["Page", "two"],
+    ]);
+    expect(await extractPdfText(new ArrayBuffer(8))).toBe("Hello world\n\nPage two");
+  });
+
+  it("drops pages that have no text", async () => {
+    mockPdf([["only"], [""]]);
+    expect(await extractPdfText(new ArrayBuffer(8))).toBe("only");
+  });
+
+  it("returns an empty string for a scanned / image-only PDF", async () => {
+    mockPdf([[""], [""]]);
+    expect(await extractPdfText(new ArrayBuffer(8))).toBe("");
+  });
+});

--- a/packages/desktop/src/lib/pdf-text.ts
+++ b/packages/desktop/src/lib/pdf-text.ts
@@ -1,0 +1,53 @@
+/**
+ * Lazy PDF → text extraction for prompt attachments.
+ *
+ * pdf.js is heavy (~1 MB) and only needed when a PDF is actually
+ * attached, so the library and its worker are dynamically imported on
+ * first use — they never land in the initial bundle. Extraction runs in
+ * pdf.js's web worker, off the main thread.
+ */
+
+type PdfjsModule = typeof import("pdfjs-dist");
+
+let pdfjsPromise: Promise<PdfjsModule> | null = null;
+
+async function loadPdfjs(): Promise<PdfjsModule> {
+  if (!pdfjsPromise) {
+    pdfjsPromise = (async () => {
+      const pdfjs = await import("pdfjs-dist");
+      const workerUrl = (await import("pdfjs-dist/build/pdf.worker.min.mjs?url")).default;
+      pdfjs.GlobalWorkerOptions.workerSrc = workerUrl;
+      return pdfjs;
+    })();
+  }
+  return pdfjsPromise;
+}
+
+/**
+ * Extract the visible text of a PDF, one block per page (pages separated
+ * by a blank line). Returns "" for PDFs with no extractable text (e.g.
+ * scanned/image-only documents).
+ */
+export async function extractPdfText(data: ArrayBuffer | Uint8Array): Promise<string> {
+  const pdfjs = await loadPdfjs();
+  const doc = await pdfjs.getDocument({ data }).promise;
+  try {
+    const pages: string[] = [];
+    for (let pageNumber = 1; pageNumber <= doc.numPages; pageNumber++) {
+      const page = await doc.getPage(pageNumber);
+      const content = await page.getTextContent();
+      const pageText = content.items
+        .map((item) => ("str" in item ? item.str : ""))
+        .join(" ")
+        .replace(/[ \t]+/g, " ")
+        .trim();
+      pages.push(pageText);
+    }
+    return pages
+      .filter((page) => page.length > 0)
+      .join("\n\n")
+      .trim();
+  } finally {
+    await doc.destroy();
+  }
+}

--- a/packages/desktop/src/lib/prompt-attachments.test.ts
+++ b/packages/desktop/src/lib/prompt-attachments.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  ATTACHMENT_ACCEPT,
+  classifyAttachment,
+  decodeBase64Utf8,
+  formatTextAttachmentsForPrompt,
+  getExtension,
+} from "./prompt-attachments";
+
+describe("classifyAttachment", () => {
+  it("classifies images by MIME type", () => {
+    expect(classifyAttachment("x", "image/png")).toEqual({ kind: "image", mimeType: "image/png" });
+    expect(classifyAttachment("x", "image/webp")).toEqual({
+      kind: "image",
+      mimeType: "image/webp",
+    });
+  });
+
+  it("classifies images by extension when MIME is missing", () => {
+    expect(classifyAttachment("photo.JPG")).toEqual({ kind: "image", mimeType: "image/jpeg" });
+  });
+
+  it.each([["data.csv"], ["sheet.tsv"], ["notes.MD"], ["config.json"], ["log.txt"]])(
+    "classifies %s as text",
+    (name) => {
+      expect(classifyAttachment(name)).toEqual({ kind: "text" });
+    },
+  );
+
+  it("treats CSV as text regardless of the browser MIME guess", () => {
+    expect(classifyAttachment("data.csv", "application/vnd.ms-excel")).toEqual({ kind: "text" });
+    expect(classifyAttachment("data.csv", "text/csv")).toEqual({ kind: "text" });
+  });
+
+  it("falls back to text for any text/* MIME", () => {
+    expect(classifyAttachment("noext", "text/plain")).toEqual({ kind: "text" });
+  });
+
+  it("rejects unsupported files", () => {
+    expect(classifyAttachment("doc.pdf", "application/pdf")).toEqual({ kind: "unsupported" });
+    expect(classifyAttachment("archive.zip")).toEqual({ kind: "unsupported" });
+  });
+});
+
+describe("getExtension", () => {
+  it("returns the lowercased trailing extension", () => {
+    expect(getExtension("A.CSV")).toBe("csv");
+    expect(getExtension("noext")).toBe("noext");
+  });
+});
+
+describe("ATTACHMENT_ACCEPT", () => {
+  it("includes image MIME types and text extensions", () => {
+    expect(ATTACHMENT_ACCEPT).toContain("image/png");
+    expect(ATTACHMENT_ACCEPT).toContain(".csv");
+    expect(ATTACHMENT_ACCEPT).toContain(".tsv");
+  });
+});
+
+describe("decodeBase64Utf8", () => {
+  it("decodes UTF-8 content", () => {
+    // "a,é\n1,2" encoded as UTF-8 base64.
+    const base64 = btoa(String.fromCharCode(...new TextEncoder().encode("a,é\n1,2")));
+    expect(decodeBase64Utf8(base64)).toBe("a,é\n1,2");
+  });
+});
+
+describe("formatTextAttachmentsForPrompt", () => {
+  it("returns the text unchanged when there are no files", () => {
+    expect(formatTextAttachmentsForPrompt("hello", [])).toBe("hello");
+  });
+
+  it("appends each file as a fenced block labelled with its name", () => {
+    const out = formatTextAttachmentsForPrompt("summarize this", [
+      { fileName: "data.csv", text: "a,b\n1,2" },
+    ]);
+    expect(out).toBe("summarize this\n\nAttached file `data.csv`:\n```csv\na,b\n1,2\n```");
+  });
+
+  it("drops empty typed text and still includes the file", () => {
+    const out = formatTextAttachmentsForPrompt("", [{ fileName: "x.txt", text: "hi" }]);
+    expect(out).toBe("Attached file `x.txt`:\n```txt\nhi\n```");
+  });
+
+  it("grows the fence so backticks in content can't break out", () => {
+    const out = formatTextAttachmentsForPrompt("", [{ fileName: "x.md", text: "```\ncode\n```" }]);
+    expect(out).toContain("````md\n```\ncode\n```\n````");
+  });
+});

--- a/packages/desktop/src/lib/prompt-attachments.test.ts
+++ b/packages/desktop/src/lib/prompt-attachments.test.ts
@@ -36,9 +36,14 @@ describe("classifyAttachment", () => {
     expect(classifyAttachment("noext", "text/plain")).toEqual({ kind: "text" });
   });
 
+  it("classifies PDFs by extension or MIME", () => {
+    expect(classifyAttachment("report.PDF")).toEqual({ kind: "pdf" });
+    expect(classifyAttachment("blob", "application/pdf")).toEqual({ kind: "pdf" });
+  });
+
   it("rejects unsupported files", () => {
-    expect(classifyAttachment("doc.pdf", "application/pdf")).toEqual({ kind: "unsupported" });
     expect(classifyAttachment("archive.zip")).toEqual({ kind: "unsupported" });
+    expect(classifyAttachment("clip.mp4", "video/mp4")).toEqual({ kind: "unsupported" });
   });
 });
 
@@ -50,8 +55,9 @@ describe("getExtension", () => {
 });
 
 describe("ATTACHMENT_ACCEPT", () => {
-  it("includes image MIME types and text extensions", () => {
+  it("includes images, PDF, and text extensions", () => {
     expect(ATTACHMENT_ACCEPT).toContain("image/png");
+    expect(ATTACHMENT_ACCEPT).toContain(".pdf");
     expect(ATTACHMENT_ACCEPT).toContain(".csv");
     expect(ATTACHMENT_ACCEPT).toContain(".tsv");
   });

--- a/packages/desktop/src/lib/prompt-attachments.test.ts
+++ b/packages/desktop/src/lib/prompt-attachments.test.ts
@@ -80,12 +80,17 @@ describe("formatTextAttachmentsForPrompt", () => {
     const out = formatTextAttachmentsForPrompt("summarize this", [
       { fileName: "data.csv", text: "a,b\n1,2" },
     ]);
-    expect(out).toBe("summarize this\n\nAttached file `data.csv`:\n```csv\na,b\n1,2\n```");
+    expect(out).toBe("summarize this\n\nAttached file: data.csv\n```csv\na,b\n1,2\n```");
   });
 
   it("drops empty typed text and still includes the file", () => {
     const out = formatTextAttachmentsForPrompt("", [{ fileName: "x.txt", text: "hi" }]);
-    expect(out).toBe("Attached file `x.txt`:\n```txt\nhi\n```");
+    expect(out).toBe("Attached file: x.txt\n```txt\nhi\n```");
+  });
+
+  it("does not let a backtick in the filename break formatting", () => {
+    const out = formatTextAttachmentsForPrompt("", [{ fileName: "we`ird.csv", text: "a" }]);
+    expect(out).toBe("Attached file: we`ird.csv\n```csv\na\n```");
   });
 
   it("grows the fence so backticks in content can't break out", () => {

--- a/packages/desktop/src/lib/prompt-attachments.ts
+++ b/packages/desktop/src/lib/prompt-attachments.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared classification + formatting helpers for prompt attachments.
+ *
+ * Two kinds of attachment are supported in the agent composer:
+ *   - **image** files travel to the agent as base64 `image` content blocks
+ *     (the existing multimodal path).
+ *   - **text** files (CSV, TSV, JSON, Markdown, …) have their contents
+ *     embedded into the prompt text at send time. This is provider-neutral
+ *     — every agent (Claude Code, Codex, OpenCode) reads plain text — so no
+ *     backend/protocol change is needed to support them.
+ */
+
+const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+const IMAGE_EXTENSION_TO_MIME: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+/**
+ * Text/data file extensions accepted as text attachments. Deliberately
+ * scoped to data, docs, and config formats — source files usually live in
+ * the repo the agent can already read.
+ */
+export const TEXT_ATTACHMENT_EXTENSIONS = [
+  "csv",
+  "tsv",
+  "txt",
+  "text",
+  "log",
+  "md",
+  "markdown",
+  "mdx",
+  "json",
+  "jsonc",
+  "ndjson",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "env",
+  "xml",
+  "html",
+  "css",
+  "sql",
+];
+
+const TEXT_EXTENSIONS: ReadonlySet<string> = new Set(TEXT_ATTACHMENT_EXTENSIONS);
+
+export const MAX_ATTACHMENT_FILES = 10;
+export const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // 20MB
+/** Text files are inlined into the prompt, so keep them prompt-sized. */
+export const MAX_TEXT_BYTES = 1024 * 1024; // 1MB
+
+/** `accept` attribute for the file picker — image MIME types + text extensions. */
+export const ATTACHMENT_ACCEPT = [
+  ...ALLOWED_IMAGE_TYPES,
+  ...TEXT_ATTACHMENT_EXTENSIONS.map((ext) => `.${ext}`),
+].join(",");
+
+/** User-facing hint listing what can be attached. */
+export const ATTACHMENT_SUPPORT_HINT =
+  "Attach images (PNG, JPEG, GIF, WebP) or text files like CSV, TSV, JSON, and Markdown.";
+
+export interface ImageAttachment {
+  id: string;
+  fileName: string;
+  base64: string;
+  mimeType: string;
+  previewUrl: string;
+}
+
+/** A text/data file (CSV, JSON, …) inlined into the prompt at send time. */
+export interface TextAttachment {
+  id: string;
+  fileName: string;
+  text: string;
+  sizeBytes: number;
+}
+
+export type PromptAttachment = ImageAttachment | TextAttachment;
+
+export function isImageAttachment(attachment: PromptAttachment): attachment is ImageAttachment {
+  return "base64" in attachment;
+}
+
+export function isTextAttachment(attachment: PromptAttachment): attachment is TextAttachment {
+  return "text" in attachment;
+}
+
+export type AttachmentClass =
+  | { kind: "image"; mimeType: string }
+  | { kind: "text" }
+  | { kind: "unsupported" };
+
+export function getExtension(fileName: string): string {
+  return fileName.split(".").pop()?.toLowerCase() ?? "";
+}
+
+/**
+ * Decide how a file should be attached, from its name and (optional)
+ * browser-reported MIME type. The extension is authoritative for text
+ * files since browsers report CSV inconsistently (`text/csv`,
+ * `application/vnd.ms-excel`, or empty).
+ */
+export function classifyAttachment(fileName: string, fileType?: string): AttachmentClass {
+  if (fileType && ALLOWED_IMAGE_TYPES.includes(fileType)) {
+    return { kind: "image", mimeType: fileType };
+  }
+  const ext = getExtension(fileName);
+  const imageMime = IMAGE_EXTENSION_TO_MIME[ext];
+  if (imageMime) return { kind: "image", mimeType: imageMime };
+  if (TEXT_EXTENSIONS.has(ext)) return { kind: "text" };
+  // Fallback: any file the browser tags as text (e.g. an extensionless
+  // `text/plain` drop) is safe to inline.
+  if (fileType?.startsWith("text/")) return { kind: "text" };
+  return { kind: "unsupported" };
+}
+
+/** Decode a base64 string (from the desktop bridge) as UTF-8 text. */
+export function decodeBase64Utf8(base64: string): string {
+  const binary = atob(base64);
+  const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function longestBacktickRun(value: string): number {
+  let max = 0;
+  for (const match of value.matchAll(/`+/g)) max = Math.max(max, match[0].length);
+  return max;
+}
+
+/**
+ * Build the message text sent to the agent: the typed prompt followed by
+ * each text attachment fenced in a code block labelled with its filename.
+ * The fence length adapts so file contents containing backticks can't
+ * break out of the block.
+ */
+export function formatTextAttachmentsForPrompt(
+  text: string,
+  files: ReadonlyArray<{ fileName: string; text: string }>,
+): string {
+  if (files.length === 0) return text;
+  const blocks = files.map((file) => {
+    const fence = "`".repeat(Math.max(3, longestBacktickRun(file.text) + 1));
+    const lang = getExtension(file.fileName);
+    return `Attached file \`${file.fileName}\`:\n${fence}${lang}\n${file.text}\n${fence}`;
+  });
+  return [text.trim(), ...blocks].filter((part) => part.length > 0).join("\n\n");
+}

--- a/packages/desktop/src/lib/prompt-attachments.ts
+++ b/packages/desktop/src/lib/prompt-attachments.ts
@@ -147,7 +147,8 @@ function longestBacktickRun(value: string): number {
  * Build the message text sent to the agent: the typed prompt followed by
  * each text attachment fenced in a code block labelled with its filename.
  * The fence length adapts so file contents containing backticks can't
- * break out of the block.
+ * break out of the block. The filename label is left unformatted so a
+ * backtick in the name can't break out of an inline-code span.
  */
 export function formatTextAttachmentsForPrompt(
   text: string,
@@ -157,7 +158,7 @@ export function formatTextAttachmentsForPrompt(
   const blocks = files.map((file) => {
     const fence = "`".repeat(Math.max(3, longestBacktickRun(file.text) + 1));
     const lang = getExtension(file.fileName);
-    return `Attached file \`${file.fileName}\`:\n${fence}${lang}\n${file.text}\n${fence}`;
+    return `Attached file: ${file.fileName}\n${fence}${lang}\n${file.text}\n${fence}`;
   });
   return [text.trim(), ...blocks].filter((part) => part.length > 0).join("\n\n");
 }

--- a/packages/desktop/src/lib/prompt-attachments.ts
+++ b/packages/desktop/src/lib/prompt-attachments.ts
@@ -54,16 +54,20 @@ export const MAX_ATTACHMENT_FILES = 10;
 export const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // 20MB
 /** Text files are inlined into the prompt, so keep them prompt-sized. */
 export const MAX_TEXT_BYTES = 1024 * 1024; // 1MB
+/** PDFs are parsed to text in-app before inlining; cap the raw file size. */
+export const MAX_PDF_BYTES = 20 * 1024 * 1024; // 20MB
 
-/** `accept` attribute for the file picker — image MIME types + text extensions. */
+/** `accept` attribute for the file picker — images + PDF + text extensions. */
 export const ATTACHMENT_ACCEPT = [
   ...ALLOWED_IMAGE_TYPES,
+  "application/pdf",
+  ".pdf",
   ...TEXT_ATTACHMENT_EXTENSIONS.map((ext) => `.${ext}`),
 ].join(",");
 
 /** User-facing hint listing what can be attached. */
 export const ATTACHMENT_SUPPORT_HINT =
-  "Attach images (PNG, JPEG, GIF, WebP) or text files like CSV, TSV, JSON, and Markdown.";
+  "Attach images (PNG, JPEG, GIF, WebP), PDFs, or text files like CSV, TSV, JSON, and Markdown.";
 
 export interface ImageAttachment {
   id: string;
@@ -94,6 +98,7 @@ export function isTextAttachment(attachment: PromptAttachment): attachment is Te
 export type AttachmentClass =
   | { kind: "image"; mimeType: string }
   | { kind: "text" }
+  | { kind: "pdf" }
   | { kind: "unsupported" };
 
 export function getExtension(fileName: string): string {
@@ -113,6 +118,7 @@ export function classifyAttachment(fileName: string, fileType?: string): Attachm
   const ext = getExtension(fileName);
   const imageMime = IMAGE_EXTENSION_TO_MIME[ext];
   if (imageMime) return { kind: "image", mimeType: imageMime };
+  if (ext === "pdf" || fileType === "application/pdf") return { kind: "pdf" };
   if (TEXT_EXTENSIONS.has(ext)) return { kind: "text" };
   // Fallback: any file the browser tags as text (e.g. an extensionless
   // `text/plain` drop) is safe to inline.
@@ -120,11 +126,15 @@ export function classifyAttachment(fileName: string, fileType?: string): Attachm
   return { kind: "unsupported" };
 }
 
-/** Decode a base64 string (from the desktop bridge) as UTF-8 text. */
-export function decodeBase64Utf8(base64: string): string {
+/** Decode a base64 string (from the desktop bridge) into raw bytes. */
+export function base64ToBytes(base64: string): Uint8Array {
   const binary = atob(base64);
-  const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
+  return Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+}
+
+/** Decode a base64 string as UTF-8 text. */
+export function decodeBase64Utf8(base64: string): string {
+  return new TextDecoder().decode(base64ToBytes(base64));
 }
 
 function longestBacktickRun(value: string): number {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
+      pdfjs-dist:
+        specifier: ^5.7.284
+        version: 5.7.284
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.4)
@@ -1498,6 +1501,81 @@ packages:
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.100':
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.1.2':
     resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
@@ -5737,6 +5815,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfjs-dist@5.7.284:
+    resolution: {integrity: sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -8498,6 +8580,54 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
+
+  '@napi-rs/canvas-android-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.100':
+    optional: true
+
+  '@napi-rs/canvas@0.1.100':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -13531,6 +13661,10 @@ snapshots:
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
+
+  pdfjs-dist@5.7.284:
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
 
   pe-library@0.4.1: {}
 


### PR DESCRIPTION
## What & why

The agent composer accepted **images only**. Dropping, pasting, or picking a `.csv` produced *"Unsupported file: … — Only PNG, JPEG, GIF, and WebP images can be attached."* This generalizes prompt attachments so text/data files (CSV, TSV, TXT, JSON, Markdown, YAML, …) can be attached too.

## How

- Images keep travelling to the agent as base64 `image` content blocks (unchanged).
- **Text files have their contents embedded into the prompt text at send time.** This is provider-neutral — Claude Code, Codex, and OpenCode all read plain text — so **no backend, WebSocket-protocol, or persistence change is needed.**
- Each text file is fenced in a code block labelled with its filename; the fence auto-grows so backticks in the data can't break out.
- All three entry points now accept text files: **file picker** (`accept`), **drag-drop**, and **paste**.
- Text attachments render as a file chip (icon + name) in the composer; images still render as thumbnails. Text files are capped at 1 MB since they're inlined into the prompt.

## Key changes

- `lib/prompt-attachments.ts` *(new)* — attachment types + guards, `classifyAttachment`, accept list, size caps, base64→UTF-8 decode, and `formatTextAttachmentsForPrompt`
- `hooks/useImageAttachments.ts` — generalized to a `PromptAttachment` union (image | text)
- `components/agent-prompt-send.ts` — partitions attachments; images → payload, text → composed into the prompt
- `ImageAttachmentPreview.tsx` / `ImageAttachmentButton.tsx` / `ImagePastePlugin.tsx` — UI + paste support

## Notes / trade-offs

- The CSV content appears **inline** in the sent message (and the transcript) as a fenced block — transparent, but a large file is verbose. Rendering it as a collapsed chip in history would be a larger change (new protocol field + persistence).

## Testing

- New parser/format/classification suite + text-attachment cases across the touched components
- Full desktop suite green (**2337 tests**), `ts-check`, `oxlint`, `knip`, and `oxfmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachments now support text files (CSV/TSV/MD/JSON/TXT) and PDFs; text attachments are inlined into prompts and PDF text can be extracted.
  * Attachment button icon changed to a paperclip and accessible label updated to “Attach files”.
  * Pasting and dropping now accept multiple attachable file types beyond images.

* **Tests**
  * Expanded test coverage for mixed attachment scenarios, paste/drop behavior, and PDF/text handling.

* **Bug Fixes**
  * Improved error messaging for oversized/unsupported attachments and refined paste/drop fall-through behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->