### PR TITLE
docs: add windows wsl setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Use this path if you want to try the latest code or contribute.
 
 On Linux, follow the [Linux development setup](./docs/LINUX_SETUP.md).
 
+On Windows, use WSL2/WSLg and follow the [Windows / WSL development setup](./docs/WINDOWS_WSL_SETUP.md).
+
 #### Requirements
 
 - **Node.js 22.x** — the repo enforces `>=22.18.0 <23.0.0`.

--- a/docs/WINDOWS_WSL_SETUP.md
+++ b/docs/WINDOWS_WSL_SETUP.md
@@ -1,0 +1,120 @@
+# Windows / WSL development setup
+
+This guide documents the setup path for running Cadencr from source on Windows through WSL2 and WSLg.
+
+## Environment
+
+- Windows with WSL2 enabled.
+- Ubuntu in WSL.
+- WSLg enabled so Electron can open a Linux GUI window.
+- Node.js `22.18.0`; the repo enforces `>=22.18.0 <23.0.0`.
+
+The commands below should be run inside the WSL shell from the repository root.
+
+## System packages
+
+Install the C/Rust build toolchain and the Linux GUI libraries Electron needs:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential pkg-config
+sudo apt-get install -y libatk1.0-0 libatk-bridge2.0-0 libcups2 libcairo2 libgtk-3-0 libpango-1.0-0 libxdamage1 libgbm1 libxkbcommon0 libatspi2.0-0
+```
+
+If Electron still fails to start with a missing shared library, check the remaining gaps with:
+
+```bash
+ldd node_modules/electron/dist/electron | grep 'not found'
+```
+
+Install the missing Ubuntu package, then retry `pnpm dev`.
+
+## Node and pnpm
+
+Enable Corepack and install workspace dependencies:
+
+```bash
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter @cadencr/desktop ensure:electron
+```
+
+The project pins pnpm through `packageManager` in the root `package.json`.
+
+## Rust
+
+Install Rust with rustup if it is not already installed:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -o /tmp/rustup-init https://sh.rustup.rs
+chmod +x /tmp/rustup-init
+/tmp/rustup-init -y --profile minimal
+. "$HOME/.cargo/env"
+rustup component add rustfmt clippy
+cargo install cargo-watch --locked
+```
+
+Optional, but useful for warming the cache before the first dev launch:
+
+```bash
+cargo fetch
+cargo check
+```
+
+## Local environment files
+
+Create local env files from the examples:
+
+```bash
+cp packages/service/.env.example packages/service/.env
+cp packages/desktop/.env.example packages/desktop/.env
+```
+
+Set the same random local token in both files:
+
+- `CADENCR_AUTH_TOKEN` in `packages/service/.env`
+- `VITE_API_TOKEN` in `packages/desktop/.env`
+
+Keep the default ports unless they conflict with another local process:
+
+- desktop renderer: `1420`
+- Rust service: `5005`
+- remote TLS listener: `5007`
+
+## Start the app
+
+Use the normal full-workspace dev command:
+
+```bash
+pnpm dev
+```
+
+Expected local services:
+
+- Electron renderer: `http://127.0.0.1:1420/`
+- Rust service: `http://127.0.0.1:5005/`
+- Landing site: `http://localhost:4321/`
+
+For desktop-only development, use:
+
+```bash
+pnpm start
+```
+
+## Expected WSL warnings
+
+Electron may print DBus, dconf, or GPU warnings under WSLg, for example:
+
+```text
+Failed to connect to the bus
+failed to commit changes to dconf
+GLES3 is unsupported
+```
+
+These are usually WSLg noise as long as the Electron window opens and the service logs:
+
+```text
+Cadencr service listening on 127.0.0.1:5005
+```
+
+The service may also warn that `claude` or `opencode` are not installed. That only means those provider CLIs are unavailable locally; Codex can still work if its CLI is installed and configured.

--- a/packages/desktop/src/components/AgentPromptBar.test.tsx
+++ b/packages/desktop/src/components/AgentPromptBar.test.tsx
@@ -292,8 +292,6 @@ describe("AgentPromptBar", () => {
         />,
       );
 
-      // Plan approval is deferred while the user has just been typing — the
-      // prompt bar stays visible until the typing-idle debounce elapses.
       expect(screen.getByText(/Plan approval pending/i)).toBeInTheDocument();
       expect(screen.getByRole("textbox")).toHaveValue("Need a smaller plan");
       await act(async () => vi.advanceTimersByTime(1000));
@@ -309,12 +307,11 @@ describe("AgentPromptBar", () => {
   });
 
   it("restores unsent text after question drawer closes", async () => {
-    const user = userEvent.setup();
+    vi.useFakeTimers();
     const { rerender } = render(<AgentPromptBar onSend={onSend} onStop={onStop} status="idle" />);
 
-    await user.type(screen.getByRole("textbox"), "Answer later");
-
-    await act(async () => {
+    try {
+      fireEvent.change(screen.getByRole("textbox"), { target: { value: "Answer later" } });
       rerender(
         <AgentPromptBar
           onSend={onSend}
@@ -324,15 +321,19 @@ describe("AgentPromptBar", () => {
           onQuestionResponse={vi.fn()}
         />,
       );
-    });
 
-    expect(await screen.findByText(/What do you need/i)).toBeInTheDocument();
+      expect(screen.getByText(/Question pending/i)).toBeInTheDocument();
+      expect(screen.getByRole("textbox")).toHaveValue("Answer later");
+      await act(async () => vi.advanceTimersByTime(1000));
+      expect(screen.getByText(/What do you need/i)).toBeInTheDocument();
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 
-    await act(async () => {
       rerender(<AgentPromptBar onSend={onSend} onStop={onStop} status="idle" />);
-    });
 
-    expect(screen.getByRole("textbox")).toHaveTextContent("Answer later");
+      expect(screen.getByRole("textbox")).toHaveValue("Answer later");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("escape calls onStop when focus is inside the prompt bar", () => {

--- a/packages/service/src/domain/checkpoints/mod.rs
+++ b/packages/service/src/domain/checkpoints/mod.rs
@@ -119,6 +119,12 @@ mod tests {
         crate::shared::git_cli::run_git(&["config", "user.name", "Test"], p)
             .await
             .unwrap();
+        crate::shared::git_cli::run_git(&["config", "commit.gpgsign", "false"], p)
+            .await
+            .unwrap();
+        crate::shared::git_cli::run_git(&["config", "tag.gpgsign", "false"], p)
+            .await
+            .unwrap();
         fs::write(p.join("a.txt"), "v1").unwrap();
         crate::shared::git_cli::run_git(&["add", "-A"], p)
             .await

--- a/packages/service/src/domain/git/commands/files.rs
+++ b/packages/service/src/domain/git/commands/files.rs
@@ -151,6 +151,8 @@ mod tests {
         git(&["init", "-q", "-b", "main"], root);
         git(&["config", "user.email", "test@example.com"], root);
         git(&["config", "user.name", "Test"], root);
+        git(&["config", "commit.gpgsign", "false"], root);
+        git(&["config", "tag.gpgsign", "false"], root);
         std::fs::write(root.join(".gitignore"), ".env*\n").unwrap();
         std::fs::write(root.join("README.md"), "# hi").unwrap();
         std::fs::write(root.join("src.rs"), "fn main() {}").unwrap();

--- a/packages/service/src/domain/git/service/blame.rs
+++ b/packages/service/src/domain/git/service/blame.rs
@@ -139,6 +139,8 @@ mod tests {
             vec!["init", "-q"],
             vec!["config", "user.email", "t@example.com"],
             vec!["config", "user.name", "T"],
+            vec!["config", "commit.gpgsign", "false"],
+            vec!["config", "tag.gpgsign", "false"],
         ] {
             let status = Command::new("git")
                 .args(&args)


### PR DESCRIPTION
## Summary

- Document Windows / WSL2 / WSLg development setup for running Cadencr from source.
- Link the Windows setup guide from the README and fix the contributing guide's README anchor.
- Stabilize pre-commit checks by aligning the AgentPromptBar question test with the prompt debounce behavior and isolating Rust test repositories from global Git signing config.

## Validation

- `pnpm --filter @cadencr/desktop test -- src/components/AgentPromptBar.test.tsx`
- `pnpm --filter @cadencr/service test`

## Notes

The GitHub SSH remote required an interactive passphrase prompt in this WSL environment, so the branch was pushed over HTTPS using authenticated `gh` credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Windows development guidance for running the project from source with WSL2/WSLg.
  * Documented prerequisites, environment setup, startup commands, local endpoints, and common warnings.

* **Tests**
  * Improved coverage for restoring unsent text after plan approval and question drawer flows.
  * Stabilized temporary Git repository tests by disabling commit and tag signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->