### PR TITLE
fix(desktop): queue outbound session envelopes while the socket is reconnecting

### DIFF
--- a/packages/desktop/src/stores/ws-session-actions.ts
+++ b/packages/desktop/src/stores/ws-session-actions.ts
@@ -1,4 +1,4 @@
-import { createPermissionRespond, createPromptSend } from "@/lib/ws-envelope";
+import { createPermissionRespond, createPromptSend, type WsEnvelope } from "@/lib/ws-envelope";
 import { getFeatureAgentState } from "@/api/generated";
 import { AGENT_STATE_OLDER_MESSAGE_LIMIT } from "@/lib/agent-state-limits";
 import { serverBlocksToAgentBlocks } from "@/hooks/useFeatureAgentState";
@@ -61,7 +61,7 @@ function decodeSnapshotQuestion(value: unknown): DecodedQuestion | null {
 export function applyApprovePlan(
   ctx: StoreAccessors,
   sessionId: string,
-  sendRaw: (sessionId: string, data: unknown) => void,
+  sendRaw: (sessionId: string, envelope: WsEnvelope) => void,
   planRestorePrefix: string,
 ): void {
   const session = ctx.getSession(sessionId);
@@ -129,7 +129,7 @@ export function applyPlanChangesRequest(
   ctx: StoreAccessors,
   sessionId: string,
   feedback: string,
-  sendRaw: (sessionId: string, data: unknown) => void,
+  sendRaw: (sessionId: string, envelope: WsEnvelope) => void,
   planRestorePrefix: string,
 ): void {
   const session = ctx.getSession(sessionId);

--- a/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
+++ b/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
@@ -200,4 +200,67 @@ describe("ws-session outbound queue", () => {
     // The entry may survive (no live conn to tear down) but its queue must not.
     expect(session?.outboundQueue ?? []).toHaveLength(0);
   });
+
+  it("does not resend a sendRequest() envelope that timed out before the reconnect", async () => {
+    const store = useWsSessionStore.getState();
+    store.connect("s1");
+    await tick();
+    const ws = getWs();
+    ws.simulateMessage({
+      domain: "session",
+      action: "initialized",
+      payload: { session_id: "7" },
+    });
+    // Socket goes non-OPEN (reconnect window) without a close event, so no
+    // auto-reconnect timer competes with the 10s request timeout. This models a
+    // long outage where the reconnect lands *after* the request has given up.
+    ws.readyState = MockWebSocket.CLOSED;
+
+    vi.useFakeTimers();
+    try {
+      const envelope = createEnvelope("session", "retry_worktree_setup", { feature_id: 42 });
+      const pending = store.sendRequest("s1", envelope);
+      expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(1);
+
+      // 10s elapse with the socket still down: the request times out and its
+      // envelope must leave the queue instead of lingering as a stale flush.
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(pending).resolves.toBeNull();
+      expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(0);
+
+      // The socket comes back: the timed-out envelope must not be replayed.
+      ws.readyState = MockWebSocket.OPEN;
+      ws.fireEvent("open");
+      expect(sentActions(ws)).not.toContain("session.retry_worktree_setup");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resolves an in-flight sendRequest() immediately on disconnect", async () => {
+    await connectInitializedThenDrop();
+    const store = useWsSessionStore.getState();
+
+    const pending = store.sendRequest(
+      "s1",
+      createEnvelope("session", "retry_worktree_setup", { feature_id: 42 }),
+    );
+    store.disconnect("s1");
+
+    // Resolves now instead of hanging until the 10s timeout after teardown.
+    await expect(pending).resolves.toBeNull();
+  });
+
+  it("resolves an in-flight sendRequest() immediately on destroy", async () => {
+    await connectInitializedThenDrop();
+    const store = useWsSessionStore.getState();
+
+    const pending = store.sendRequest(
+      "s1",
+      createEnvelope("session", "retry_worktree_setup", { feature_id: 42 }),
+    );
+    store.destroy("s1");
+
+    await expect(pending).resolves.toBeNull();
+  });
 });

--- a/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
+++ b/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Outbound-queue behavior of the WS session store: envelopes sent while the
+ * socket is down are held and delivered after the reconnect, instead of being
+ * silently dropped.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useWsSessionStore } from "./ws-session-store";
+import { createEnvelope } from "@/lib/ws-envelope";
+
+// --- Mock WebSocket (same shape as ws-session-store.test.ts) ---
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.OPEN;
+  sent: string[] = [];
+  private listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this);
+    Promise.resolve().then(() => this.fireEvent("open"));
+  }
+
+  addEventListener(event: string, cb: (...args: unknown[]) => void) {
+    (this.listeners[event] ??= []).push(cb);
+  }
+
+  removeEventListener() {}
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+
+  fireEvent(event: string, data?: unknown) {
+    for (const cb of this.listeners[event] ?? []) {
+      cb(data ?? {});
+    }
+  }
+
+  simulateMessage(envelope: { domain: string; action: string; ref?: string; payload: unknown }) {
+    const raw = JSON.stringify({ id: "srv-1", ...envelope });
+    this.fireEvent("message", { data: raw });
+  }
+
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+}
+
+const activeTimerIds = new Set<ReturnType<typeof setTimeout>>();
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => {
+    const id = setTimeout(() => {
+      activeTimerIds.delete(id);
+      resolve();
+    }, 10);
+    activeTimerIds.add(id);
+  });
+}
+
+function getWs(): MockWebSocket {
+  return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+}
+
+function sentActions(ws: MockWebSocket): string[] {
+  return ws.sent.map((raw) => {
+    const env = JSON.parse(raw) as { domain: string; action: string };
+    return `${env.domain}.${env.action}`;
+  });
+}
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  useWsSessionStore.setState({ sessions: {} });
+  vi.stubGlobal("WebSocket", MockWebSocket);
+  vi.spyOn(console, "info").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  const store = useWsSessionStore.getState();
+  for (const sessionId of Object.keys(store.sessions)) {
+    store.disconnect(sessionId);
+  }
+  for (const id of activeTimerIds) clearTimeout(id);
+  activeTimerIds.clear();
+  vi.restoreAllMocks();
+});
+
+/** Connect, receive `initialized`, then drop the socket (unintentional close). */
+async function connectInitializedThenDrop(sessionId = "s1"): Promise<void> {
+  const store = useWsSessionStore.getState();
+  store.connect(sessionId);
+  await tick();
+  const ws = getWs();
+  ws.simulateMessage({
+    domain: "session",
+    action: "initialized",
+    payload: { session_id: "7" },
+  });
+  ws.readyState = MockWebSocket.CLOSED;
+  ws.fireEvent("close");
+}
+
+describe("ws-session outbound queue", () => {
+  it("queues an envelope sent while disconnected and flushes it on reconnect", async () => {
+    await connectInitializedThenDrop();
+    const store = useWsSessionStore.getState();
+
+    store.interrupt("s1");
+    expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(1);
+
+    store.connect("s1");
+    await tick();
+
+    expect(sentActions(getWs())).toContain("session.interrupt");
+    expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(0);
+  });
+
+  it("delivers a prompt sent during the reconnect gap instead of dropping it", async () => {
+    await connectInitializedThenDrop();
+    const store = useWsSessionStore.getState();
+
+    store.sendPrompt("s1", "hello from the gap");
+    // The local echo is appended immediately…
+    const blocks = useWsSessionStore.getState().sessions.s1.blocks;
+    expect(blocks.at(-1)?.type).toBe("user_message");
+
+    store.connect("s1");
+    await tick();
+
+    // …and the prompt actually reaches the backend after the reconnect.
+    const promptRaw = getWs().sent.find((raw) => raw.includes("prompt.send"));
+    expect(promptRaw).toBeDefined();
+    expect(promptRaw).toContain("hello from the gap");
+  });
+
+  it("replays the reconnect session.init before flushing queued envelopes", async () => {
+    const store = useWsSessionStore.getState();
+    store.connect("s1");
+    await tick();
+    store.initSession("s1", { cwd: "/tmp/proj", featureId: 42 });
+    getWs().simulateMessage({
+      domain: "session",
+      action: "initialized",
+      payload: { session_id: "7" },
+    });
+    const ws = getWs();
+    ws.readyState = MockWebSocket.CLOSED;
+    ws.fireEvent("close");
+
+    store.interrupt("s1");
+    store.connect("s1");
+    await tick();
+
+    const actions = sentActions(getWs());
+    expect(actions.indexOf("session.init")).toBeGreaterThanOrEqual(0);
+    expect(actions.indexOf("session.init")).toBeLessThan(actions.indexOf("session.interrupt"));
+  });
+
+  it("sendRequest during the gap resolves with the reply that arrives after reconnect", async () => {
+    await connectInitializedThenDrop();
+    const store = useWsSessionStore.getState();
+
+    const envelope = createEnvelope("session", "retry_worktree_setup", { feature_id: 42 });
+    const pending = store.sendRequest("s1", envelope);
+
+    store.connect("s1");
+    await tick();
+
+    getWs().simulateMessage({
+      domain: "session",
+      action: "retry_worktree_setup.ok",
+      ref: envelope.id,
+      payload: { feature_id: 42 },
+    });
+
+    await expect(pending).resolves.toEqual({ feature_id: 42 });
+  });
+
+  it("disconnect clears any queued envelopes", async () => {
+    await connectInitializedThenDrop();
+    const store = useWsSessionStore.getState();
+
+    store.interrupt("s1");
+    expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(1);
+
+    store.disconnect("s1");
+    const session = useWsSessionStore.getState().sessions.s1;
+    // The entry may survive (no live conn to tear down) but its queue must not.
+    expect(session?.outboundQueue ?? []).toHaveLength(0);
+  });
+});

--- a/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
+++ b/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
@@ -136,9 +136,9 @@ describe("ws-session outbound queue", () => {
     store.connect("s1");
     await tick();
 
-    // …and the prompt actually reaches the backend after the reconnect.
+    // …and the prompt actually reaches the backend after the reconnect
+    // (toContain also fails when no prompt.send envelope was sent at all).
     const promptRaw = getWs().sent.find((raw) => raw.includes("prompt.send"));
-    expect(promptRaw).toBeDefined();
     expect(promptRaw).toContain("hello from the gap");
   });
 
@@ -160,9 +160,12 @@ describe("ws-session outbound queue", () => {
     store.connect("s1");
     await tick();
 
+    // A single assertion covers both presence and relative order.
     const actions = sentActions(getWs());
-    expect(actions.indexOf("session.init")).toBeGreaterThanOrEqual(0);
-    expect(actions.indexOf("session.init")).toBeLessThan(actions.indexOf("session.interrupt"));
+    const replayThenFlush = actions.filter(
+      (action) => action === "session.init" || action === "session.interrupt",
+    );
+    expect(replayThenFlush).toEqual(["session.init", "session.interrupt"]);
   });
 
   it("sendRequest during the gap resolves with the reply that arrives after reconnect", async () => {

--- a/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
+++ b/packages/desktop/src/stores/ws-session-outbound-queue.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useWsSessionStore } from "./ws-session-store";
 import { createEnvelope } from "@/lib/ws-envelope";
+import { forceReconnectAll } from "@/lib/ws-reconnect";
 
 // --- Mock WebSocket (same shape as ws-session-store.test.ts) ---
 
@@ -235,6 +236,64 @@ describe("ws-session outbound queue", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("drops a queued sendRequest() envelope when a transient close rejects it", async () => {
+    const store = useWsSessionStore.getState();
+    store.connect("s1");
+    await tick();
+    const ws = getWs();
+    ws.simulateMessage({
+      domain: "session",
+      action: "initialized",
+      payload: { session_id: "7" },
+    });
+
+    // Socket goes non-OPEN (no close event yet): the request gets queued.
+    ws.readyState = MockWebSocket.CLOSED;
+    const pending = store.sendRequest(
+      "s1",
+      createEnvelope("session", "retry_worktree_setup", { feature_id: 42 }),
+    );
+    expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(1);
+
+    // The close lands: the pending-request sweep resolves the promise null
+    // and must take the matching queued envelope with it.
+    ws.fireEvent("close");
+    await expect(pending).resolves.toBeNull();
+    expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(0);
+
+    // The reconnect must not replay a request the caller was told failed.
+    store.connect("s1");
+    await tick();
+    expect(sentActions(getWs())).not.toContain("session.retry_worktree_setup");
+  });
+
+  it("drops a queued sendRequest() envelope on a forced reconnect", async () => {
+    const store = useWsSessionStore.getState();
+    store.connect("s1");
+    await tick();
+    const ws = getWs();
+    ws.simulateMessage({
+      domain: "session",
+      action: "initialized",
+      payload: { session_id: "7" },
+    });
+
+    ws.readyState = MockWebSocket.CLOSED;
+    const pending = store.sendRequest(
+      "s1",
+      createEnvelope("session", "retry_worktree_setup", { feature_id: 42 }),
+    );
+    expect(useWsSessionStore.getState().sessions.s1.outboundQueue).toHaveLength(1);
+
+    // Wake-style force reconnect (usePowerEvents.handleResume): closes the
+    // old socket, sweeps pending requests, opens a replacement.
+    forceReconnectAll();
+    await tick();
+
+    await expect(pending).resolves.toBeNull();
+    expect(sentActions(getWs())).not.toContain("session.retry_worktree_setup");
   });
 
   it("resolves an in-flight sendRequest() immediately on disconnect", async () => {

--- a/packages/desktop/src/stores/ws-session-store.ts
+++ b/packages/desktop/src/stores/ws-session-store.ts
@@ -101,24 +101,26 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
     return get().sessions[sessionId] ?? createSessionEntry();
   }
 
-  function sendRaw(sessionId: string, data: unknown): void {
+  function sendRaw(sessionId: string, envelope: WsEnvelope): void {
     const session = get().sessions[sessionId];
-    if (session?.conn?.sendJson(data)) return;
+    if (session?.conn?.sendJson(envelope)) return;
     // The socket is not OPEN (reconnecting, or still CONNECTING). Dropping the
     // envelope here is silent data loss — a prompt sent during the gap shows
     // up locally but never reaches the agent. Hold it and flush on `onOpen`,
     // after the reconnect `session.init` replay.
-    session?.outboundQueue.push(data);
+    session?.outboundQueue.push(envelope);
   }
 
   /** Send queued envelopes in order; stop (and keep the rest) if the socket drops again. */
   function flushOutboundQueue(sessionId: string): void {
     const session = get().sessions[sessionId];
     if (!session?.conn) return;
-    while (session.outboundQueue.length > 0) {
-      if (!session.conn.sendJson(session.outboundQueue[0])) return;
-      session.outboundQueue.shift();
-    }
+    const queue = session.outboundQueue;
+    // Drain by index and splice once at the end: shift() per envelope would
+    // reindex the array each time (O(n²) on a long-outage backlog).
+    let sent = 0;
+    while (sent < queue.length && session.conn.sendJson(queue[sent])) sent += 1;
+    if (sent > 0) queue.splice(0, sent);
   }
 
   function forceReconnectSession(sessionId: string): void {

--- a/packages/desktop/src/stores/ws-session-store.ts
+++ b/packages/desktop/src/stores/ws-session-store.ts
@@ -100,11 +100,21 @@ function shouldTrackPromptReceipt(session: SessionEntry): boolean {
  * Resolve every in-flight `sendRequest()` with `null` and clear the map, so
  * callers stop waiting the moment the socket is gone (transient drop or
  * deliberate teardown) instead of hanging until the 10s timeout.
+ *
+ * A request resolved as failed must not execute later as a stale side effect:
+ * its envelope may still sit in `outboundQueue` (queued while the socket was
+ * down), so drop it too. Non-request envelopes (prompts, resume, control)
+ * keep the queue-and-flush policy — only rejected requests are removed.
  */
 function rejectPendingRequests(session: SessionEntry): void {
   if (!session.pendingWsRequests.size) return;
+  const requestIds = new Set(session.pendingWsRequests.keys());
   for (const cb of session.pendingWsRequests.values()) cb(null);
   session.pendingWsRequests.clear();
+  const queue = session.outboundQueue;
+  for (let i = queue.length - 1; i >= 0; i -= 1) {
+    if (requestIds.has(queue[i].id)) queue.splice(i, 1);
+  }
 }
 
 export const useWsSessionStore = create<WsSessionStore>((set, get) => {

--- a/packages/desktop/src/stores/ws-session-store.ts
+++ b/packages/desktop/src/stores/ws-session-store.ts
@@ -96,6 +96,17 @@ function shouldTrackPromptReceipt(session: SessionEntry): boolean {
   );
 }
 
+/**
+ * Resolve every in-flight `sendRequest()` with `null` and clear the map, so
+ * callers stop waiting the moment the socket is gone (transient drop or
+ * deliberate teardown) instead of hanging until the 10s timeout.
+ */
+function rejectPendingRequests(session: SessionEntry): void {
+  if (!session.pendingWsRequests.size) return;
+  for (const cb of session.pendingWsRequests.values()) cb(null);
+  session.pendingWsRequests.clear();
+}
+
 export const useWsSessionStore = create<WsSessionStore>((set, get) => {
   function getSession(sessionId: string): SessionEntry {
     return get().sessions[sessionId] ?? createSessionEntry();
@@ -126,10 +137,7 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
   function forceReconnectSession(sessionId: string): void {
     const session = get().sessions[sessionId];
     if (session?.conn) {
-      if (session.pendingWsRequests.size) {
-        for (const cb of session.pendingWsRequests.values()) cb(null);
-        session.pendingWsRequests.clear();
-      }
+      rejectPendingRequests(session);
       session.conn.close(1000, "force-reconnect");
       set(updateSession(get(), sessionId, { conn: null, isConnected: false }));
     }
@@ -257,10 +265,7 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
           // so the transcript keeps them in order.
           flushStreamDeltas(ctx, sessionId);
           const session = get().sessions[sessionId];
-          if (session?.pendingWsRequests.size) {
-            for (const cb of session.pendingWsRequests.values()) cb(null);
-            session.pendingWsRequests.clear();
-          }
+          if (session) rejectPendingRequests(session);
           const wasRunning = session != null && isTurnActive(session.lifecycle);
           const closedDerived = wasRunning
             ? blocksPatchWithDerived(session.streamingState, [
@@ -297,10 +302,7 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
           if (intentional) return;
           flushStreamDeltas(ctx, sessionId);
           const session = get().sessions[sessionId];
-          if (session?.pendingWsRequests.size) {
-            for (const cb of session.pendingWsRequests.values()) cb(null);
-            session.pendingWsRequests.clear();
-          }
+          if (session) rejectPendingRequests(session);
           set(
             updateSession(get(), sessionId, {
               conn: null,
@@ -346,6 +348,10 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
       // had closed. In-place splice because the queue is mutated in place by
       // design (see SessionEntry.outboundQueue).
       session?.outboundQueue.splice(0);
+      // The deliberate close() below skips onClose's pending-request sweep
+      // (it early-returns on `intentional`), so resolve in-flight requests now
+      // rather than leaving permission/worktree calls hanging until the timeout.
+      if (session) rejectPendingRequests(session);
       if (!session?.conn) return;
 
       if (session.serverSessionId) {
@@ -372,6 +378,12 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
         // sweep) still bound the wait.
         const timer = setTimeout(() => {
           session.pendingWsRequests.delete(envelope.id);
+          // Drop the still-queued envelope too. Otherwise a reconnect after the
+          // timeout flushes a request the caller already gave up on — e.g. a
+          // permission response the user was told "timed out" would silently
+          // reach the backend on the next onOpen.
+          const queued = session.outboundQueue.indexOf(envelope);
+          if (queued !== -1) session.outboundQueue.splice(queued, 1);
           resolve(null);
         }, 10_000);
         session.pendingWsRequests.set(envelope.id, (payload) => {
@@ -562,8 +574,10 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
       discardStreamDeltas(sessionId);
       const session = get().sessions[sessionId];
       // Same rationale as disconnect(): a destroyed session must not replay
-      // its queued envelopes on a future connect.
+      // its queued envelopes on a future connect, nor leave sendRequest()
+      // callers hanging until the timeout after a deliberate close().
       session?.outboundQueue.splice(0);
+      if (session) rejectPendingRequests(session);
       if (!session?.conn) return;
 
       if (session.serverSessionId) {

--- a/packages/desktop/src/stores/ws-session-store.ts
+++ b/packages/desktop/src/stores/ws-session-store.ts
@@ -102,7 +102,23 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
   }
 
   function sendRaw(sessionId: string, data: unknown): void {
-    getSession(sessionId).conn?.sendJson(data);
+    const session = get().sessions[sessionId];
+    if (session?.conn?.sendJson(data)) return;
+    // The socket is not OPEN (reconnecting, or still CONNECTING). Dropping the
+    // envelope here is silent data loss — a prompt sent during the gap shows
+    // up locally but never reaches the agent. Hold it and flush on `onOpen`,
+    // after the reconnect `session.init` replay.
+    session?.outboundQueue.push(data);
+  }
+
+  /** Send queued envelopes in order; stop (and keep the rest) if the socket drops again. */
+  function flushOutboundQueue(sessionId: string): void {
+    const session = get().sessions[sessionId];
+    if (!session?.conn) return;
+    while (session.outboundQueue.length > 0) {
+      if (!session.conn.sendJson(session.outboundQueue[0])) return;
+      session.outboundQueue.shift();
+    }
   }
 
   function forceReconnectSession(sessionId: string): void {
@@ -223,6 +239,10 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
           // wiped, the more confusing `INVALID_SESSION_ID`).
           // Provider-neutral: applies to Claude Code, OpenCode, Codex.
           reinitOnReconnect(sessionId);
+          // Deliver whatever was sent while the socket was down (prompts,
+          // permission responses, session.resume after wake). After the init
+          // replay so the backend has rebuilt its handle for this session.
+          flushOutboundQueue(sessionId);
           // Catch up on anything the agent streamed while the socket was
           // down (e.g. the mobile client was asleep). WS streaming only
           // delivers live; without this pull the gap is lost forever. Guarded
@@ -317,6 +337,7 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
       useConnectionStatusStore.getState().clearSource(wsSessionSourceKey(sessionId));
       discardStreamDeltas(sessionId);
       const session = get().sessions[sessionId];
+      session?.outboundQueue.splice(0);
       if (!session?.conn) return;
 
       if (session.serverSessionId) {
@@ -333,10 +354,14 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
     sendRequest(sessionId: string, envelope: WsEnvelope): Promise<unknown> {
       return new Promise((resolve) => {
         const session = get().sessions[sessionId];
-        if (!session?.conn?.isOpen()) {
+        if (!session) {
           resolve(null);
           return;
         }
+        // A non-OPEN socket is not an instant failure: sendRaw queues the
+        // envelope and the reconnect flush usually lands well inside the
+        // timeout window. The timer (and the close handler's pending-request
+        // sweep) still bound the wait.
         const timer = setTimeout(() => {
           session.pendingWsRequests.delete(envelope.id);
           resolve(null);
@@ -528,6 +553,7 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
       useConnectionStatusStore.getState().clearSource(wsSessionSourceKey(sessionId));
       discardStreamDeltas(sessionId);
       const session = get().sessions[sessionId];
+      session?.outboundQueue.splice(0);
       if (!session?.conn) return;
 
       if (session.serverSessionId) {

--- a/packages/desktop/src/stores/ws-session-store.ts
+++ b/packages/desktop/src/stores/ws-session-store.ts
@@ -337,6 +337,12 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
       useConnectionStatusStore.getState().clearSource(wsSessionSourceKey(sessionId));
       discardStreamDeltas(sessionId);
       const session = get().sessions[sessionId];
+      // Deliberate teardown: queued envelopes must not outlive it. Without
+      // this, a disconnect while the socket is already down early-returns
+      // below (conn is null), the entry survives, and a later connect() would
+      // flush stale envelopes (e.g. an old prompt) into a session the user
+      // had closed. In-place splice because the queue is mutated in place by
+      // design (see SessionEntry.outboundQueue).
       session?.outboundQueue.splice(0);
       if (!session?.conn) return;
 
@@ -553,6 +559,8 @@ export const useWsSessionStore = create<WsSessionStore>((set, get) => {
       useConnectionStatusStore.getState().clearSource(wsSessionSourceKey(sessionId));
       discardStreamDeltas(sessionId);
       const session = get().sessions[sessionId];
+      // Same rationale as disconnect(): a destroyed session must not replay
+      // its queued envelopes on a future connect.
       session?.outboundQueue.splice(0);
       if (!session?.conn) return;
 

--- a/packages/desktop/src/stores/ws-session-types.ts
+++ b/packages/desktop/src/stores/ws-session-types.ts
@@ -180,7 +180,7 @@ export interface SessionEntry {
    * Mutated in place (like `pendingWsRequests`) — transport plumbing, not
    * render state.
    */
-  outboundQueue: unknown[];
+  outboundQueue: WsEnvelope[];
   worktreeStatus: WorktreeStatus;
   worktreePath: string | null;
   worktreeBranch: string | null;
@@ -316,7 +316,7 @@ export interface WsSessionStore {
   connect: (sessionId: string) => void;
   disconnect: (sessionId: string) => void;
 
-  send: (sessionId: string, data: unknown) => void;
+  send: (sessionId: string, envelope: WsEnvelope) => void;
   initSession: (sessionId: string, config: SessionConfig) => void;
   sendPrompt: (sessionId: string, text: string, options?: PromptDispatchOptions) => void;
   respondToPermission: (

--- a/packages/desktop/src/stores/ws-session-types.ts
+++ b/packages/desktop/src/stores/ws-session-types.ts
@@ -173,6 +173,14 @@ export interface SessionEntry {
   featureTitle: string | null;
   isAutoNaming: boolean;
   pendingWsRequests: Map<string, (payload: unknown) => void>;
+  /**
+   * Envelopes that could not be sent because the socket was not OPEN
+   * (reconnecting after a drop, or still CONNECTING). Flushed in order once
+   * the transport is back, right after the reconnect `session.init` replay.
+   * Mutated in place (like `pendingWsRequests`) — transport plumbing, not
+   * render state.
+   */
+  outboundQueue: unknown[];
   worktreeStatus: WorktreeStatus;
   worktreePath: string | null;
   worktreeBranch: string | null;
@@ -242,6 +250,7 @@ export function createSessionEntry(): SessionEntry {
     featureTitle: null,
     isAutoNaming: false,
     pendingWsRequests: new Map(),
+    outboundQueue: [],
     worktreeStatus: "idle",
     worktreePath: null,
     worktreeBranch: null,


### PR DESCRIPTION
## Problem

`sendRaw` in `ws-session-store` ignores `sendJson`'s return value, so any envelope sent while the socket isn't OPEN is silently dropped. That window is small but users hit it constantly around sleep/wake and transient drops:

- **Prompts**: `sendPrompt` on an initialized session appends the local echo, then drops the envelope. The message is on screen but the agent never got it — the conversation silently diverges.
- **`session.resume` after wake**: `usePowerEvents.handleResume` calls `forceReconnectAll()` (which closes every socket and leaves the replacements in CONNECTING), *then* sends `session.resume`. The envelope is always dropped, the backend never broadcasts the `Resumed` lifecycle event, yet the "Reconnecting agent after sleep…" toast shows anyway.
- **Permission responses and other control envelopes** (`interrupt`, `mode.set`, …) vanish the same way, and `sendRequest` resolved `null` immediately on a closed socket, which `respondToPermission` reports as a bogus "Permission response timed out".

## Fix

Each session entry gets an `outboundQueue`. When a write fails, the envelope is held; on the next `onOpen` the queue is flushed in order, right after the existing `session.init` replay so the backend has rebuilt its per-connection handle first. `sendRequest` now queues too instead of failing instantly — the reconnect flush usually lands well inside its existing 10s timeout. The queue is cleared on `disconnect`/`destroy`, and a flush stops (keeping the rest) if the socket drops mid-flush.

No change to the pre-init `queuedPrompts` path; this covers the post-init reconnect gap it doesn't.

The queue is deliberately unbounded: it only accumulates explicit user actions during an outage, and capping it would reintroduce exactly the silent drop this removes.

## Tests

New `ws-session-outbound-queue.test.ts`:
- envelope sent while disconnected is flushed on reconnect
- a prompt sent during the gap reaches the backend after reconnect
- the `session.init` replay is sent before the queued envelopes
- `sendRequest` during the gap resolves with the reply arriving after reconnect
- `disconnect` clears the queue

Full desktop suite: 2907 tests pass. `ts-check`, `lint`, `format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## User impact

The most visible shape: you send a message, it appears in the chat, and the agent just never answers — the prompt was dropped in the reconnect gap. The wake-after-sleep shape: "Reconnecting agent after sleep…" shows but the session stays stuck as suspended because `session.resume` went into a closed socket. Clicking Allow on a permission during the gap shows a bogus "Permission response timed out". Frequency: the resume drop happens on essentially **every** OS sleep/wake with a suspended session (the race is structural, not timing luck); the prompt/permission drops need an action inside the ~0.5–2s reconnect window, so they're occasional on desktop and common on remote/mobile links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket reliability by queuing outbound messages during reconnect gaps and flushing them after reconnect.
  * Ensures correct replay order by sending `session.init` before queued messages.
  * Updated message handling to use typed WebSocket envelopes, and hardened disconnect/error/timeout behavior to avoid stale replays and properly resolve timed-out requests.
* **Tests**
  * Added Vitest coverage for outbound queue flushing, prompt echo vs backend delivery, request resolution after reconnect, timeout removal, and queue clearing on disconnect/destroy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->