### PR TITLE
fix(desktop): avoid Virtuoso crash from undefined components prop

### DIFF
--- a/packages/desktop/src/components/diff/GitGraphView.tsx
+++ b/packages/desktop/src/components/diff/GitGraphView.tsx
@@ -169,7 +169,7 @@ export const GitGraphView = memo(function GitGraphView({
           itemContent={itemContent}
           endReached={handleEndReached}
           increaseViewportBy={ROW_HEIGHT * 6}
-          components={hasMore ? { Footer: GraphFooter } : undefined}
+          components={hasMore ? { Footer: GraphFooter } : {}}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes a Git graph crash caused by passing `components={undefined}` to `react-virtuoso` when there are no further pages to load. We now pass `{}` instead so Virtuoso keeps a defined components object.

## Motivation

The Git graph tab crashed with `Cannot read properties of undefined (reading 'EmptyPlaceholder')` on branches with no further pages to load, typically branches with ≤ 50 commits. The whole tab was replaced by the error boundary.

Root cause: `GitGraphView` passed:

```tsx
components={hasMore ? { Footer: GraphFooter } : undefined}
```

In `react-virtuoso@4.18.6`, optional props are published into its internal stream when the prop key is present, even if the value is `undefined`. That overwrote Virtuoso’s default `{}` components object with `undefined`, then a derived selector tried to read `undefined.EmptyPlaceholder`.

Key subtlety: omitting the prop is safe, but passing `undefined` is not.

## Linked issues

No linked issue exists for this fix.

## Type

* [x] Bug fix
* [ ] Feature
* [ ] Docs
* [ ] Maintenance / tooling

## Areas touched

* [x] Desktop frontend
* [ ] Backend service
* [ ] Claude provider
* [ ] Codex provider
* [ ] OpenCode provider
* [ ] Database / migration
* [ ] API surface
* [ ] Docs
* [ ] CI / release

## Changes

* Changed Virtuoso `components` fallback from `undefined` to `{}` when there is no footer.
* Prevented Virtuoso from dereferencing `undefined.EmptyPlaceholder` on branches with no further pages to load.

## Screenshots / recordings

N/A — no visible UI change beyond preventing the crash.

## API / database changes

* [x] No API or database changes
* [ ] API changed and generated client was updated
* [ ] Database migration added
* [ ] Migration tested locally

## UX checklist

* [x] Loading/error states are visible for async operations
* [x] Keyboard shortcut impact considered
* [x] No optimistic frontend updates added

## Test plan

Commands run:

```bash
tsc --noEmit
oxlint
```

Results:

* `tsc --noEmit` for `@cadencr/desktop`: clean
* `oxlint`: 0 warnings / 0 errors

Manual flows verified:

* [x] Opened the Git graph tab on a branch with no further pages to load.
* [x] Verified the Git graph no longer crashes when `hasMore` is false.

Automated tests:

No automated test accompanies this fix. `react-virtuoso` is mocked in `test-setup.ts`, and the mock reads `components?.Footer` with optional chaining, so it tolerates the `undefined` value that crashes the real library. A unit test using the current mock would stay green even with the bug present.

## Checklist

* [x] Commits follow the [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) style.
* [ ] Rebased onto the latest `main`.
* [ ] Docs (README, CONTRIBUTING, etc.) updated for any user-visible change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the graph view’s loading behavior by making the component configuration consistent when there are no additional items to load.
  * Ensured the graph footer is only shown when more entries are available, preventing inconsistent timeline display when the list ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->