### PR TITLE
Harden Claude Code provider streaming reliability (stops mid-message)

### DIFF
--- a/packages/claude-agent-sdk-rs/src/messages/deserialize.rs
+++ b/packages/claude-agent-sdk-rs/src/messages/deserialize.rs
@@ -392,17 +392,17 @@ impl From<SdkMessageInner> for SdkMessage {
     }
 }
 
-impl<'de> Deserialize<'de> for SdkMessage {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
-        // Buffer the raw value so we can try again on failure.
-        let raw = Value::deserialize(deserializer)?;
+impl SdkMessage {
+    /// Convert a raw CLI wire message into an `SdkMessage`, infallibly.
+    ///
+    /// Never silently drops: a message that fails to match any known schema
+    /// becomes `Unknown(raw)` (so the stream survives) with a log of exactly
+    /// what and why, so a CLI wire-format drift is diagnosable instead of
+    /// presenting as an agent that "just stopped".
+    pub fn from_raw(raw: Value) -> Self {
         match SdkMessageInner::deserialize(&raw) {
-            Ok(inner) => Ok(SdkMessage::from(inner)),
+            Ok(inner) => SdkMessage::from(inner),
             Err(error) => {
-                // Never silently drop: a message that fails to match any known
-                // schema becomes `Unknown` (so the stream survives), but we log
-                // exactly what and why so a CLI wire-format drift is diagnosable
-                // instead of presenting as an agent that "just stopped".
                 let message_type = raw
                     .get("type")
                     .and_then(|v| v.as_str())
@@ -414,9 +414,17 @@ impl<'de> Deserialize<'de> for SdkMessage {
                     %error,
                     "claude SDK: message did not match any known schema; forwarding as Unknown (it will not render in the conversation)"
                 );
-                Ok(SdkMessage::Unknown(raw))
+                SdkMessage::Unknown(raw)
             }
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for SdkMessage {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        // Buffer the raw value so the fallback can keep it on failure.
+        let raw = Value::deserialize(deserializer)?;
+        Ok(SdkMessage::from_raw(raw))
     }
 }
 

--- a/packages/claude-agent-sdk-rs/src/messages/events.rs
+++ b/packages/claude-agent-sdk-rs/src/messages/events.rs
@@ -65,9 +65,10 @@ pub enum StreamEventData {
 
     /// Any stream event the CLI emits that we don't model yet. Catching it here
     /// keeps a novel event from sinking the whole `stream_event` message into
-    /// `SdkMessage::Unknown`, which would silently drop the live turn.
-    #[serde(other)]
-    Other,
+    /// `SdkMessage::Unknown`, which would silently drop the live turn. Carries
+    /// the raw JSON so the consumer can log/inspect what was dropped.
+    #[serde(untagged)]
+    Other(Value),
 }
 
 // ── SystemMessage ────────────────────────────────────────────────────────────

--- a/packages/claude-agent-sdk-rs/src/query/permission_dispatch.rs
+++ b/packages/claude-agent-sdk-rs/src/query/permission_dispatch.rs
@@ -50,9 +50,16 @@ pub(super) async fn handle_can_use_tool_request(
             match serde_json::to_value(&result) {
                 Ok(v) => v,
                 Err(e) => {
+                    // Surface the failure, but still answer the CLI with a
+                    // deny: leaving the request unanswered blocks the CLI
+                    // forever and strands the turn in `WaitingForPermission` —
+                    // the session then looks frozen with no error anywhere.
                     error!("failed to serialize permission response: {e}");
                     let _ = tx.send(Err(SdkError::SerializationError(e))).await;
-                    return;
+                    serde_json::json!({
+                        "behavior": "deny",
+                        "message": "Cadencr failed to build the permission response; the tool use was denied so the session can continue."
+                    })
                 }
             }
         }
@@ -75,7 +82,14 @@ pub(super) async fn handle_can_use_tool_request(
     });
 
     if let Err(e) = write_to_stdin(&process_stdin, &response_json).await {
+        error!(tool = %tool_name, "failed to write permission response to CLI stdin: {e}");
         let _ = tx.send(Err(e)).await;
+        // The write failed, so the CLI never got an answer — the pipe is
+        // almost certainly dead and the process-exit path will surface the
+        // real failure. Flip the state anyway: `WaitingForPermission` would
+        // tell consumers the turn is waiting on the *user*, which is false,
+        // and would strand the session in a frozen, errorless state.
+        *turn_state.lock().await = TurnState::AgentWorking;
         return;
     }
 
@@ -92,6 +106,55 @@ mod tests {
     use futures::StreamExt;
     use tempfile::TempDir;
     use tokio::sync::{oneshot, Notify};
+
+    /// Regression test for the stranded-permission freeze.
+    ///
+    /// If writing the permission response to the CLI fails (dead pipe,
+    /// closed stdin), the turn state used to stay `WaitingForPermission`
+    /// forever: consumers reported the turn as waiting on the user while the
+    /// CLI was actually gone — a session frozen with no error anywhere. The
+    /// dispatch must surface the error on the stream AND flip the turn state
+    /// back so the process-exit path can end the turn visibly.
+    #[tokio::test]
+    async fn write_failure_surfaces_error_and_does_not_strand_turn_state() {
+        use crate::error::SdkError;
+        use crate::query::turn_state::TurnState;
+
+        // `None` stdin makes `write_to_stdin` fail deterministically
+        // (`SdkError::InputClosed`) — the same shape as a dead pipe.
+        let process_stdin = Arc::new(tokio::sync::Mutex::new(None));
+        let turn_state = Arc::new(tokio::sync::Mutex::new(TurnState::WaitingForPermission {
+            tool_name: "Write".to_string(),
+            tool_use_id: "toolu_dead".to_string(),
+        }));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+
+        super::handle_can_use_tool_request(
+            Arc::clone(&process_stdin),
+            Arc::clone(&turn_state),
+            tx,
+            None, // no handler -> auto-allow path; the write is what fails
+            PermissionRequest {
+                tool_name: "Write".to_string(),
+                input: serde_json::json!({}),
+                tool_use_id: "toolu_dead".to_string(),
+                agent_id: None,
+                suggestions: None,
+                blocked_path: None,
+                decision_reason: None,
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(rx.recv().await, Some(Err(SdkError::InputClosed))),
+            "the write failure must surface on the message stream"
+        );
+        assert!(
+            matches!(&*turn_state.lock().await, TurnState::AgentWorking),
+            "turn state must not stay WaitingForPermission after a failed write"
+        );
+    }
 
     use crate::messages::SdkMessage;
     use crate::options::Options;

--- a/packages/claude-agent-sdk-rs/src/query/reader_task.rs
+++ b/packages/claude-agent-sdk-rs/src/query/reader_task.rs
@@ -203,10 +203,9 @@ impl ReaderTask {
     }
 
     async fn forward_sdk_message(&self, raw: Value) -> RawOutcome {
-        // `SdkMessage`'s custom `Deserialize` is infallible (it falls back to
-        // `Unknown` and logs internally), so the `unwrap_or` branch is unreachable.
-        let message: SdkMessage =
-            serde_json::from_value(raw).unwrap_or(SdkMessage::Unknown(Value::Null));
+        // Infallible: falls back to `Unknown(raw)` (raw payload preserved)
+        // and logs internally when the message matches no known schema.
+        let message = SdkMessage::from_raw(raw);
         self.capture_session_id(&message).await;
         self.cache_mcp_servers(&message).await;
         self.update_turn_state(&message).await;

--- a/packages/claude-agent-sdk-rs/src/types.rs
+++ b/packages/claude-agent-sdk-rs/src/types.rs
@@ -51,9 +51,10 @@ pub enum ContentBlock {
     /// `server_tool_use`, `web_search_tool_result`, or image block). Catching
     /// it here keeps an unknown *sibling* block from sinking the entire
     /// assistant message into `SdkMessage::Unknown` — the known text/tool
-    /// blocks beside it still parse and surface.
-    #[serde(other)]
-    Other,
+    /// blocks beside it still parse and surface. Carries the raw JSON so the
+    /// consumer can log/inspect what was dropped instead of losing it.
+    #[serde(untagged)]
+    Other(Value),
 }
 
 /// A streaming content delta. Tagged by the `type` field.
@@ -72,9 +73,10 @@ pub enum ContentDelta {
     /// Any delta type the CLI emits that we don't model yet (e.g.
     /// `signature_delta` or `citations_delta`). Catching it here keeps an
     /// unknown delta from sinking the whole `stream_event` into
-    /// `SdkMessage::Unknown` and dropping the live turn.
-    #[serde(other)]
-    Other,
+    /// `SdkMessage::Unknown` and dropping the live turn. Carries the raw JSON
+    /// so the consumer can log/inspect what was dropped instead of losing it.
+    #[serde(untagged)]
+    Other(Value),
 }
 
 /// A slash command available in the CLI.

--- a/packages/claude-agent-sdk-rs/tests/message_parsing.rs
+++ b/packages/claude-agent-sdk-rs/tests/message_parsing.rs
@@ -656,7 +656,15 @@ fn assistant_with_unknown_content_block_keeps_known_text() {
         SdkMessage::Assistant { message, .. } => {
             assert_eq!(message.content.len(), 2);
             assert!(matches!(&message.content[0], ContentBlock::Text { text } if text == "hello"));
-            assert!(matches!(&message.content[1], ContentBlock::Other));
+            // The unknown sibling degrades to Other WITH its raw payload
+            // preserved, so consumers can log/inspect what was dropped.
+            match &message.content[1] {
+                ContentBlock::Other(raw) => {
+                    assert_eq!(raw["type"], "server_tool_use");
+                    assert_eq!(raw["name"], "web_search");
+                }
+                other => panic!("expected raw-preserving Other, got {other:?}"),
+            }
         }
         other => panic!("unknown block must not sink the assistant message: {other:?}"),
     }
@@ -680,7 +688,13 @@ fn stream_event_with_unknown_delta_stays_stream_event() {
         SdkMessage::StreamEvent {
             event: StreamEventData::ContentBlockDelta { delta, .. },
             ..
-        } => assert!(matches!(delta, ContentDelta::Other)),
+        } => match delta {
+            ContentDelta::Other(raw) => {
+                assert_eq!(raw["type"], "signature_delta");
+                assert_eq!(raw["signature"], "abc");
+            }
+            other => panic!("expected raw-preserving Other, got {other:?}"),
+        },
         other => panic!("unknown delta must not sink the stream event: {other:?}"),
     }
 }
@@ -695,7 +709,13 @@ fn unknown_stream_event_type_stays_stream_event() {
     });
     let msg: SdkMessage = serde_json::from_value(raw).unwrap();
     match msg {
-        SdkMessage::StreamEvent { event, .. } => assert!(matches!(event, StreamEventData::Other)),
+        SdkMessage::StreamEvent { event, .. } => match event {
+            StreamEventData::Other(raw) => {
+                assert_eq!(raw["type"], "some_future_event");
+                assert_eq!(raw["foo"], 1);
+            }
+            other => panic!("expected raw-preserving Other, got {other:?}"),
+        },
         other => panic!("unknown stream event must not become Unknown: {other:?}"),
     }
 }

--- a/packages/desktop/src/stores/ws-envelope-payload.ts
+++ b/packages/desktop/src/stores/ws-envelope-payload.ts
@@ -214,10 +214,15 @@ export function parseCompactingPayload(payload: unknown): { active: boolean } | 
   return active == null ? null : { active };
 }
 
-export function parseMessageBlocksPayload(payload: unknown): { blocks: unknown[] } | null {
+export function parseMessageBlocksPayload(
+  payload: unknown,
+): { blocks: unknown[]; seq: number | null } | null {
   const record = asRecord(payload);
   if (!record) return null;
-  return { blocks: optionalArray(record, "blocks") ?? [] };
+  return {
+    blocks: optionalArray(record, "blocks") ?? [],
+    seq: optionalNumber(record, "seq") ?? null,
+  };
 }
 
 export function parsePermissionPayload(payload: unknown): {

--- a/packages/desktop/src/stores/ws-envelope-session-handlers.ts
+++ b/packages/desktop/src/stores/ws-envelope-session-handlers.ts
@@ -16,6 +16,7 @@ import { appendLocalUserMessage } from "./ws-session-store-helpers";
 import { buildClearedGatePatch } from "./ws-gate-state";
 import {
   type BlockMutation,
+  type StreamingState,
   blocksPatchWithDerived,
   createStreamingState,
   isRecord,
@@ -23,6 +24,7 @@ import {
   applyMutations,
   buildMessagePatch,
 } from "./ws-message-processing";
+import { trackStreamSeq } from "./ws-session-resync";
 import { normalizeContextWindow } from "@/types/agent";
 import { parseCodexPermissionMode } from "@/types/codex-permission-mode";
 import type { SessionEntry } from "./ws-session-types";
@@ -124,14 +126,28 @@ function mcpServersEqual(
 
 export function handleMessage(ctx: StoreAccessors, sessionId: string, payload: unknown): void {
   const p = parseMessageBlocksPayload(payload);
-  if (!p) return;
+  if (!p) {
+    // Never drop silently: a malformed `session.message` is a lost stream
+    // chunk — the exact "text stopped mid-message" a user can't diagnose.
+    console.warn("[ws-session] dropping malformed session.message payload", payload);
+    return;
+  }
   const state = ctx.getSession(sessionId).streamingState;
+  trackStreamSeq(ctx, sessionId, state, p.seq);
+  processMessageBlocks(ctx, sessionId, state, p.blocks);
+}
 
+function processMessageBlocks(
+  ctx: StoreAccessors,
+  sessionId: string,
+  state: StreamingState,
+  blocks: unknown[],
+): void {
   const allMutations: BlockMutation[] = [];
   let enterPlanModeRequested = false;
   let compactBoundaryObserved = false;
   let manualCompactBoundaryObserved = false;
-  for (const rawBlock of p.blocks) {
+  for (const rawBlock of blocks) {
     if (!isRecord(rawBlock)) continue;
     const result = processSdkMessage(rawBlock, state);
     allMutations.push(...result.mutations);

--- a/packages/desktop/src/stores/ws-envelope-turn-handlers.ts
+++ b/packages/desktop/src/stores/ws-envelope-turn-handlers.ts
@@ -8,6 +8,7 @@ import type { SessionEntry } from "./ws-session-types";
 import { updateSession } from "./ws-session-types";
 import { transitionTurn, type TurnTerminalReason } from "./ws-turn-lifecycle";
 import { removePendingPromptBlocks, trimTailPromptTurnBoundary } from "./ws-pending-prompts";
+import { repairPersistedBlocksAfterTurn } from "./ws-session-resync";
 import type { StoreAccessors } from "./ws-envelope-types";
 
 /**
@@ -63,6 +64,14 @@ export function handleTurnComplete(ctx: StoreAccessors, sessionId: string, paylo
     return;
   }
   const state = session.streamingState;
+  // A seq gap was detected mid-turn: now that no more deltas can arrive, the
+  // persisted transcript is authoritative — overwrite any truncated blocks.
+  if (state.tailRepairNeeded) {
+    state.tailRepairNeeded = false;
+    repairPersistedBlocksAfterTurn(ctx, sessionId).catch((err: unknown) => {
+      console.warn("[ws-session] post-turn transcript repair failed", err);
+    });
+  }
   for (const stream of state.streams.values()) {
     if (!stream.parentToolUseId) {
       continue;

--- a/packages/desktop/src/stores/ws-message-processing-core.ts
+++ b/packages/desktop/src/stores/ws-message-processing-core.ts
@@ -1,13 +1,14 @@
 import type { AgentBlockData } from "@/components/AgentBlock";
 import { normalizeToolName } from "@/lib/tool-adapter";
 import { createToolUseBlock } from "./ws-message-processing-tool-blocks";
+import { processStreamEvent } from "./ws-message-processing-stream";
 import { processSystemMessage } from "./ws-message-processing-system";
 import { processUserMessage } from "./ws-message-processing-user";
 import { nextSyntheticBlockId } from "./ws-message-processing-utils";
 
 export { isRecord } from "./ws-message-processing-utils";
 
-interface StreamContext {
+export interface StreamContext {
   model: string | null;
   contentBlockIds: Map<number, string>;
   parentToolUseId: string | null;
@@ -32,6 +33,18 @@ export interface StreamingState {
   rootBlockPosById: Map<string, number>;
   /** Map from a tool_call's `toolUseId` to its matching `tool_result` block. */
   toolResultMap: Map<string, AgentBlockData>;
+  /**
+   * Last `seq` observed on a `session.message` envelope. Used to detect a
+   * dropped envelope (gap) so the client can resync instead of silently
+   * rendering a truncated message. `null` until the first stamped envelope.
+   */
+  lastMessageSeq: number | null;
+  /**
+   * Set when a seq gap was detected mid-turn. The truncated tail can't be
+   * repaired while deltas are still flowing (an in-place rewrite would race
+   * in-flight appends), so the repair runs once the turn ends.
+   */
+  tailRepairNeeded: boolean;
 }
 
 export interface ParserSignals {
@@ -59,6 +72,8 @@ export function createStreamingState(): StreamingState {
     rootBlocks: [],
     rootBlockPosById: new Map(),
     toolResultMap: new Map(),
+    lastMessageSeq: null,
+    tailRepairNeeded: false,
   };
 }
 
@@ -90,161 +105,17 @@ export function processSdkMessage(
     case "system":
       return { mutations: processSystemMessage(msg, state, signals), signals };
     case "result":
+      return { mutations: [], signals };
     default:
+      // A message type this parser doesn't know. The backend independently
+      // surfaces unknown provider messages as visible errors; here we only
+      // leave a trace so a "text stopped mid-message" report is diagnosable.
+      console.warn("[agent-stream] dropping unknown message type", msg.type);
       return { mutations: [], signals };
   }
 }
 
-function processStreamEvent(msg: Record<string, unknown>, state: StreamingState): BlockMutation[] {
-  const event = msg.event as Record<string, unknown> | undefined;
-  if (!event) return [];
-
-  const stream = getOrCreateStreamContext(state, getStreamSessionId(msg));
-  // The server stamps the active model onto every forwarded stream event. Seed
-  // `stream.model` from it so a client that missed `message_start` (e.g. a
-  // remote device that joined the turn late) still labels streamed text with
-  // the right model instead of "unknown".
-  if (typeof msg.model === "string") {
-    stream.model = msg.model;
-  }
-  const parentToolUseId = (msg.parent_tool_use_id as string) ?? null;
-  if (stream.parentToolUseId && stream.parentToolUseId !== parentToolUseId) {
-    const prevParent = state.toolUseIdToBlock.get(stream.parentToolUseId);
-    if (prevParent?.childBlocks) {
-      prevParent.taskComplete = true;
-    }
-  }
-  stream.parentToolUseId = parentToolUseId;
-
-  switch (event.type as string) {
-    case "message_start": {
-      const message = event.message as Record<string, unknown> | undefined;
-      if (message?.model) {
-        stream.model = message.model as string;
-      }
-      stream.contentBlockIds.clear();
-      return [];
-    }
-    case "content_block_start":
-      return processContentBlockStart(
-        event,
-        state,
-        stream,
-        parentToolUseId,
-        blockIdFromAgentMessage(msg),
-      );
-    case "content_block_delta":
-      return processContentBlockDelta(event, stream, blockIdFromAgentMessage(msg));
-    default:
-      return [];
-  }
-}
-
-function processContentBlockStart(
-  event: Record<string, unknown>,
-  state: StreamingState,
-  stream: StreamContext,
-  parentToolUseId: string | null,
-  persistedBlockId: string | null,
-): BlockMutation[] {
-  const index = event.index as number;
-  const contentBlock = event.content_block as Record<string, unknown> | undefined;
-  if (!contentBlock) return [];
-
-  const blockId = persistedBlockId ?? nextSyntheticBlockId(state);
-  stream.contentBlockIds.set(index, blockId);
-
-  switch (contentBlock.type as string) {
-    case "tool_use":
-      return [
-        {
-          action: "append",
-          block: createToolUseBlock(
-            state,
-            blockId,
-            contentBlock,
-            parentToolUseId,
-            new Date().toISOString(),
-            false,
-          ),
-        },
-      ];
-    case "thinking":
-      return [
-        {
-          action: "append",
-          block: {
-            id: blockId,
-            type: "thinking",
-            content: typeof contentBlock.thinking === "string" ? contentBlock.thinking : "",
-            parentToolUseId,
-            createdAt: new Date().toISOString(),
-          },
-        },
-      ];
-    case "text":
-      return [
-        {
-          action: "append",
-          block: {
-            id: blockId,
-            type: "text",
-            content: typeof contentBlock.text === "string" ? contentBlock.text : "",
-            parentToolUseId,
-            model: stream.model ?? undefined,
-            createdAt: new Date().toISOString(),
-          },
-        },
-      ];
-    default:
-      return [];
-  }
-}
-
-function processContentBlockDelta(
-  event: Record<string, unknown>,
-  stream: StreamContext,
-  persistedBlockId: string | null,
-): BlockMutation[] {
-  const index = event.index as number;
-  const delta = event.delta as Record<string, unknown> | undefined;
-  if (!delta) return [];
-
-  const blockId = persistedBlockId ?? stream.contentBlockIds.get(index);
-  if (!blockId) return [];
-  if (persistedBlockId) {
-    stream.contentBlockIds.set(index, persistedBlockId);
-  }
-
-  switch (delta.type as string) {
-    case "text_delta":
-      return [
-        { action: "update", block: { id: blockId, type: "text", content: delta.text as string } },
-      ];
-    case "thinking_delta":
-      return [
-        {
-          action: "update",
-          block: { id: blockId, type: "thinking", content: delta.thinking as string },
-        },
-      ];
-    case "input_json_delta":
-      return [
-        {
-          action: "update",
-          block: {
-            id: blockId,
-            type: "tool_call",
-            content: delta.partial_json as string,
-          },
-        },
-      ];
-    default:
-      return [];
-  }
-}
-
-function blockIdFromAgentMessage(msg: Record<string, unknown>): string | null {
+export function blockIdFromAgentMessage(msg: Record<string, unknown>): string | null {
   const rawId = msg.agent_message_id;
   if (typeof rawId === "number" && Number.isSafeInteger(rawId)) {
     return `msg-${rawId}`;
@@ -376,11 +247,11 @@ function createAssistantMutation(
   }
 }
 
-function getStreamSessionId(msg: Record<string, unknown>): StreamSessionId {
+export function getStreamSessionId(msg: Record<string, unknown>): StreamSessionId {
   return typeof msg.session_id === "string" ? msg.session_id : DEFAULT_STREAM_SESSION_ID;
 }
 
-function getOrCreateStreamContext(
+export function getOrCreateStreamContext(
   state: StreamingState,
   streamSessionId: StreamSessionId,
 ): StreamContext {

--- a/packages/desktop/src/stores/ws-message-processing-stream.ts
+++ b/packages/desktop/src/stores/ws-message-processing-stream.ts
@@ -1,0 +1,225 @@
+/**
+ * `stream_event` processing — content block starts and deltas.
+ *
+ * This is the hot path for live streaming. Its resilience rule: a chunk the
+ * parser can't attach or recognize must never vanish silently — either
+ * self-heal (orphan deltas synthesize their block) or leave a console trace,
+ * because a silently dropped chunk shows up to the user as text that just
+ * stops mid-message.
+ */
+
+import { createToolUseBlock } from "./ws-message-processing-tool-blocks";
+import { nextSyntheticBlockId } from "./ws-message-processing-utils";
+import {
+  blockIdFromAgentMessage,
+  getOrCreateStreamContext,
+  getStreamSessionId,
+  type BlockMutation,
+  type StreamContext,
+  type StreamingState,
+} from "./ws-message-processing-core";
+
+export function processStreamEvent(
+  msg: Record<string, unknown>,
+  state: StreamingState,
+): BlockMutation[] {
+  const event = msg.event as Record<string, unknown> | undefined;
+  if (!event) return [];
+
+  const stream = getOrCreateStreamContext(state, getStreamSessionId(msg));
+  // The server stamps the active model onto every forwarded stream event. Seed
+  // `stream.model` from it so a client that missed `message_start` (e.g. a
+  // remote device that joined the turn late) still labels streamed text with
+  // the right model instead of "unknown".
+  if (typeof msg.model === "string") {
+    stream.model = msg.model;
+  }
+  const parentToolUseId = (msg.parent_tool_use_id as string) ?? null;
+  if (stream.parentToolUseId && stream.parentToolUseId !== parentToolUseId) {
+    const prevParent = state.toolUseIdToBlock.get(stream.parentToolUseId);
+    if (prevParent?.childBlocks) {
+      prevParent.taskComplete = true;
+    }
+  }
+  stream.parentToolUseId = parentToolUseId;
+
+  switch (event.type as string) {
+    case "message_start": {
+      const message = event.message as Record<string, unknown> | undefined;
+      if (message?.model) {
+        stream.model = message.model as string;
+      }
+      stream.contentBlockIds.clear();
+      return [];
+    }
+    case "content_block_start":
+      return processContentBlockStart(
+        event,
+        state,
+        stream,
+        parentToolUseId,
+        blockIdFromAgentMessage(msg),
+      );
+    case "content_block_delta":
+      return processContentBlockDelta(
+        event,
+        state,
+        stream,
+        parentToolUseId,
+        blockIdFromAgentMessage(msg),
+      );
+    // Envelope markers with no renderable content — intentionally ignored.
+    case "content_block_stop":
+    case "message_delta":
+    case "message_stop":
+      return [];
+    default:
+      console.warn("[agent-stream] dropping unknown stream event type", event.type);
+      return [];
+  }
+}
+
+function processContentBlockStart(
+  event: Record<string, unknown>,
+  state: StreamingState,
+  stream: StreamContext,
+  parentToolUseId: string | null,
+  persistedBlockId: string | null,
+): BlockMutation[] {
+  const index = event.index as number;
+  const contentBlock = event.content_block as Record<string, unknown> | undefined;
+  if (!contentBlock) return [];
+
+  // An unrenderable block type must NOT claim the index: leaving the index
+  // unregistered lets the first delta self-heal into a rendered block
+  // (processContentBlockDelta), instead of every delta updating a block that
+  // was never appended — which applyMutations silently discards.
+  if (!isRenderableContentBlockType(contentBlock.type)) {
+    console.warn("[agent-stream] unknown content block type at start", contentBlock.type);
+    return [];
+  }
+
+  const blockId = persistedBlockId ?? nextSyntheticBlockId(state);
+  stream.contentBlockIds.set(index, blockId);
+
+  switch (contentBlock.type as string) {
+    case "tool_use":
+      return [
+        {
+          action: "append",
+          block: createToolUseBlock(
+            state,
+            blockId,
+            contentBlock,
+            parentToolUseId,
+            new Date().toISOString(),
+            false,
+          ),
+        },
+      ];
+    case "thinking":
+      return [
+        {
+          action: "append",
+          block: {
+            id: blockId,
+            type: "thinking",
+            content: typeof contentBlock.thinking === "string" ? contentBlock.thinking : "",
+            parentToolUseId,
+            createdAt: new Date().toISOString(),
+          },
+        },
+      ];
+    case "text":
+      return [
+        {
+          action: "append",
+          block: {
+            id: blockId,
+            type: "text",
+            content: typeof contentBlock.text === "string" ? contentBlock.text : "",
+            parentToolUseId,
+            model: stream.model ?? undefined,
+            createdAt: new Date().toISOString(),
+          },
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
+function isRenderableContentBlockType(type: unknown): boolean {
+  return type === "tool_use" || type === "thinking" || type === "text";
+}
+
+/** Block type and content carried by a known delta type, or null for unknown. */
+function deltaPayload(
+  delta: Record<string, unknown>,
+): { type: "text" | "thinking" | "tool_call"; content: string } | null {
+  switch (delta.type as string) {
+    case "text_delta":
+      return { type: "text", content: (delta.text as string) ?? "" };
+    case "thinking_delta":
+      return { type: "thinking", content: (delta.thinking as string) ?? "" };
+    case "input_json_delta":
+      return { type: "tool_call", content: (delta.partial_json as string) ?? "" };
+    default:
+      return null;
+  }
+}
+
+function processContentBlockDelta(
+  event: Record<string, unknown>,
+  state: StreamingState,
+  stream: StreamContext,
+  parentToolUseId: string | null,
+  persistedBlockId: string | null,
+): BlockMutation[] {
+  const index = event.index as number;
+  const delta = event.delta as Record<string, unknown> | undefined;
+  if (!delta) return [];
+
+  const payload = deltaPayload(delta);
+  if (!payload) {
+    console.warn("[agent-stream] dropping unknown content delta type", delta.type);
+    return [];
+  }
+
+  const knownBlockId = persistedBlockId ?? stream.contentBlockIds.get(index);
+  if (persistedBlockId) {
+    stream.contentBlockIds.set(index, persistedBlockId);
+  }
+
+  // Self-heal an orphan delta: if the `content_block_start` for this index was
+  // never seen (lost envelope, block type we couldn't render at start),
+  // dropping the delta would silently discard every following chunk of this
+  // block — the text visibly "stops mid-message" while the backend keeps
+  // persisting fine. Synthesize the block from the first delta instead, so
+  // this and all subsequent deltas render.
+  if (!knownBlockId) {
+    console.warn(
+      "[agent-stream] content_block_delta for unseen block index; synthesizing block",
+      index,
+    );
+    const blockId = nextSyntheticBlockId(state);
+    stream.contentBlockIds.set(index, blockId);
+    return [
+      {
+        action: "append",
+        block: {
+          id: blockId,
+          type: payload.type,
+          content: payload.content,
+          parentToolUseId,
+          model: payload.type === "text" ? (stream.model ?? undefined) : undefined,
+          createdAt: new Date().toISOString(),
+        },
+      },
+    ];
+  }
+
+  return [
+    { action: "update", block: { id: knownBlockId, type: payload.type, content: payload.content } },
+  ];
+}

--- a/packages/desktop/src/stores/ws-message-processing.test.ts
+++ b/packages/desktop/src/stores/ws-message-processing.test.ts
@@ -299,3 +299,137 @@ describe("server-stamped model on stream events", () => {
     expect(result.mutations[0].block.model).toBeUndefined();
   });
 });
+
+describe("stream resilience — fault injection", () => {
+  const streamEvent = (event: Record<string, unknown>): Record<string, unknown> => ({
+    type: "stream_event",
+    session_id: "thread",
+    event,
+  });
+
+  it("self-heals an orphan delta whose content_block_start was never seen", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const state = createStreamingState();
+    // The start envelope for index 0 was lost. Dropping this delta would also
+    // drop every following delta of the block — text stopping mid-message.
+    const first = processSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "recovered " },
+      }),
+      state,
+    );
+    expect(first.mutations).toHaveLength(1);
+    expect(first.mutations[0].action).toBe("append");
+    expect(first.mutations[0].block.type).toBe("text");
+    expect(first.mutations[0].block.content).toBe("recovered ");
+
+    // The next delta for the same index updates the synthesized block.
+    const second = processSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "tail" },
+      }),
+      state,
+    );
+    expect(second.mutations).toHaveLength(1);
+    expect(second.mutations[0].action).toBe("update");
+    expect(second.mutations[0].block.id).toBe(first.mutations[0].block.id);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("self-heals deltas that follow an unrenderable content_block_start", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const state = createStreamingState();
+    // A block type we can't render must not claim the index…
+    const start = processSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "server_tool_use", id: "srv1", name: "web_search" },
+      }),
+      state,
+    );
+    expect(start.mutations).toHaveLength(0);
+
+    // …so its deltas synthesize a renderable block instead of vanishing.
+    const delta = processSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"query":' },
+      }),
+      state,
+    );
+    expect(delta.mutations).toHaveLength(1);
+    expect(delta.mutations[0].action).toBe("append");
+    expect(delta.mutations[0].block.type).toBe("tool_call");
+    warn.mockRestore();
+  });
+
+  it("drops an unknown delta type with a trace, without corrupting the stream", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const state = createStreamingState();
+    processSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      state,
+    );
+    const unknown = processSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "signature_delta", signature: "abc" },
+      }),
+      state,
+    );
+    expect(unknown.mutations).toHaveLength(0);
+    expect(warn).toHaveBeenCalledWith(
+      "[agent-stream] dropping unknown content delta type",
+      "signature_delta",
+    );
+
+    // A known delta for the same block still lands.
+    const text = processSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "still streaming" },
+      }),
+      state,
+    );
+    expect(text.mutations).toHaveLength(1);
+    warn.mockRestore();
+  });
+
+  it("warns on unknown stream event and message types, but not on envelope markers", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const state = createStreamingState();
+
+    processSdkMessage(streamEvent({ type: "some_future_event", foo: 1 }), state);
+    expect(warn).toHaveBeenCalledWith(
+      "[agent-stream] dropping unknown stream event type",
+      "some_future_event",
+    );
+
+    processSdkMessage({ type: "some_future_message", session_id: "s" }, state);
+    expect(warn).toHaveBeenCalledWith(
+      "[agent-stream] dropping unknown message type",
+      "some_future_message",
+    );
+
+    // Intentionally-ignored markers must stay silent — no warn spam per block.
+    warn.mockClear();
+    processSdkMessage(streamEvent({ type: "content_block_stop", index: 0 }), state);
+    processSdkMessage(streamEvent({ type: "message_stop" }), state);
+    processSdkMessage({ type: "result", session_id: "s" }, state);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/desktop/src/stores/ws-session-resync.ts
+++ b/packages/desktop/src/stores/ws-session-resync.ts
@@ -16,7 +16,7 @@
 import { getFeatureAgentState } from "@/api/generated";
 import { serverBlocksToAgentBlocks } from "@/hooks/useFeatureAgentState";
 import type { AgentBlockData } from "@/components/AgentBlock";
-import { blocksPatchWithDerived } from "./ws-message-processing";
+import { blocksPatchWithDerived, type StreamingState } from "./ws-message-processing";
 import { updateSession, type ResyncTarget } from "./ws-session-types";
 import type { StoreAccessors } from "./ws-envelope-handler";
 
@@ -95,4 +95,128 @@ export async function resyncMessagesOnReconnect(
       lastAppliedMessageId: nextCursor,
     }),
   );
+}
+
+/**
+ * Detect a dropped `session.message` envelope via the backend's per-stream
+ * `seq` stamp. A gap means content was lost in transit — resync missed rows
+ * from the DB now, and mark the stream for a tail repair at turn end (a
+ * truncated in-flight block can't be rewritten while deltas still race in).
+ * A seq lower than expected is a stream-reader restart, not a gap.
+ */
+export function trackStreamSeq(
+  ctx: StoreAccessors,
+  sessionId: string,
+  state: StreamingState,
+  seq: number | null,
+): void {
+  if (seq == null) return;
+  const last = state.lastMessageSeq;
+  state.lastMessageSeq = seq;
+  if (last == null || seq <= last + 1) return;
+  console.warn("[ws-session] stream envelope gap detected; resyncing", {
+    expected: last + 1,
+    received: seq,
+  });
+  state.tailRepairNeeded = true;
+  resyncMessagesOnReconnect(ctx, sessionId).catch((err: unknown) => {
+    console.warn("[ws-session] gap resync failed; tail repair will retry at turn end", err);
+  });
+}
+
+/**
+ * Post-turn repair for a stream that dropped envelopes mid-turn (detected via
+ * the `seq` gap). The reconnect resync above only *appends* missed rows — a
+ * block we already hold whose deltas were lost stays truncated because its id
+ * is deduped. Once the turn has ended (no more in-flight deltas to race), the
+ * DB is the authoritative transcript: refetch it and overwrite any held block
+ * whose persisted content is longer than what we rendered.
+ */
+export async function repairPersistedBlocksAfterTurn(
+  ctx: StoreAccessors,
+  sessionId: string,
+): Promise<void> {
+  const session = ctx.get().sessions[sessionId];
+  if (!session?.featureId || !session.sessionDbId) return;
+
+  const data = await getFeatureAgentState(session.featureId);
+  const serverSession = data.sessions.find((s) => s.sessionDbId === session.sessionDbId);
+  if (!serverSession) return;
+
+  const fetched = serverBlocksToAgentBlocks(serverSession.blocks as never[]);
+  const current = ctx.get().sessions[sessionId];
+  if (!current) return;
+
+  const serverById = new Map<string, AgentBlockData>();
+  collectBlockTree(fetched, serverById);
+
+  let changed = false;
+  const markChanged = () => {
+    changed = true;
+  };
+  const repaired = current.blocks.map((block) => repairBlockTree(block, serverById, markChanged));
+
+  const heldIds = new Set<string>();
+  collectBlockTree(current.blocks, heldIds);
+  const appended = fetched.filter((b) => !heldIds.has(b.id));
+
+  if (!changed && appended.length === 0) return;
+  console.warn("[ws-session] repaired stream-truncated blocks from persisted transcript", {
+    replaced: changed,
+    appended: appended.length,
+  });
+  ctx.set(
+    updateSession(ctx.get(), sessionId, {
+      ...blocksPatchWithDerived(current.streamingState, [...repaired, ...appended]),
+      lastAppliedMessageId: Math.max(
+        current.lastAppliedMessageId ?? 0,
+        serverSession.maxMessageId ?? 0,
+      ),
+    }),
+  );
+}
+
+function collectBlockTree(
+  blocks: AgentBlockData[],
+  into: Map<string, AgentBlockData> | Set<string>,
+): void {
+  for (const block of blocks) {
+    if (into instanceof Set) {
+      into.add(block.id);
+    } else {
+      into.set(block.id, block);
+    }
+    if (block.childBlocks?.length) collectBlockTree(block.childBlocks, into);
+  }
+}
+
+/**
+ * Overwrite a held block's content with the persisted version when the DB has
+ * strictly more of it (a lost delta always leaves the client behind, never
+ * ahead — the backend persists before it forwards). Recurses into children;
+ * returns the original reference when nothing changed so React sees no-ops.
+ */
+function repairBlockTree(
+  block: AgentBlockData,
+  serverById: Map<string, AgentBlockData>,
+  markChanged: () => void,
+): AgentBlockData {
+  let next = block;
+
+  const server = serverById.get(block.id);
+  if (server && server.content !== block.content && server.content.length > block.content.length) {
+    next = { ...block, content: server.content, toolArgs: server.toolArgs ?? block.toolArgs };
+    markChanged();
+  }
+
+  if (block.childBlocks?.length) {
+    const children = block.childBlocks.map((child) =>
+      repairBlockTree(child, serverById, markChanged),
+    );
+    if (children.some((child, i) => child !== block.childBlocks?.[i])) {
+      next = { ...next, childBlocks: children };
+    }
+  }
+
+  return next;
 }

--- a/packages/desktop/src/stores/ws-session-store.ts
+++ b/packages/desktop/src/stores/ws-session-store.ts
@@ -293,8 +293,11 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
           let envelope: WsEnvelope;
           try {
             envelope = parseEnvelope(data);
-          } catch {
-            return; // genuinely unparseable — skip
+          } catch (err) {
+            // Never drop silently: a discarded envelope can be a lost stream
+            // chunk, which shows up as text stopping mid-message with no clue.
+            console.warn("[ws-session] dropping unparseable envelope:", err);
+            return;
           }
           try {
             handleEnvelope(ctx, sessionId, envelope);

--- a/packages/service/src/domain/agents/claude_code/events.rs
+++ b/packages/service/src/domain/agents/claude_code/events.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use tracing::warn;
 
 use crate::domain::agents::adapter::{
     RuntimeAssistantMessage, RuntimeCompactMetadata, RuntimeContentBlock, RuntimeContentDelta,
@@ -66,6 +67,13 @@ fn api_error_text(
     }
 }
 
+/// The `type` tag of a raw wire payload, for drop-trace logging.
+fn raw_type(raw: &Value) -> &str {
+    raw.get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("<missing>")
+}
+
 fn map_content_block(block: &claude_agent_sdk_rs::types::ContentBlock) -> RuntimeContentBlock {
     match block {
         claude_agent_sdk_rs::types::ContentBlock::Text { text } => {
@@ -83,7 +91,18 @@ fn map_content_block(block: &claude_agent_sdk_rs::types::ContentBlock) -> Runtim
                 input: input.clone(),
             }
         }
-        _ => RuntimeContentBlock::Other,
+        // Modeled but intentionally not rendered as assistant content.
+        claude_agent_sdk_rs::types::ContentBlock::ToolResult { .. } => RuntimeContentBlock::Other,
+        // A block type the SDK doesn't model. Its content can't render, but it
+        // must never vanish without a trace (the "stopped mid-message with no
+        // reason" class) — log exactly what the CLI sent.
+        claude_agent_sdk_rs::types::ContentBlock::Other(raw) => {
+            warn!(
+                block_type = raw_type(raw),
+                "claude adapter: unmodeled content block dropped from rendering"
+            );
+            RuntimeContentBlock::Other
+        }
     }
 }
 
@@ -130,8 +149,17 @@ fn map_stream_event(event: &claude_agent_sdk_rs::StreamEventData) -> RuntimeStre
                     }
                 }
                 // An unknown delta type carries nothing we can render; treat the
-                // whole event as `Other` rather than fabricating a delta.
-                claude_agent_sdk_rs::types::ContentDelta::Other => RuntimeStreamEvent::Other,
+                // whole event as `Other` rather than fabricating a delta — but
+                // log it: a CLI that starts streaming a new delta type would
+                // otherwise look like text that just stops mid-message.
+                claude_agent_sdk_rs::types::ContentDelta::Other(raw) => {
+                    warn!(
+                        delta_type = raw_type(raw),
+                        index,
+                        "claude adapter: unmodeled content delta dropped from the live stream"
+                    );
+                    RuntimeStreamEvent::Other
+                }
             }
         }
         claude_agent_sdk_rs::StreamEventData::ContentBlockStop { index } => {
@@ -139,7 +167,18 @@ fn map_stream_event(event: &claude_agent_sdk_rs::StreamEventData) -> RuntimeStre
                 index: u64::from(*index),
             }
         }
-        _ => RuntimeStreamEvent::Other,
+        // Modeled and intentionally unmapped: turn accounting comes from the
+        // `Result` message, not these envelope markers.
+        claude_agent_sdk_rs::StreamEventData::MessageDelta { .. }
+        | claude_agent_sdk_rs::StreamEventData::MessageStop => RuntimeStreamEvent::Other,
+        // A stream event type the SDK doesn't model — log what was dropped.
+        claude_agent_sdk_rs::StreamEventData::Other(raw) => {
+            warn!(
+                event_type = raw_type(raw),
+                "claude adapter: unmodeled stream event dropped"
+            );
+            RuntimeStreamEvent::Other
+        }
     }
 }
 
@@ -188,46 +227,26 @@ pub(super) fn normalize_event(msg: claude_agent_sdk_rs::SdkMessage) -> RuntimeEv
         raw: serde_json::to_value(&msg).unwrap_or(Value::Null),
     };
 
+    let (kind, result_error) = classify_message(msg);
+
+    RuntimeEvent::new(metadata, kind)
+        .with_background_agent(background_agent)
+        .with_result_error(result_error)
+}
+
+/// Map an `SdkMessage` to its runtime event kind plus, for a failing `Result`,
+/// the extracted [`RuntimeResultError`]. Split out of [`normalize_event`]
+/// (which keeps metadata assembly) so each stays within the function-size
+/// budget. The match is intentionally exhaustive — no `_` catch-all — so a new
+/// SDK variant is a compile error here instead of a silent drop.
+fn classify_message(
+    msg: claude_agent_sdk_rs::SdkMessage,
+) -> (RuntimeEventKind, Option<RuntimeResultError>) {
     // Populated by a failing (`is_error`) `Result`; see `RuntimeResultError`.
     let mut result_error: Option<RuntimeResultError> = None;
 
     let kind = match msg {
-        claude_agent_sdk_rs::SdkMessage::System(system) => match system {
-            claude_agent_sdk_rs::messages::SystemMessage::Init {
-                model, mcp_servers, ..
-            } => {
-                let context_window = init_model_context_window(&model);
-                RuntimeEventKind::Init(RuntimeInitEvent {
-                    model: Some(model),
-                    mcp_servers: mcp_servers
-                        .into_iter()
-                        .map(|server| RuntimeMcpServerStatus {
-                            name: server.name,
-                            status: server.status,
-                        })
-                        .collect(),
-                    context_window,
-                })
-            }
-            claude_agent_sdk_rs::messages::SystemMessage::CompactBoundary {
-                compact_metadata,
-                ..
-            } => RuntimeEventKind::CompactBoundary {
-                metadata: Some(RuntimeCompactMetadata {
-                    trigger: Some(compact_metadata.trigger),
-                    pre_tokens: Some(compact_metadata.pre_tokens),
-                }),
-            },
-            status @ claude_agent_sdk_rs::messages::SystemMessage::Status { .. } => {
-                if status.is_compaction_started() {
-                    RuntimeEventKind::TurnStarted {
-                        source: RuntimeTurnStartedSource::ManualCompact,
-                    }
-                } else {
-                    RuntimeEventKind::Other
-                }
-            }
-        },
+        claude_agent_sdk_rs::SdkMessage::System(system) => classify_system_message(system),
         claude_agent_sdk_rs::SdkMessage::Assistant {
             message,
             parent_tool_use_id,
@@ -292,29 +311,107 @@ pub(super) fn normalize_event(msg: claude_agent_sdk_rs::SdkMessage) -> RuntimeEv
             }
             RuntimeEventKind::Result
         }
-        // A message type the SDK has never seen. Keep the raw payload so the
-        // stream reader can surface it to the conversation instead of dropping
-        // it silently — the silent-stop users couldn't diagnose. EXCEPT
-        // `system` messages: those are operational metadata, not conversation
-        // content, and the run-in-background agent protocol (issue #58) emits
-        // `system/task_started` / `system/task_notification` that arrive here
-        // as Unknown by design. Surfacing those as visible errors would spam
-        // the conversation on every background-agent run, so an unknown
-        // `system` subtype stays silent (`Other`) like every other operational
-        // message; only genuinely-unknown NON-system messages reach the user.
-        claude_agent_sdk_rs::SdkMessage::Unknown(raw) => {
-            if raw.get("type").and_then(Value::as_str) == Some("system") {
-                RuntimeEventKind::Other
-            } else {
-                RuntimeEventKind::Unknown { raw }
-            }
-        }
-        _ => RuntimeEventKind::Other,
+        claude_agent_sdk_rs::SdkMessage::Unknown(raw) => classify_unknown_message(raw),
+        // Modeled operational messages, intentionally not part of the
+        // conversation. Listed explicitly (no `_` catch-all) so a future SDK
+        // variant is a compile error here instead of a silent drop.
+        claude_agent_sdk_rs::SdkMessage::Status { .. }
+        | claude_agent_sdk_rs::SdkMessage::HookStarted { .. }
+        | claude_agent_sdk_rs::SdkMessage::HookProgress { .. }
+        | claude_agent_sdk_rs::SdkMessage::HookResponse { .. }
+        | claude_agent_sdk_rs::SdkMessage::ToolProgress { .. }
+        | claude_agent_sdk_rs::SdkMessage::AuthStatus { .. }
+        | claude_agent_sdk_rs::SdkMessage::TaskNotification { .. }
+        | claude_agent_sdk_rs::SdkMessage::TaskStarted { .. }
+        | claude_agent_sdk_rs::SdkMessage::TaskProgress { .. }
+        | claude_agent_sdk_rs::SdkMessage::FilesPersisted { .. }
+        | claude_agent_sdk_rs::SdkMessage::RateLimit { .. }
+        | claude_agent_sdk_rs::SdkMessage::PromptSuggestion { .. } => RuntimeEventKind::Other,
     };
 
-    RuntimeEvent::new(metadata, kind)
-        .with_background_agent(background_agent)
-        .with_result_error(result_error)
+    (kind, result_error)
+}
+
+/// Map a `system` message to its runtime event kind. Compaction start is a
+/// synthetic turn boundary; its end/failure is carried by the typed
+/// `CompactBoundary` and the compact command's own response, so other status
+/// values are operational and unmapped — but a status we've never seen must
+/// leave a trace.
+fn classify_system_message(
+    system: claude_agent_sdk_rs::messages::SystemMessage,
+) -> RuntimeEventKind {
+    match system {
+        claude_agent_sdk_rs::messages::SystemMessage::Init {
+            model, mcp_servers, ..
+        } => {
+            let context_window = init_model_context_window(&model);
+            RuntimeEventKind::Init(RuntimeInitEvent {
+                model: Some(model),
+                mcp_servers: mcp_servers
+                    .into_iter()
+                    .map(|server| RuntimeMcpServerStatus {
+                        name: server.name,
+                        status: server.status,
+                    })
+                    .collect(),
+                context_window,
+            })
+        }
+        claude_agent_sdk_rs::messages::SystemMessage::CompactBoundary {
+            compact_metadata, ..
+        } => RuntimeEventKind::CompactBoundary {
+            metadata: Some(RuntimeCompactMetadata {
+                trigger: Some(compact_metadata.trigger),
+                pre_tokens: Some(compact_metadata.pre_tokens),
+            }),
+        },
+        status @ claude_agent_sdk_rs::messages::SystemMessage::Status { .. } => {
+            if status.is_compaction_started() {
+                RuntimeEventKind::TurnStarted {
+                    source: RuntimeTurnStartedSource::ManualCompact,
+                }
+            } else {
+                if let claude_agent_sdk_rs::messages::SystemMessage::Status {
+                    status: Some(value),
+                    compact_result: None,
+                    compact_error: None,
+                    ..
+                } = &status
+                {
+                    warn!(status = %value, "claude adapter: unrecognized system status dropped");
+                }
+                RuntimeEventKind::Other
+            }
+        }
+    }
+}
+
+/// Map an unmodeled (`Unknown`) message to its runtime event kind. Keep the raw
+/// payload so the stream reader can surface it to the conversation instead of
+/// dropping it silently — the silent-stop class users couldn't diagnose. EXCEPT
+/// `system` messages: those are operational metadata, not conversation content,
+/// and the run-in-background agent protocol (issue #58) emits
+/// `system/task_started` / `system/task_notification` that arrive here as
+/// Unknown by design. Surfacing those as visible errors would spam the
+/// conversation on every background-agent run, so an unknown `system` subtype
+/// stays out of the conversation (`Other`) — but only the allowlisted
+/// background-task subtypes stay *quiet*; anything else logs loudly so a CLI
+/// drift is diagnosable from the service log.
+fn classify_unknown_message(raw: Value) -> RuntimeEventKind {
+    if raw_type(&raw) == "system" {
+        let subtype = raw.get("subtype").and_then(Value::as_str);
+        const IGNORED_SYSTEM_SUBTYPES: [&str; 3] =
+            ["task_started", "task_notification", "task_progress"];
+        if !subtype.is_some_and(|s| IGNORED_SYSTEM_SUBTYPES.contains(&s)) {
+            warn!(
+                subtype = subtype.unwrap_or("<missing>"),
+                "claude adapter: unrecognized system message dropped"
+            );
+        }
+        RuntimeEventKind::Other
+    } else {
+        RuntimeEventKind::Unknown { raw }
+    }
 }
 
 /// Assemble a [`RuntimeResultError`] from a failing Claude Code `Result`.
@@ -433,6 +530,27 @@ mod tests {
             event.background_agent_signal().is_some(),
             "the background-agent signal must still be derived from the raw message"
         );
+    }
+
+    #[test]
+    fn normalize_event_surfaces_unknown_non_system_messages() {
+        // The counterpart to the `system` carve-out above: a message whose
+        // `type` the SDK models no schema for — and which is NOT operational
+        // `system` metadata — must reach the conversation verbatim rather than
+        // vanish. This is the whole point of the raw-preserving `Unknown`
+        // fallback: the "stopped mid-message with no reason" class.
+        let msg: claude_agent_sdk_rs::SdkMessage = serde_json::from_value(json!({
+            "type": "some_future_message_type", "session_id": "s", "payload": { "text": "hi" }
+        }))
+        .expect("unknown message deserializes infallibly");
+        assert!(matches!(msg, claude_agent_sdk_rs::SdkMessage::Unknown(_)));
+
+        let event = normalize_event(msg);
+        let raw = event
+            .unknown_message()
+            .expect("an unknown non-system message must surface verbatim");
+        assert_eq!(raw["type"], "some_future_message_type");
+        assert_eq!(raw["payload"]["text"], "hi");
     }
 
     #[test]

--- a/packages/service/src/domain/ws_session/handler/session_prompt.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt.rs
@@ -12,6 +12,7 @@ mod prompt_send;
 mod prompt_status;
 mod prompt_worktree;
 mod runtime_mcp;
+mod stream_diagnostics;
 mod stream_reader;
 mod stream_reader_background_agents;
 mod stream_reader_forward;

--- a/packages/service/src/domain/ws_session/handler/session_prompt/stream_diagnostics.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/stream_diagnostics.rs
@@ -1,0 +1,157 @@
+//! Per-stream wire-tap diagnostics (issue #78).
+//!
+//! Every silent-stop investigation so far began with "we have no idea what
+//! the CLI actually sent". This keeps a bounded ring buffer of the raw
+//! provider events a stream reader saw and, when a turn ends abnormally,
+//! dumps the tail to a file under `~/.cadencr/diagnostics/` so the surfaced
+//! error can point at concrete evidence instead of asking the user to
+//! reproduce with logging enabled. Conforms to
+//! `.claude/rules/inline-rust-tests.md`.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use tracing::warn;
+
+/// Bounded tail of raw events kept per stream reader.
+const MAX_EVENTS: usize = 200;
+/// Cap per recorded event so one huge payload can't dominate the buffer.
+const MAX_EVENT_CHARS: usize = 2000;
+
+pub(super) struct StreamDiagnostics {
+    events: VecDeque<String>,
+}
+
+impl StreamDiagnostics {
+    pub(super) fn new() -> Self {
+        Self {
+            events: VecDeque::with_capacity(MAX_EVENTS),
+        }
+    }
+
+    /// Record one raw provider event (newest last, oldest evicted). Called for
+    /// every streamed event, so the common (small) payload must stay cheap:
+    /// byte length ≥ char count for UTF-8, so the O(1) `len()` guard skips the
+    /// O(n) char scan unless the payload actually exceeds the cap.
+    pub(super) fn record(&mut self, raw: &serde_json::Value) {
+        let serialized = raw.to_string();
+        let entry: String =
+            if serialized.len() > MAX_EVENT_CHARS && serialized.chars().count() > MAX_EVENT_CHARS {
+                let mut truncated: String = serialized.chars().take(MAX_EVENT_CHARS).collect();
+                truncated.push_str("… (truncated)");
+                truncated
+            } else {
+                serialized
+            };
+        if self.events.len() == MAX_EVENTS {
+            self.events.pop_front();
+        }
+        self.events.push_back(entry);
+    }
+
+    /// Write the recorded tail to a diagnostics file and return its path.
+    /// Returns `None` (with a log) when writing fails — the caller's error
+    /// message simply omits the pointer; surfacing the original agent error
+    /// must never depend on this file.
+    pub(super) fn dump(
+        &self,
+        db_session_id: i64,
+        reason: &str,
+        error_detail: Option<&str>,
+    ) -> Option<PathBuf> {
+        let dir = diagnostics_dir();
+        if let Err(error) = std::fs::create_dir_all(&dir) {
+            warn!(db_session_id, %error, "failed to create diagnostics dir");
+            return None;
+        }
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let path = dir.join(format!("session-{db_session_id}-{timestamp}.log"));
+
+        let mut content = format!(
+            "Cadencr agent-stream diagnostics\nsession: {db_session_id}\nreason: {reason}\n"
+        );
+        if let Some(detail) = error_detail {
+            content.push_str(&format!("error: {detail}\n"));
+        }
+        content.push_str(&format!(
+            "--- last {} provider events (newest last) ---\n",
+            self.events.len()
+        ));
+        for event in &self.events {
+            content.push_str(event);
+            content.push('\n');
+        }
+
+        match std::fs::write(&path, content) {
+            Ok(()) => Some(path),
+            Err(error) => {
+                warn!(db_session_id, %error, "failed to write diagnostics dump");
+                None
+            }
+        }
+    }
+}
+
+/// `~/.cadencr/diagnostics` in production (sibling of the settings dir); an
+/// isolated per-test dir in test builds via the settings-dir test override.
+fn diagnostics_dir() -> PathBuf {
+    let settings = crate::domain::settings_store::dir::global_dir();
+    settings
+        .parent()
+        .map(|parent| parent.join("diagnostics"))
+        .unwrap_or_else(|| settings.join("diagnostics"))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{StreamDiagnostics, MAX_EVENTS};
+
+    #[test]
+    fn record_keeps_only_the_newest_events() {
+        let mut diagnostics = StreamDiagnostics::new();
+        for i in 0..(MAX_EVENTS + 10) {
+            diagnostics.record(&json!({ "type": "stream_event", "n": i }));
+        }
+        assert_eq!(diagnostics.events.len(), MAX_EVENTS);
+        assert!(
+            diagnostics
+                .events
+                .back()
+                .unwrap()
+                .contains(&format!("\"n\":{}", MAX_EVENTS + 9)),
+            "newest event must be kept"
+        );
+        assert!(
+            diagnostics.events.front().unwrap().contains("\"n\":10"),
+            "oldest events must be evicted"
+        );
+    }
+
+    #[test]
+    fn record_truncates_oversized_events() {
+        let mut diagnostics = StreamDiagnostics::new();
+        diagnostics.record(&json!({ "type": "assistant", "text": "x".repeat(10_000) }));
+        let entry = diagnostics.events.front().unwrap();
+        assert!(entry.chars().count() < 3000);
+        assert!(entry.ends_with("… (truncated)"));
+    }
+
+    #[test]
+    fn dump_writes_reason_error_and_events() {
+        let mut diagnostics = StreamDiagnostics::new();
+        diagnostics.record(&json!({ "type": "stream_event", "marker": "evt-1" }));
+        let path = diagnostics
+            .dump(42, "AGENT_STOPPED", Some("boom"))
+            .expect("dump must write");
+        let content = std::fs::read_to_string(&path).expect("dump file readable");
+        assert!(content.contains("session: 42"));
+        assert!(content.contains("reason: AGENT_STOPPED"));
+        assert!(content.contains("error: boom"));
+        assert!(content.contains("evt-1"));
+    }
+}

--- a/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task.rs
@@ -71,6 +71,15 @@ pub(super) struct StreamReaderState {
     /// premature eviction (e.g. on a nested-agent `MessageStart`) would wrongly
     /// drop it mid-run.
     pub(super) live_background_agents: HashSet<String>,
+    /// Monotonic counter stamped onto every `session.message` envelope this
+    /// reader emits, so clients can detect a dropped envelope (gap) and
+    /// resync. Restarts at 1 with each reader; clients treat a lower-than-
+    /// expected value as a stream restart, not a gap.
+    pub(super) message_seq: u64,
+    /// Bounded wire tap of the raw provider events this reader saw, dumped to
+    /// a file when the turn ends abnormally so the surfaced error can point at
+    /// evidence (issue #78).
+    pub(super) diagnostics: super::stream_diagnostics::StreamDiagnostics,
 }
 
 enum ReaderAction {
@@ -95,6 +104,8 @@ impl StreamReaderState {
             compacting: false,
             surfaced_error_this_turn: false,
             live_background_agents: HashSet::new(),
+            message_seq: 0,
+            diagnostics: super::stream_diagnostics::StreamDiagnostics::new(),
         }
     }
 }
@@ -146,14 +157,14 @@ impl StreamReaderTask {
                 ReaderAction::Break => break,
                 ReaderAction::Closed => {
                     if self.stream_close_was_unexpected(&state).await {
-                        self.handle_unexpected_stop().await;
+                        self.handle_unexpected_stop(&state).await;
                     } else {
                         self.send_stream_closed().await;
                     }
                     break;
                 }
                 ReaderAction::Error(error) => {
-                    self.handle_stream_error(error).await;
+                    self.handle_stream_error(&state, error).await;
                     break;
                 }
                 ReaderAction::Event(runtime_event) => {

--- a/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task_completion.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task_completion.rs
@@ -58,11 +58,13 @@ impl StreamReaderTask {
                 serde_json::Value::String(model.to_string()),
             );
         }
+        state.message_seq += 1;
         Some(WsEnvelope::new(
             "session",
             "message",
             serde_json::to_value(SessionMessagePayload {
                 blocks: vec![block],
+                seq: Some(state.message_seq),
             })
             .unwrap(),
         ))
@@ -116,13 +118,19 @@ impl StreamReaderTask {
         ))
     }
 
-    pub(super) async fn handle_stream_error(&self, error: RuntimeError) {
+    pub(super) async fn handle_stream_error(&self, state: &StreamReaderState, error: RuntimeError) {
         let code = match &error {
             RuntimeError::CompactFailed(_) => "COMPACT_ERROR",
             _ => "SDK_ERROR",
         };
-        let message = error.to_string();
+        let mut message = error.to_string();
         error!(self.db_session_id, error = %message, "SDK stream error");
+        if let Some(path) = state
+            .diagnostics
+            .dump(self.db_session_id, code, Some(&message))
+        {
+            message.push_str(&format!("\n\nDiagnostics saved to: {}", path.display()));
+        }
         self.surface_session_error(code, message).await;
     }
 
@@ -182,16 +190,19 @@ impl StreamReaderTask {
     /// (handled via [`Self::handle_stream_error`]); this covers the genuinely
     /// silent case (clean code-0 exit, empty stderr) so the user sees an error
     /// instead of an agent that simply froze.
-    pub(super) async fn handle_unexpected_stop(&self) {
+    pub(super) async fn handle_unexpected_stop(&self, state: &StreamReaderState) {
         error!(
             self.db_session_id,
             "SDK stream closed mid-turn without a result"
         );
-        self.surface_session_error(
-            "AGENT_STOPPED",
-            "The agent stopped unexpectedly before finishing its turn.".to_string(),
-        )
-        .await;
+        let mut message = "The agent stopped unexpectedly before finishing its turn.".to_string();
+        if let Some(path) = state
+            .diagnostics
+            .dump(self.db_session_id, "AGENT_STOPPED", None)
+        {
+            message.push_str(&format!("\n\nDiagnostics saved to: {}", path.display()));
+        }
+        self.surface_session_error("AGENT_STOPPED", message).await;
     }
 
     pub(super) async fn send_stream_closed(&self) {

--- a/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task_error.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task_error.rs
@@ -1,4 +1,4 @@
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::domain::agents::adapter::RuntimeEvent;
 
@@ -83,6 +83,11 @@ impl StreamReaderTask {
             return false;
         };
         if already_surfaced {
+            debug!(
+                self.db_session_id,
+                code = error.code,
+                "suppressing duplicate error result (an error was already surfaced this turn)"
+            );
             return false;
         }
         error!(

--- a/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task_event.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/stream_reader_task_event.rs
@@ -29,6 +29,7 @@ impl StreamReaderTask {
         runtime_event: RuntimeEvent,
     ) {
         state.last_runtime_activity = tokio::time::Instant::now();
+        state.diagnostics.record(runtime_event.raw_json());
         self.forward_compaction_state(state, &runtime_event).await;
         track_background_agents(&mut state.live_background_agents, &runtime_event);
 

--- a/packages/service/src/domain/ws_session/handler/tests/stream_reader.rs
+++ b/packages/service/src/domain/ws_session/handler/tests/stream_reader.rs
@@ -837,3 +837,95 @@ async fn test_error_result_after_provider_error_does_not_double_surface() {
     .unwrap();
     assert_eq!(count, 1, "only one error message persisted");
 }
+
+#[tokio::test]
+async fn test_session_message_envelopes_carry_monotonic_seq() {
+    // Clients detect a dropped stream envelope (silently truncated message)
+    // via the per-stream `seq` stamp — it must be present and strictly
+    // increasing on every `session.message` this reader emits.
+    let app_state = make_test_app_state().await;
+    let sdk_sessions: SdkSessions = Arc::new(Mutex::new(HashMap::new()));
+    let (ws_tx, mut ws_rx) = mpsc::unbounded_channel();
+
+    let db_session_id = 95i64;
+    let feature_id = 1i64;
+
+    sqlx::query("INSERT INTO agent_sessions (id, feature_id, status) VALUES (?, ?, 'running')")
+        .bind(db_session_id)
+        .bind(feature_id)
+        .execute(&app_state.write_pool)
+        .await
+        .unwrap();
+    {
+        let mut sessions = sdk_sessions.lock().await;
+        sessions.insert(
+            db_session_id,
+            make_active_handle(feature_id, Some("cli".into())),
+        );
+    }
+
+    let (msg_tx, msg_rx) = mpsc::channel::<Result<RuntimeEvent, RuntimeError>>(4);
+    for text in ["hello ", "world"] {
+        msg_tx
+            .send(Ok(RuntimeEvent::new(
+                crate::domain::agents::adapter::RuntimeEventMetadata {
+                    session_id: Some("cli".to_string()),
+                    usage: None,
+                    context_window: None,
+                    raw: serde_json::json!({
+                        "type": "stream_event",
+                        "event": {
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": { "type": "text_delta", "text": text }
+                        }
+                    }),
+                },
+                RuntimeEventKind::StreamEvent {
+                    event: crate::domain::agents::adapter::RuntimeStreamEvent::ContentBlockDelta {
+                        index: 0,
+                        delta: crate::domain::agents::adapter::RuntimeContentDelta::Text {
+                            text: text.to_string(),
+                        },
+                    },
+                    parent_tool_use_id: None,
+                },
+            )))
+            .await
+            .unwrap();
+    }
+    drop(msg_tx);
+
+    spawn_test_stream_reader(
+        &app_state,
+        db_session_id,
+        feature_id,
+        msg_rx,
+        ws_tx,
+        sdk_sessions.clone(),
+        crate::domain::agents::runtime::DEFAULT_PROVIDER,
+    );
+
+    let mut seqs: Vec<u64> = Vec::new();
+    while let Ok(Some(msg)) =
+        tokio::time::timeout(std::time::Duration::from_secs(2), ws_rx.recv()).await
+    {
+        if let Message::Text(text) = msg {
+            let env: WsEnvelope = serde_json::from_str(&text).unwrap();
+            if env.action == "message" {
+                let payload: SessionMessagePayload = serde_json::from_value(env.payload).unwrap();
+                seqs.push(
+                    payload
+                        .seq
+                        .expect("streamed session.message must carry seq"),
+                );
+            }
+        }
+    }
+    assert_eq!(
+        seqs,
+        (1..=seqs.len() as u64).collect::<Vec<_>>(),
+        "seq must start at 1 and increase without gaps"
+    );
+    assert!(seqs.len() >= 2, "both deltas must be forwarded");
+}

--- a/packages/service/src/domain/ws_session/protocol.rs
+++ b/packages/service/src/domain/ws_session/protocol.rs
@@ -278,6 +278,7 @@ mod tests {
         // SessionMessagePayload
         let p = SessionMessagePayload {
             blocks: vec![serde_json::json!({"type": "text"})],
+            seq: Some(1),
         };
         let v = serde_json::to_value(&p).unwrap();
         let _: SessionMessagePayload = serde_json::from_value(v).unwrap();

--- a/packages/service/src/domain/ws_session/protocol/server.rs
+++ b/packages/service/src/domain/ws_session/protocol/server.rs
@@ -43,6 +43,12 @@ pub struct SessionInitializedPayload {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionMessagePayload {
     pub blocks: Vec<serde_json::Value>,
+    /// Per-stream monotonic sequence number stamped by the stream reader so a
+    /// client can detect a dropped envelope (a gap) and resync from the DB
+    /// instead of silently rendering a truncated message. `None` on
+    /// non-streamed `session.message` emitters.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Why

Users reported the Claude Code agent **stopping mid-message with no error and no obvious cause**. An audit of the whole path (SDK → service → frontend) found the failure was a *class* of silent drops: unknown wire data collapsing into empty sinks, a lost stream envelope eating every subsequent chunk of a block, a permission dispatch that could strand a turn, and no diagnostics to tell any of these apart after the fact.

This PR closes every silent-drop path found, and — where content can still be lost in transit — verifies against the persisted transcript (the DB is authoritative; the WebSocket is not) and time-bounds the repair to the turn boundary.

> Note: a turn-liveness watchdog was **deliberately not** added — `run_in_background` sub-agents legitimately keep a turn "working" for hours, so "quiet = broken" is a false signal here.

## What

**SDK (`claude-agent-sdk-rs`)**
- Unmodeled content blocks / stream deltas / messages now carry their raw JSON (`#[serde(untagged)] Other(Value)`) instead of collapsing into empty `#[serde(other)]` sinks or `Unknown(Value::Null)`; `SdkMessage::from_raw` is the single infallible entry that logs and preserves the payload.
- Permission dispatch can no longer strand a turn: deny-to-continue on serialize failure, reset `TurnState` off `WaitingForPermission` on stdin-write failure (regression test included).

**Service**
- `normalize_event`'s `_ =>` catch-all is replaced by an exhaustive match — a future SDK variant is now a **compile error**, not a silent drop — and unmodeled blocks/deltas/status/system-subtypes log what the CLI sent.
- Every `session.message` envelope is stamped with a per-stream monotonic `seq` for client-side gap detection.
- A bounded wire tap (last 200 raw provider events) dumps to `~/.cadencr/diagnostics/` on an abnormal stop; the surfaced error points at the file.

**Frontend (`desktop`)**
- Orphan `content_block_delta` (whose `content_block_start` was lost) self-heals by synthesizing its block from the first delta; unknown message/event/delta types and unparseable envelopes leave a `console.warn` instead of vanishing.
- A `seq` gap triggers an append-only resync and flags a **post-turn tail repair** that overwrites any block whose persisted content is longer than what was rendered — run only once no deltas can race in.

## Testing
- `cargo test` across `claude-agent-sdk-rs` + `cadencr-service`: **1811 + all suites pass, 0 failed**; new coverage for raw-preservation, permission write-failure, diagnostics ring buffer, `seq` stamping, unknown-non-system surfacing.
- Frontend vitest incl. a fault-injection suite (orphan delta, unrenderable start, unknown delta/event/message types, silent-on-markers); ts-check, oxlint, oxfmt, knip clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream sequence numbers to session messages so clients can detect missing updates and resync more reliably.
  * Preserved raw data for unrecognized message, block, delta, and event payloads, improving visibility into unexpected content.

* **Bug Fixes**
  * Improved recovery from out-of-order or malformed streaming updates so live output continues instead of stalling.
  * Fixed permission and stream error handling to avoid frozen sessions or unanswered prompts.
  * Added better warnings and diagnostics for parsing failures and unexpected stream stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->