### PR TITLE
feat(ContextUsageBar): add popover with usage on hover

### DIFF
--- a/packages/desktop/src/components/ContextUsageBar.test.tsx
+++ b/packages/desktop/src/components/ContextUsageBar.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@/test-utils";
 import { ContextUsageBar } from "./ContextUsageBar";
@@ -138,5 +139,61 @@ describe("ContextUsageBar", () => {
       />,
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it("shows token detail popover on hover", async () => {
+    const user = userEvent.setup();
+    render(
+      <ContextUsageBar
+        usage={makeUsage({ inputTokens: 40000, outputTokens: 5230, contextWindow: 200000 })}
+        isStreaming={false}
+      />,
+    );
+
+    expect(screen.queryByText("Tokens used")).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText("23%"));
+
+    expect(await screen.findByText("Tokens used")).toBeInTheDocument();
+    expect(screen.getByText("45,230 / 200,000")).toBeInTheDocument();
+    expect(screen.getByText("Input")).toBeInTheDocument();
+    expect(screen.getByText("40,000")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByText("5,230")).toBeInTheDocument();
+  });
+
+  it("hides the popover again on unhover", async () => {
+    const user = userEvent.setup();
+    render(<ContextUsageBar usage={makeUsage({ usageRatio: 0.3 })} isStreaming={false} />);
+
+    await user.hover(screen.getByText("30%"));
+    expect(await screen.findByText("Tokens used")).toBeInTheDocument();
+
+    await user.unhover(screen.getByText("30%"));
+    expect(screen.queryByText("Tokens used")).not.toBeInTheDocument();
+  });
+
+  it("shows the compacted row only when wasCompacted is true", async () => {
+    const user = userEvent.setup();
+    render(
+      <ContextUsageBar
+        usage={makeUsage({ usageRatio: 0.3, wasCompacted: true })}
+        isStreaming={false}
+      />,
+    );
+
+    await user.hover(screen.getByText("30%"));
+
+    expect(await screen.findByText("Context compacted")).toBeInTheDocument();
+  });
+
+  it("omits the compacted row when wasCompacted is false", async () => {
+    const user = userEvent.setup();
+    render(<ContextUsageBar usage={makeUsage({ usageRatio: 0.3 })} isStreaming={false} />);
+
+    await user.hover(screen.getByText("30%"));
+
+    expect(await screen.findByText("Tokens used")).toBeInTheDocument();
+    expect(screen.queryByText("Context compacted")).not.toBeInTheDocument();
   });
 });

--- a/packages/desktop/src/components/ContextUsageBar.tsx
+++ b/packages/desktop/src/components/ContextUsageBar.tsx
@@ -1,12 +1,14 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useState } from "react";
 import {
   normalizeContextWindow,
+  totalTokens,
   type ContextUsageState,
   usageRatio as computeUsageRatio,
 } from "@/types/agent";
 import { cn } from "@/lib/utils";
 import { getContextUsageAppearance } from "@/lib/context-usage-appearance";
 import { KbdShortcut } from "@/components/KbdShortcut";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 export function ContextUsageBar({
   usage,
@@ -17,6 +19,8 @@ export function ContextUsageBar({
   className?: string;
   isStreaming: boolean;
 }): ReactElement | null {
+  const [open, setOpen] = useState(false);
+
   if (!usage) return null;
   if (normalizeContextWindow(usage.contextWindow) == null) return null;
 
@@ -24,27 +28,71 @@ export function ContextUsageBar({
   const appearance = getContextUsageAppearance(ratio);
 
   return (
-    <div className={cn("flex items-center gap-2 px-3 py-1", className)}>
-      <div className="h-[3px] flex-1 rounded-full bg-border/80">
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
         <div
-          className={cn(
-            "h-full rounded-full transition-all duration-300",
-            isStreaming ? "context-usage-glow" : appearance.barClassName,
-          )}
-          data-context-usage-style="glow"
-          style={{
-            width: `${ratio * 100}%`,
-            backgroundColor: appearance.glowColor,
-            boxShadow: isStreaming
-              ? `0 0 4px ${appearance.glowColor}, 0 0 10px color-mix(in srgb, ${appearance.glowColor} 75%, transparent), 0 0 16px color-mix(in srgb, ${appearance.glowColor} 45%, transparent)`
-              : "none",
-          }}
-        />
-      </div>
-      <span className="shrink-0 text-[10px] font-medium tabular-nums text-muted-foreground">
-        {Math.round(ratio * 100)}%
-      </span>
-      <PromptKeyboardHint />
+          tabIndex={0}
+          className={cn("flex items-center gap-2 px-3 py-1", className)}
+          onMouseEnter={() => setOpen(true)}
+          onMouseLeave={() => setOpen(false)}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+        >
+          <div className="h-[3px] flex-1 rounded-full bg-border/80">
+            <div
+              className={cn(
+                "h-full rounded-full transition-all duration-300",
+                isStreaming ? "context-usage-glow" : appearance.barClassName,
+              )}
+              data-context-usage-style="glow"
+              style={{
+                width: `${ratio * 100}%`,
+                backgroundColor: appearance.glowColor,
+                boxShadow: isStreaming
+                  ? `0 0 4px ${appearance.glowColor}, 0 0 10px color-mix(in srgb, ${appearance.glowColor} 75%, transparent), 0 0 16px color-mix(in srgb, ${appearance.glowColor} 45%, transparent)`
+                  : "none",
+              }}
+            />
+          </div>
+          <span className="shrink-0 text-[10px] font-medium tabular-nums text-muted-foreground">
+            {Math.round(ratio * 100)}%
+          </span>
+          <PromptKeyboardHint />
+        </div>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="top"
+        className="pointer-events-none flex w-auto flex-col gap-2 p-3"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
+        <ContextUsageDetails usage={usage} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ContextUsageDetails({ usage }: { usage: ContextUsageState }): ReactElement {
+  const contextWindow = normalizeContextWindow(usage.contextWindow);
+  return (
+    <div className="flex flex-col gap-1.5">
+      <ContextUsageRow
+        label="Tokens used"
+        value={`${totalTokens(usage).toLocaleString()} / ${contextWindow?.toLocaleString() ?? "—"}`}
+      />
+      <ContextUsageRow label="Input" value={usage.inputTokens.toLocaleString()} />
+      <ContextUsageRow label="Output" value={usage.outputTokens.toLocaleString()} />
+      {usage.wasCompacted ? <ContextUsageRow label="Context compacted" value="Yes" /> : null}
+    </div>
+  );
+}
+
+function ContextUsageRow({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-[11px] font-medium text-muted-foreground">{label}</span>
+      <span className="rounded bg-muted/60 px-2 py-1 font-mono text-[11px]">{value}</span>
     </div>
   );
 }


### PR DESCRIPTION


## Summary

Adds a hover popover to the `ContextUsageBar` component showing detailed token usage (total, input, output) and context compaction status.

## Motivation

Users need visibility into context window usage details without cluttering the main UI. The popover provides this information on demand.

## Linked issues

- Closes #

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Maintenance / tooling

## Areas touched

- [x] Desktop frontend
- [ ] Backend service
- [ ] Claude provider
- [ ] Codex provider
- [ ] OpenCode provider
- [ ] Database / migration
- [ ] API surface
- [ ] Docs
- [ ] CI / release

## Changes

- Wrap `ContextUsageBar` in a `Popover` that opens on mouse enter/leave
- Add `ContextUsageDetails` component showing total tokens, input/output breakdown, and compaction indicator
- Add `ContextUsageRow` helper for consistent row rendering
- Add 4 unit tests for popover hover/unhover and compaction row visibility
- Import `totalTokens` from `@/types/agent`

## Screenshots / recordings

<img width="1030" height="178" alt="image" src="https://github.com/user-attachments/assets/cd0f1d67-e970-49c5-8639-ba27cf4d5e61" />

## API / database changes

- [x] No API or database changes
- [ ] API changed and generated client was updated
- [ ] Database migration added
- [ ] Migration tested locally

## UX checklist

- [x] Loading/error states are visible for async operations
- [ ] Keyboard shortcut impact considered
- [x] No optimistic frontend updates added

## Test plan

Commands run:

```bash
pnpm --filter @cadencr/desktop test ContextUsageBar
```

Manual flows verified:

- [ ] Hover over ContextUsageBar to verify popover appears
- [ ] Move cursor away to verify popover closes
- [ ] Verify "Context compacted" row shows/hides based on `wasCompacted`

## Checklist

- [ ] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style.
- [ ] Rebased onto the latest `main`.
- [ ] Docs (README, CONTRIBUTING, etc.) updated for any user-visible change.