### PR TITLE
Mitigate infinite reconnect loops and renderer crashes

### DIFF
--- a/packages/desktop/src/components/AgentStream.tsx
+++ b/packages/desktop/src/components/AgentStream.tsx
@@ -236,9 +236,9 @@ function AgentVirtuoso({
       computeItemKey={computeItemKey}
       initialTopMostItemIndex={{ index: "LAST", align: "end" }}
       defaultItemHeight={40}
-      increaseViewportBy={{ top: 1600, bottom: 800 }}
-      minOverscanItemCount={{ top: 12, bottom: 8 }}
-      overscan={{ main: 800, reverse: 800 }}
+      increaseViewportBy={{ top: 600, bottom: 400 }}
+      minOverscanItemCount={{ top: 4, bottom: 3 }}
+      overscan={{ main: 300, reverse: 300 }}
       components={VIRTUOSO_COMPONENTS}
       context={context}
       followOutput={followOutput}

--- a/packages/desktop/src/components/InlineDiffBlock.test.tsx
+++ b/packages/desktop/src/components/InlineDiffBlock.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test-utils";
+import { getDiffRenderDiagnostics } from "@/lib/diff-render-diagnostics";
 import { InlineDiffBlock } from "./InlineDiffBlock";
 
 const mocks = vi.hoisted(() => ({
@@ -273,6 +274,51 @@ describe("InlineDiffBlock large diff safety", () => {
     expect(screen.getByText(/Large diff shown without syntax highlighting/)).toBeInTheDocument();
     expect(screen.queryByTestId("diff-view")).not.toBeInTheDocument();
     expect(onExpandedChange).not.toHaveBeenCalled();
+  });
+
+  it("uses UTF-8 bytes to classify and label multibyte content", async () => {
+    const cjkContent = "界".repeat(70_000);
+    const { user } = render(
+      <InlineDiffBlock
+        filePath="translations.txt"
+        oldContent=""
+        newContent={cjkContent}
+        expanded
+      />,
+    );
+
+    expect(screen.queryByTestId("diff-view")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Expand diff" }));
+    expect(screen.getByText(/about 205\.\d KB/)).toBeInTheDocument();
+  });
+
+  it("does not count streamed large-patch updates as remounts", async () => {
+    const before = getDiffRenderDiagnostics();
+    const { user, rerender } = render(
+      <InlineDiffBlock
+        filePath="generated.ts"
+        oldContent={oldContent}
+        newContent={newContent}
+        expanded
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Expand diff" }));
+    const afterMount = getDiffRenderDiagnostics();
+
+    rerender(
+      <InlineDiffBlock
+        filePath="generated.ts"
+        oldContent={oldContent}
+        newContent={`${newContent}\nstreamed tail`}
+        expanded
+      />,
+    );
+    const afterUpdate = getDiffRenderDiagnostics();
+
+    expect(afterMount.heavyInlineMounts - before.heavyInlineMounts).toBe(1);
+    expect(afterUpdate.heavyInlineMounts).toBe(afterMount.heavyInlineMounts);
+    expect(afterUpdate.heavyInlineMounted).toBe(afterMount.heavyInlineMounted);
+    expect(afterUpdate.heavyInlineVisible).toBe(afterMount.heavyInlineVisible);
   });
 });
 

--- a/packages/desktop/src/components/InlineDiffBlock.test.tsx
+++ b/packages/desktop/src/components/InlineDiffBlock.test.tsx
@@ -238,6 +238,44 @@ describe("InlineDiffBlock controlled expand API", () => {
   });
 });
 
+describe("InlineDiffBlock large diff safety", () => {
+  const oldContent = Array.from({ length: 751 }, (_, index) => `old line ${index}`).join("\n");
+  const newContent = Array.from({ length: 751 }, (_, index) => `new line ${index}`).join("\n");
+
+  it("keeps a large diff collapsed even when transcript verbosity requests expansion", () => {
+    render(
+      <InlineDiffBlock
+        filePath="generated.ts"
+        oldContent={oldContent}
+        newContent={newContent}
+        expanded
+      />,
+    );
+
+    expect(screen.queryByTestId("diff-view")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand diff" })).toBeInTheDocument();
+  });
+
+  it("uses a plain-text renderer when the user explicitly expands a large diff", async () => {
+    const onExpandedChange = vi.fn();
+    const { user } = render(
+      <InlineDiffBlock
+        filePath="generated.ts"
+        oldContent={oldContent}
+        newContent={newContent}
+        expanded
+        onExpandedChange={onExpandedChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Expand diff" }));
+
+    expect(screen.getByText(/Large diff shown without syntax highlighting/)).toBeInTheDocument();
+    expect(screen.queryByTestId("diff-view")).not.toBeInTheDocument();
+    expect(onExpandedChange).not.toHaveBeenCalled();
+  });
+});
+
 it("uses the theme-owned file-change identity for edit tool-call headers", () => {
   render(
     <InlineDiffBlock

--- a/packages/desktop/src/components/InlineDiffBlock.tsx
+++ b/packages/desktop/src/components/InlineDiffBlock.tsx
@@ -1,15 +1,16 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ChevronRightIcon, PencilIcon, FilePlusIcon } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { useControllableBoolean } from "@/hooks/useControllableBoolean";
 import { cn, toRelativePath } from "@/lib/utils";
 import { NumStat } from "@/components/NumStat";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
-import { PatchDiffView } from "@/components/diff/PatchDiffView";
+import { InlineDiffBody } from "@/components/InlineDiffBody";
 import { useOpenDiffInEditor } from "@/components/diff/OpenDiffInEditorContext";
 import { createUnifiedPatch } from "@/lib/create-unified-patch";
 import { firstChangedNewLine } from "@/lib/diff-line";
 import { countPatchStats } from "@/lib/patch-stats";
+import { isLargeDiff, isLargeDiffByLines } from "@/lib/diff-thresholds";
 
 interface InlineDiffBlockProps {
   filePath: string;
@@ -21,11 +22,12 @@ interface InlineDiffBlockProps {
   toolName?: string;
   onOpenFileInEditor?: (filePath: string, lineNumber?: number) => void;
   /**
-   * Controlled expand state. When provided, the diff body is hidden while
-   * `expanded === false`; clicking the header toggles `onExpandedChange`. When
-   * omitted, the diff stays fully expanded (legacy behavior).
+   * Expansion policy for ordinary diffs. Crash-risk large diffs always begin
+   * locally collapsed and require an explicit click, regardless of this value.
+   * When omitted, ordinary diffs stay fully expanded (legacy behavior).
    */
   expanded?: boolean;
+  /** Reports ordinary diff policy changes; large-diff disclosure stays local. */
   onExpandedChange?: (next: boolean) => void;
 }
 
@@ -120,20 +122,31 @@ export function InlineDiffBlock({
   const contextOpenFileInEditor = useOpenDiffInEditor();
   const openFileInEditor = onOpenFileInEditor ?? contextOpenFileInEditor;
   const displayPath = useMemo(() => toRelativePath(filePath, basePath), [filePath, basePath]);
-  // When controlled, the parent decides visibility. When uncontrolled (the
-  // legacy callsite), the block stays expanded — matching pre-existing
-  // behavior so non-verbosity callers don't suddenly hide their diffs.
-  const { value: isExpanded, toggle: toggleExpanded } = useControllableBoolean({
-    value: expanded,
-    onChange: onExpandedChange,
-    defaultValue: true,
-  });
-
   const patch = useMemo(
     () => createUnifiedPatch({ filePath: displayPath, oldContent, newContent }),
     [displayPath, oldContent, newContent],
   );
   const stats = useMemo(() => countPatchStats(patch), [patch]);
+  const isLarge =
+    isLargeDiff(oldContent.length, newContent.length) ||
+    isLargeDiffByLines(stats.additions, stats.deletions);
+  // When controlled, the parent decides visibility. When uncontrolled (the
+  // legacy callsite), the block stays expanded — matching pre-existing
+  // behavior so non-verbosity callers don't suddenly hide their diffs.
+  const { value: policyExpanded, toggle: togglePolicyExpanded } = useControllableBoolean({
+    value: expanded,
+    onChange: onExpandedChange,
+    defaultValue: true,
+  });
+  const [largeExpanded, setLargeExpanded] = useState(false);
+  const isExpanded = isLarge ? largeExpanded : policyExpanded;
+  const toggleExpanded = useCallback((): void => {
+    if (!isLarge) {
+      togglePolicyExpanded();
+      return;
+    }
+    setLargeExpanded((previous) => !previous);
+  }, [isLarge, togglePolicyExpanded]);
 
   if (oldContent === newContent) {
     return (
@@ -160,14 +173,12 @@ export function InlineDiffBlock({
       />
 
       <CollapsibleSection open={isExpanded}>
-        <PatchDiffView
+        <InlineDiffBody
+          isLarge={isLarge}
           patch={patch}
-          mode="unified"
-          className="cadencr-patch-diff-inline max-h-[500px] overflow-auto"
-          themeAppearance={theme.appearance}
+          patchLines={additions + deletions}
           themeId={theme.id}
-          disableFileHeader
-          hunkSeparators="simple"
+          themeAppearance={theme.appearance}
         />
       </CollapsibleSection>
     </div>

--- a/packages/desktop/src/components/InlineDiffBlock.tsx
+++ b/packages/desktop/src/components/InlineDiffBlock.tsx
@@ -10,7 +10,7 @@ import { useOpenDiffInEditor } from "@/components/diff/OpenDiffInEditorContext";
 import { createUnifiedPatch } from "@/lib/create-unified-patch";
 import { firstChangedNewLine } from "@/lib/diff-line";
 import { countPatchStats } from "@/lib/patch-stats";
-import { isLargeDiff, isLargeDiffByLines } from "@/lib/diff-thresholds";
+import { isLargeDiff, isLargeDiffByLines, utf8ByteLength } from "@/lib/diff-thresholds";
 
 interface InlineDiffBlockProps {
   filePath: string;
@@ -127,9 +127,12 @@ export function InlineDiffBlock({
     [displayPath, oldContent, newContent],
   );
   const stats = useMemo(() => countPatchStats(patch), [patch]);
+  const [oldBytes, newBytes] = useMemo(
+    () => [utf8ByteLength(oldContent), utf8ByteLength(newContent)],
+    [oldContent, newContent],
+  );
   const isLarge =
-    isLargeDiff(oldContent.length, newContent.length) ||
-    isLargeDiffByLines(stats.additions, stats.deletions);
+    isLargeDiff(oldBytes, newBytes) || isLargeDiffByLines(stats.additions, stats.deletions);
   // When controlled, the parent decides visibility. When uncontrolled (the
   // legacy callsite), the block stays expanded — matching pre-existing
   // behavior so non-verbosity callers don't suddenly hide their diffs.

--- a/packages/desktop/src/components/InlineDiffBody.tsx
+++ b/packages/desktop/src/components/InlineDiffBody.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useId, useRef } from "react";
+import { FileWarningIcon } from "lucide-react";
+import { PatchDiffView } from "@/components/diff/PatchDiffView";
+import { useInViewport } from "@/hooks/useInViewport";
+import {
+  recordHeavyInlineMounted,
+  recordHeavyInlineUnmounted,
+  recordHeavyInlineVisible,
+} from "@/lib/diff-render-diagnostics";
+import { formatBytes } from "@/lib/diff-thresholds";
+import type { ThemeAppearance, ThemeId } from "@/lib/themes";
+
+interface InlineDiffBodyProps {
+  isLarge: boolean;
+  patch: string;
+  patchLines: number;
+  themeAppearance: ThemeAppearance;
+  themeId: ThemeId;
+}
+
+// Unlike the Git diff's opt-in progressive renderer, this path deliberately
+// avoids mounting Pierre at all after the user expands a crash-risk inline diff.
+function LargeInlineDiff({ patch, patchLines }: Pick<InlineDiffBodyProps, "patch" | "patchLines">) {
+  return (
+    <div className="max-h-[500px] overflow-auto bg-[var(--editor-bg)]">
+      <div className="sticky top-0 flex items-center gap-2 border-b border-[var(--editor-border)] bg-[var(--editor-bg)] px-3 py-2 text-xs text-[var(--editor-comment)]">
+        <FileWarningIcon className="size-3.5 shrink-0" />
+        <span>
+          Large diff shown without syntax highlighting (about {formatBytes(patch.length)},{" "}
+          {patchLines.toLocaleString()} changed lines)
+        </span>
+      </div>
+      <pre className="m-0 min-w-max p-3 font-mono text-xs leading-5 text-[var(--editor-fg)]">
+        {patch}
+      </pre>
+    </div>
+  );
+}
+
+export function InlineDiffBody({
+  isLarge,
+  patch,
+  patchLines,
+  themeAppearance,
+  themeId,
+}: InlineDiffBodyProps) {
+  const blockId = useId();
+  const viewportRootRef = useRef<HTMLElement | null>(null);
+  const { setRef: viewportRef, inView: isNearViewport } = useInViewport(
+    viewportRootRef,
+    "600px 0px",
+  );
+
+  useEffect(() => {
+    if (!isLarge) return;
+    recordHeavyInlineMounted(blockId, patch.length, patchLines);
+    return () => recordHeavyInlineUnmounted(blockId);
+  }, [blockId, isLarge, patch.length, patchLines]);
+
+  useEffect(() => {
+    if (isLarge) recordHeavyInlineVisible(blockId, isNearViewport);
+  }, [blockId, isLarge, isNearViewport]);
+
+  return (
+    <div ref={viewportRef} data-testid="inline-diff-body">
+      {!isNearViewport ? (
+        <div className="px-3 py-3 text-xs text-[var(--editor-comment)]">
+          Diff renderer deferred until this change is near the viewport.
+        </div>
+      ) : isLarge ? (
+        <LargeInlineDiff patch={patch} patchLines={patchLines} />
+      ) : (
+        <PatchDiffView
+          patch={patch}
+          mode="unified"
+          className="cadencr-patch-diff-inline max-h-[500px] overflow-auto"
+          themeAppearance={themeAppearance}
+          themeId={themeId}
+          disableFileHeader
+          hunkSeparators="simple"
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/desktop/src/components/InlineDiffBody.tsx
+++ b/packages/desktop/src/components/InlineDiffBody.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useMemo, useRef } from "react";
 import { FileWarningIcon } from "lucide-react";
 import { PatchDiffView } from "@/components/diff/PatchDiffView";
 import { useInViewport } from "@/hooks/useInViewport";
 import {
   recordHeavyInlineMounted,
   recordHeavyInlineUnmounted,
+  recordHeavyInlineUpdated,
   recordHeavyInlineVisible,
 } from "@/lib/diff-render-diagnostics";
-import { formatBytes } from "@/lib/diff-thresholds";
+import { formatBytes, utf8ByteLength } from "@/lib/diff-thresholds";
 import type { ThemeAppearance, ThemeId } from "@/lib/themes";
 
 interface InlineDiffBodyProps {
@@ -21,12 +22,13 @@ interface InlineDiffBodyProps {
 // Unlike the Git diff's opt-in progressive renderer, this path deliberately
 // avoids mounting Pierre at all after the user expands a crash-risk inline diff.
 function LargeInlineDiff({ patch, patchLines }: Pick<InlineDiffBodyProps, "patch" | "patchLines">) {
+  const patchBytes = useMemo(() => utf8ByteLength(patch), [patch]);
   return (
     <div className="max-h-[500px] overflow-auto bg-[var(--editor-bg)]">
       <div className="sticky top-0 flex items-center gap-2 border-b border-[var(--editor-border)] bg-[var(--editor-bg)] px-3 py-2 text-xs text-[var(--editor-comment)]">
         <FileWarningIcon className="size-3.5 shrink-0" />
         <span>
-          Large diff shown without syntax highlighting (about {formatBytes(patch.length)},{" "}
+          Large diff shown without syntax highlighting (about {formatBytes(patchBytes)},{" "}
           {patchLines.toLocaleString()} changed lines)
         </span>
       </div>
@@ -53,8 +55,12 @@ export function InlineDiffBody({
 
   useEffect(() => {
     if (!isLarge) return;
-    recordHeavyInlineMounted(blockId, patch.length, patchLines);
+    recordHeavyInlineMounted(blockId);
     return () => recordHeavyInlineUnmounted(blockId);
+  }, [blockId, isLarge]);
+
+  useEffect(() => {
+    if (isLarge) recordHeavyInlineUpdated(blockId, patch.length, patchLines);
   }, [blockId, isLarge, patch.length, patchLines]);
 
   useEffect(() => {

--- a/packages/desktop/src/components/diff/PatchDiffView.tsx
+++ b/packages/desktop/src/components/diff/PatchDiffView.tsx
@@ -25,6 +25,13 @@ import { parseUnifiedDiff } from "@/lib/parse-unified-diff";
 import type { PrThreadLine } from "@/lib/pr-review-threads";
 import type { ThemeAppearance, ThemeId } from "@/lib/themes";
 import { cn } from "@/lib/utils";
+import {
+  countTextLines,
+  recordPierreCleaned,
+  recordPierreCreated,
+  recordPierreRenderCompleted,
+  recordPierreRenderStarted,
+} from "@/lib/diff-render-diagnostics";
 
 import { DIFF_UNSAFE_CSS } from "./patch-diff-css";
 import type { ActiveWidget, CommentCallbacks, CommentLineData } from "./diff-comment-decorations";
@@ -87,7 +94,9 @@ function cleanUpManagedPierreHost<LAnnotation>(
   instance: PierreDiffInstance<LAnnotation> | null,
   container: HTMLElement | null,
 ): void {
+  const cleanupStartedAt = performance.now();
   instance?.cleanUp();
+  if (instance) recordPierreCleaned(instance.__id, performance.now() - cleanupStartedAt);
   // Clear managed shadow DOM so StrictMode cannot retain an orphaned virtualized placeholder.
   container?.shadowRoot?.replaceChildren();
 }
@@ -183,6 +192,8 @@ function SafePatchDiff<LAnnotation>({
           )
         : new PierreFileDiff(currentOptions, undefined, true);
       instanceRef.current = instance;
+      recordPierreCreated(instance.__id, patch.length, countTextLines(patch));
+      recordPierreRenderStarted(instance.__id);
       instance.hydrate({
         fileDiff: fileDiffRef.current,
         fileContainer: node,
@@ -214,9 +225,11 @@ function SafePatchDiff<LAnnotation>({
       // capture the OLD visible-line anchor before it renders the new target.
       virtualizedInstance.prepareCodeViewItem(fileDiff, virtualizedInstance.top ?? 0);
       virtualizedInstance.setLineAnnotations(lineAnnotations ?? []);
+      recordPierreRenderStarted(instance.__id);
       virtualizedInstance.rerender();
       return;
     }
+    recordPierreRenderStarted(instance.__id);
     instance.render({ forceRender, fileDiff, lineAnnotations });
   }, [fileDiff, lineAnnotations, options, virtualizer]);
   const getHoveredLine = useCallback(() => instanceRef.current?.getHoveredLine(), []);
@@ -339,6 +352,9 @@ function PatchDiffViewImpl({
       onGutterUtilityClick: onAddComment ? handleAddComment : undefined,
       onLineClick:
         !CAN_HOVER && onAddComment ? (line) => revealGutterUtility(line.numberElement) : undefined,
+      onPostRender: (_node, instance, phase) => {
+        if (phase !== "unmount") recordPierreRenderCompleted(instance.__id);
+      },
       unsafeCSS: DIFF_UNSAFE_CSS,
     }),
     [

--- a/packages/desktop/src/hooks/usePromptHistory.test.ts
+++ b/packages/desktop/src/hooks/usePromptHistory.test.ts
@@ -65,6 +65,26 @@ describe("usePromptHistory", () => {
     expect(result.current.historyIndex).toBe(0);
   });
 
+  it("preserves loaded history when a reconnect fetch times out", async () => {
+    mockSendRequest.mockResolvedValueOnce({ entries: ["first"] });
+    const { result, rerender } = renderHook(() => usePromptHistory(1, "ws-test-1"));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    mockIsConnected.mockReturnValue(false);
+    rerender();
+    mockSendRequest.mockResolvedValueOnce(null as never);
+    mockIsConnected.mockReturnValue(true);
+    rerender();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.navigateUp("draft")).toBe("first");
+  });
+
   it("navigateUp goes to older entries", async () => {
     mockSendRequest.mockResolvedValue({ entries: ["first", "second", "third"] });
     const { result } = renderHook(() => usePromptHistory(1, "ws-test-1"));

--- a/packages/desktop/src/hooks/usePromptHistory.ts
+++ b/packages/desktop/src/hooks/usePromptHistory.ts
@@ -79,8 +79,8 @@ export function usePromptHistory(projectId: number, wsSessionId?: string) {
   useEffect(() => {
     if (!wsSessionId || !projectId || !isConnected) return;
     void sendRequest(wsSessionId, createHistoryGet(projectId)).then((payload) => {
-      const data = payload as HistoryResultPayload;
-      setHistory(data.entries ?? []);
+      const data = payload as HistoryResultPayload | null;
+      if (data) setHistory(data.entries ?? []);
     });
   }, [wsSessionId, projectId, isConnected, sendRequest]);
 

--- a/packages/desktop/src/hooks/useTerminalWebSocket.ts
+++ b/packages/desktop/src/hooks/useTerminalWebSocket.ts
@@ -8,6 +8,7 @@ import {
   unregisterReconnector,
   resetReconnectState,
   forceReconnect,
+  WS_RATE_LIMIT_RETRY_MS,
 } from "@/lib/ws-reconnect";
 import {
   reportManualReconnectRequired,
@@ -223,14 +224,17 @@ function useTerminalConnector(
             .getState()
             .reportSource(reconnectKey, "reconnecting", "Terminal WebSocket error");
         },
-        onClose: (intentional) => {
+        onClose: (intentional, event) => {
           setIsConnected(false);
           if (intentional) return;
           refs.optionsRef.current.onError("Connection lost. Reconnecting…");
           useConnectionStatusStore
             .getState()
             .reportSource(reconnectKey, "reconnecting", "Terminal WebSocket dropped");
-          scheduleReconnect(reconnectKey, reconnect);
+          scheduleReconnect(reconnectKey, reconnect, {
+            minimumDelayMs:
+              event.code === 1006 || event.code === 1013 ? WS_RATE_LIMIT_RETRY_MS : undefined,
+          });
         },
       });
     },

--- a/packages/desktop/src/hooks/useWebSocketSession.test.ts
+++ b/packages/desktop/src/hooks/useWebSocketSession.test.ts
@@ -2800,6 +2800,61 @@ describe("useWebSocketSession", () => {
     expect(result.current.isConnected).toBe(true);
   });
 
+  it("deduplicates reconnect errors across a flapping active session", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    renderHook(() => useWebSocketSession("flapping-id"));
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const firstWs = getWs();
+    act(() => {
+      firstWs.simulateMessage({
+        domain: "session",
+        action: "initialized",
+        payload: { session_id: "srv-session-1" },
+      });
+      firstWs.simulateMessage({
+        domain: "session",
+        action: "message",
+        payload: {
+          blocks: [
+            {
+              type: "assistant",
+              uuid: "u1",
+              session_id: "srv-session-1",
+              parent_tool_use_id: null,
+              error: null,
+              message: {
+                id: "msg1",
+                model: "test-model",
+                content: [{ type: "text", text: "working" }],
+                stop_reason: null,
+              },
+            },
+          ],
+        },
+      });
+      firstWs.fireEvent("close", { code: 1006, reason: "" });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const secondWs = getWs();
+    act(() => {
+      secondWs.fireEvent("close", { code: 1006, reason: "" });
+    });
+
+    const reconnectErrors = useWsSessionStore
+      .getState()
+      .sessions["flapping-id"].blocks.filter((block) => block.errorCode === "WS_RECONNECTING");
+    expect(reconnectErrors).toHaveLength(1);
+  });
+
   it("creates separate connections for different sessionIds", async () => {
     const { result: r1 } = renderHook(() => useWebSocketSession("session-a"));
     const { result: r2 } = renderHook(() => useWebSocketSession("session-b"));

--- a/packages/desktop/src/hooks/useWebSocketSession.ts
+++ b/packages/desktop/src/hooks/useWebSocketSession.ts
@@ -33,6 +33,7 @@ import type { DisplayRowMode } from "@/components/agentStreamDisplay";
 import { parseAccessMode, type AccessMode } from "@/types/access-mode";
 import { parsePermissionMode } from "@/types/permission-mode";
 import type { McpServerStatus, SessionEntry } from "@/stores/ws-session-types";
+import { retainWsSession } from "@/hooks/ws-session-retention";
 
 export interface UseWebSocketSessionReturn {
   blocks: AgentBlockData[];
@@ -153,8 +154,9 @@ export function useWebSocketSession(
   const liveStatus = useSessionStatus(sessionDbId)?.status ?? null;
 
   useEffect(() => {
+    const release = retainWsSession(sessionId);
     useWsSessionStore.getState().connect(sessionId);
-    // Connections are cached; no disconnect on unmount.
+    return release;
   }, [sessionId]);
 
   usePersistedSessionLoader(session, sessionId, featureId, options);

--- a/packages/desktop/src/hooks/ws-session-retention.test.ts
+++ b/packages/desktop/src/hooks/ws-session-retention.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearWsSessionRetentionForTests,
+  retainWsSession,
+  WS_SESSION_EVICTION_MS,
+} from "./ws-session-retention";
+
+const mocks = vi.hoisted(() => ({
+  disconnect: vi.fn(),
+  sessions: {} as Record<string, { sessionDbId: number | null; serverSessionId: string }>,
+  statuses: {} as Record<number, { status: "idle" | "agent" | "question" }>,
+}));
+
+vi.mock("@/stores/ws-session-store", () => ({
+  useWsSessionStore: {
+    getState: () => ({ sessions: mocks.sessions, disconnect: mocks.disconnect }),
+  },
+}));
+
+vi.mock("@/stores/session-status-store", () => ({
+  useSessionStatusStore: {
+    getState: () => ({ bySession: mocks.statuses }),
+  },
+}));
+
+describe("ws-session-retention", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.disconnect.mockClear();
+    mocks.sessions = {};
+    mocks.statuses = {};
+  });
+
+  afterEach(() => {
+    clearWsSessionRetentionForTests();
+    vi.useRealTimers();
+  });
+
+  it("evicts an unreferenced idle session after the grace period", () => {
+    mocks.sessions["session-1"] = { sessionDbId: 42, serverSessionId: "runtime-1" };
+    mocks.statuses[42] = { status: "idle" };
+    const release = retainWsSession("session-1");
+
+    release();
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS);
+
+    expect(mocks.disconnect).toHaveBeenCalledWith("session-1");
+  });
+
+  it("evicts an uninitialized session using the store's empty runtime-id sentinel", () => {
+    mocks.sessions["session-1"] = { sessionDbId: null, serverSessionId: "" };
+    const release = retainWsSession("session-1");
+
+    release();
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS);
+
+    expect(mocks.disconnect).toHaveBeenCalledWith("session-1");
+  });
+
+  it("does not evict an active session", () => {
+    mocks.sessions["session-1"] = { sessionDbId: 42, serverSessionId: "runtime-1" };
+    mocks.statuses[42] = { status: "agent" };
+    const release = retainWsSession("session-1");
+
+    release();
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS * 2);
+
+    expect(mocks.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("evicts once a previously active session becomes idle", () => {
+    mocks.sessions["session-1"] = { sessionDbId: 42, serverSessionId: "runtime-1" };
+    mocks.statuses[42] = { status: "agent" };
+    const release = retainWsSession("session-1");
+
+    release();
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS);
+    mocks.statuses[42] = { status: "idle" };
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS);
+
+    expect(mocks.disconnect).toHaveBeenCalledWith("session-1");
+  });
+
+  it("cancels eviction when a second consumer retains the session", () => {
+    mocks.sessions["session-1"] = { sessionDbId: null, serverSessionId: "" };
+    const firstRelease = retainWsSession("session-1");
+    firstRelease();
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS - 1);
+
+    retainWsSession("session-1");
+    vi.advanceTimersByTime(WS_SESSION_EVICTION_MS);
+
+    expect(mocks.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop/src/hooks/ws-session-retention.ts
+++ b/packages/desktop/src/hooks/ws-session-retention.ts
@@ -1,0 +1,60 @@
+import { useSessionStatusStore } from "@/stores/session-status-store";
+import { useWsSessionStore } from "@/stores/ws-session-store";
+
+export const WS_SESSION_EVICTION_MS = 5 * 60_000;
+
+interface RetentionEntry {
+  references: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const entries = new Map<string, RetentionEntry>();
+
+function canEvictSession(sessionId: string): boolean {
+  const session = useWsSessionStore.getState().sessions[sessionId];
+  if (!session) return true;
+  if (session.sessionDbId == null) {
+    // An uninitialized, empty session is safe to release. Once the backend has
+    // assigned a runtime id, wait for canonical status before tearing it down.
+    return session.serverSessionId === "";
+  }
+  return useSessionStatusStore.getState().bySession[session.sessionDbId]?.status === "idle";
+}
+
+function scheduleEviction(sessionId: string, entry: RetentionEntry): void {
+  entry.timer = setTimeout(() => {
+    entry.timer = null;
+    if (entry.references > 0) return;
+    if (!canEvictSession(sessionId)) {
+      scheduleEviction(sessionId, entry);
+      return;
+    }
+    useWsSessionStore.getState().disconnect(sessionId);
+    entries.delete(sessionId);
+  }, WS_SESSION_EVICTION_MS);
+}
+
+export function retainWsSession(sessionId: string): () => void {
+  const entry = entries.get(sessionId) ?? { references: 0, timer: null };
+  entries.set(sessionId, entry);
+  entry.references += 1;
+  if (entry.timer) {
+    clearTimeout(entry.timer);
+    entry.timer = null;
+  }
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    entry.references = Math.max(0, entry.references - 1);
+    if (entry.references === 0 && !entry.timer) scheduleEviction(sessionId, entry);
+  };
+}
+
+export function clearWsSessionRetentionForTests(): void {
+  for (const entry of entries.values()) {
+    if (entry.timer) clearTimeout(entry.timer);
+  }
+  entries.clear();
+}

--- a/packages/desktop/src/lib/diff-render-diagnostics.test.ts
+++ b/packages/desktop/src/lib/diff-render-diagnostics.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  countTextLines,
+  getDiffRenderDiagnostics,
+  recordPierreCleaned,
+  recordPierreCreated,
+  recordPierreRenderCompleted,
+  recordPierreRenderStarted,
+} from "./diff-render-diagnostics";
+
+describe("diff-render-diagnostics", () => {
+  it("tracks completed and cancelled render lifecycles without retaining instances", () => {
+    const before = getDiffRenderDiagnostics();
+    const instanceId = "diagnostics-test-instance";
+
+    recordPierreCreated(instanceId, 12, 3);
+    recordPierreRenderStarted(instanceId);
+    recordPierreRenderStarted(instanceId);
+    recordPierreRenderCompleted(instanceId);
+    recordPierreCleaned(instanceId, 4);
+
+    const after = getDiffRenderDiagnostics();
+    expect(after.pierreCreated - before.pierreCreated).toBe(1);
+    expect(after.pierreCleaned - before.pierreCleaned).toBe(1);
+    expect(after.pierreLive).toBe(before.pierreLive);
+    expect(after.highlightStarted - before.highlightStarted).toBe(2);
+    expect(after.highlightCompleted - before.highlightCompleted).toBe(1);
+    expect(after.highlightCancelled - before.highlightCancelled).toBe(1);
+    expect(window.__CADENCR_DIFF_DIAGNOSTICS__).toEqual(after);
+  });
+
+  it("counts empty and newline-terminated text correctly", () => {
+    expect(countTextLines("")).toBe(0);
+    expect(countTextLines("one\ntwo\n")).toBe(3);
+  });
+});

--- a/packages/desktop/src/lib/diff-render-diagnostics.test.ts
+++ b/packages/desktop/src/lib/diff-render-diagnostics.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   countTextLines,
   getDiffRenderDiagnostics,
+  recordHeavyInlineMounted,
+  recordHeavyInlineUnmounted,
+  recordHeavyInlineUpdated,
+  recordHeavyInlineVisible,
   recordPierreCleaned,
   recordPierreCreated,
   recordPierreRenderCompleted,
@@ -32,5 +36,29 @@ describe("diff-render-diagnostics", () => {
   it("counts empty and newline-terminated text correctly", () => {
     expect(countTextLines("")).toBe(0);
     expect(countTextLines("one\ntwo\n")).toBe(3);
+  });
+
+  it("updates heavy-inline maxima without changing mount or visibility counts", () => {
+    const before = getDiffRenderDiagnostics();
+    const blockId = "diagnostics-heavy-inline-update";
+    const patchChars = before.maxPatchChars + 1;
+    const patchLines = before.maxPatchLines + 1;
+
+    recordHeavyInlineMounted(blockId);
+    recordHeavyInlineVisible(blockId, true);
+    recordHeavyInlineUpdated(blockId, patchChars, patchLines);
+    recordHeavyInlineUpdated(blockId, patchChars + 1, patchLines + 1);
+
+    const updated = getDiffRenderDiagnostics();
+    expect(updated.heavyInlineMounts - before.heavyInlineMounts).toBe(1);
+    expect(updated.heavyInlineMounted - before.heavyInlineMounted).toBe(1);
+    expect(updated.heavyInlineVisible - before.heavyInlineVisible).toBe(1);
+    expect(updated.maxPatchChars).toBe(patchChars + 1);
+    expect(updated.maxPatchLines).toBe(patchLines + 1);
+
+    recordHeavyInlineUnmounted(blockId);
+    const unmounted = getDiffRenderDiagnostics();
+    expect(unmounted.heavyInlineMounted).toBe(before.heavyInlineMounted);
+    expect(unmounted.heavyInlineVisible).toBe(before.heavyInlineVisible);
   });
 });

--- a/packages/desktop/src/lib/diff-render-diagnostics.ts
+++ b/packages/desktop/src/lib/diff-render-diagnostics.ts
@@ -1,0 +1,126 @@
+export interface DiffRenderDiagnosticsSnapshot {
+  pierreCreated: number;
+  pierreCleaned: number;
+  pierreLive: number;
+  highlightStarted: number;
+  highlightCompleted: number;
+  highlightCancelled: number;
+  maxPatchChars: number;
+  maxPatchLines: number;
+  maxCleanupDurationMs: number;
+  heavyInlineMounted: number;
+  heavyInlineVisible: number;
+  heavyInlineMounts: number;
+}
+
+const livePierre = new Set<string>();
+const pendingPierre = new Map<string, number>();
+const mountedHeavyInline = new Set<string>();
+const visibleHeavyInline = new Set<string>();
+
+let pierreCreated = 0;
+let pierreCleaned = 0;
+let highlightStarted = 0;
+let highlightCompleted = 0;
+let highlightCancelled = 0;
+let maxPatchChars = 0;
+let maxPatchLines = 0;
+let maxCleanupDurationMs = 0;
+let heavyInlineMounts = 0;
+
+export function getDiffRenderDiagnostics(): DiffRenderDiagnosticsSnapshot {
+  return {
+    pierreCreated,
+    pierreCleaned,
+    pierreLive: livePierre.size,
+    highlightStarted,
+    highlightCompleted,
+    highlightCancelled,
+    maxPatchChars,
+    maxPatchLines,
+    maxCleanupDurationMs,
+    heavyInlineMounted: mountedHeavyInline.size,
+    heavyInlineVisible: visibleHeavyInline.size,
+    heavyInlineMounts,
+  };
+}
+
+export function countTextLines(text: string): number {
+  let lines = text.length === 0 ? 0 : 1;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) === 10) lines += 1;
+  }
+  return lines;
+}
+
+export function recordPierreCreated(
+  instanceId: string,
+  patchChars: number,
+  patchLines: number,
+): void {
+  if (!livePierre.has(instanceId)) {
+    livePierre.add(instanceId);
+    pierreCreated += 1;
+  }
+  maxPatchChars = Math.max(maxPatchChars, patchChars);
+  maxPatchLines = Math.max(maxPatchLines, patchLines);
+}
+
+export function recordPierreRenderStarted(instanceId: string): void {
+  pendingPierre.set(instanceId, (pendingPierre.get(instanceId) ?? 0) + 1);
+  highlightStarted += 1;
+}
+
+export function recordPierreRenderCompleted(instanceId: string): void {
+  const pending = pendingPierre.get(instanceId);
+  if (pending == null) return;
+  if (pending === 1) pendingPierre.delete(instanceId);
+  else pendingPierre.set(instanceId, pending - 1);
+  highlightCompleted += 1;
+}
+
+export function recordPierreCleaned(instanceId: string, cleanupMs: number): void {
+  if (livePierre.delete(instanceId)) pierreCleaned += 1;
+  maxCleanupDurationMs = Math.max(maxCleanupDurationMs, cleanupMs);
+  const pending = pendingPierre.get(instanceId);
+  if (pending != null) {
+    pendingPierre.delete(instanceId);
+    highlightCancelled += pending;
+  }
+}
+
+export function recordHeavyInlineMounted(
+  blockId: string,
+  patchChars: number,
+  patchLines: number,
+): void {
+  mountedHeavyInline.add(blockId);
+  heavyInlineMounts += 1;
+  maxPatchChars = Math.max(maxPatchChars, patchChars);
+  maxPatchLines = Math.max(maxPatchLines, patchLines);
+}
+
+export function recordHeavyInlineVisible(blockId: string, visible: boolean): void {
+  if (visible) visibleHeavyInline.add(blockId);
+  else visibleHeavyInline.delete(blockId);
+}
+
+export function recordHeavyInlineUnmounted(blockId: string): void {
+  mountedHeavyInline.delete(blockId);
+  visibleHeavyInline.delete(blockId);
+}
+
+declare global {
+  interface Window {
+    __CADENCR_DIFF_DIAGNOSTICS__?: DiffRenderDiagnosticsSnapshot;
+  }
+}
+
+// Intentionally available in packaged builds for reporter diagnostics. A
+// getter keeps the render hot path allocation-free until somebody inspects it.
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "__CADENCR_DIFF_DIAGNOSTICS__", {
+    configurable: true,
+    get: getDiffRenderDiagnostics,
+  });
+}

--- a/packages/desktop/src/lib/diff-render-diagnostics.ts
+++ b/packages/desktop/src/lib/diff-render-diagnostics.ts
@@ -89,13 +89,18 @@ export function recordPierreCleaned(instanceId: string, cleanupMs: number): void
   }
 }
 
-export function recordHeavyInlineMounted(
+export function recordHeavyInlineMounted(blockId: string): void {
+  mountedHeavyInline.add(blockId);
+  heavyInlineMounts += 1;
+}
+
+/** Update maxima without changing the block's mount or visibility lifecycle. */
+export function recordHeavyInlineUpdated(
   blockId: string,
   patchChars: number,
   patchLines: number,
 ): void {
-  mountedHeavyInline.add(blockId);
-  heavyInlineMounts += 1;
+  if (!mountedHeavyInline.has(blockId)) return;
   maxPatchChars = Math.max(maxPatchChars, patchChars);
   maxPatchLines = Math.max(maxPatchLines, patchLines);
 }

--- a/packages/desktop/src/lib/diff-thresholds.test.ts
+++ b/packages/desktop/src/lib/diff-thresholds.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isLargeDiff, LARGE_DIFF_BYTES, utf8ByteLength } from "./diff-thresholds";
+
+describe("diff-thresholds", () => {
+  it("measures multibyte content using encoded UTF-8 bytes", () => {
+    const cjkContent = "界".repeat(70_000);
+
+    expect(cjkContent.length).toBeLessThan(LARGE_DIFF_BYTES);
+    expect(utf8ByteLength(cjkContent)).toBe(210_000);
+    expect(isLargeDiff(0, utf8ByteLength(cjkContent))).toBe(true);
+  });
+});

--- a/packages/desktop/src/lib/diff-thresholds.ts
+++ b/packages/desktop/src/lib/diff-thresholds.ts
@@ -21,10 +21,16 @@ export const LARGE_DIFF_BYTES = 200_000;
  */
 export const LARGE_DIFF_LINES = 1_500;
 
+const utf8Encoder = new TextEncoder();
+
+/** Return the encoded UTF-8 byte length used by backend size thresholds. */
+export function utf8ByteLength(text: string): number {
+  return utf8Encoder.encode(text).byteLength;
+}
+
 /**
  * True when either side's byte size is large enough that auto-rendering
- * would jank the UI. Pass content lengths in characters or bytes — the
- * threshold is generous enough that the difference is irrelevant.
+ * would jank the UI.
  */
 export function isLargeDiff(oldLen: number, newLen: number): boolean {
   return Math.max(oldLen, newLen) >= LARGE_DIFF_BYTES;

--- a/packages/desktop/src/lib/ws-connection.test.ts
+++ b/packages/desktop/src/lib/ws-connection.test.ts
@@ -102,7 +102,7 @@ describe("createWsConnection", () => {
     const onClose = vi.fn();
     createWsConnection({ url: "ws://x", onClose, onMessage: vi.fn() });
     lastWs().simulateClose();
-    expect(onClose).toHaveBeenCalledWith(false);
+    expect(onClose).toHaveBeenCalledWith(false, expect.anything());
   });
 
   it("calls onClose with intentional=true after close() is called", () => {
@@ -110,7 +110,7 @@ describe("createWsConnection", () => {
     const conn = createWsConnection({ url: "ws://x", onClose, onMessage: vi.fn() });
     lastWs().simulateOpen();
     conn.close();
-    expect(onClose).toHaveBeenCalledWith(true);
+    expect(onClose).toHaveBeenCalledWith(true, expect.anything());
   });
 
   it("calls onError with intentional flag", () => {

--- a/packages/desktop/src/lib/ws-connection.ts
+++ b/packages/desktop/src/lib/ws-connection.ts
@@ -8,7 +8,7 @@ export interface WsConnectionOptions {
   /** Forwarded to `new WebSocket(url, protocols)`; see `getWsProtocols`. */
   protocols?: string[];
   onOpen?: () => void;
-  onClose?: (intentional: boolean) => void;
+  onClose?: (intentional: boolean, event: CloseEvent) => void;
   onError?: (intentional: boolean) => void;
   onMessage: (data: string) => void;
 }
@@ -30,7 +30,7 @@ export function createWsConnection(options: WsConnectionOptions): WsConnection {
   ws.addEventListener("open", () => options.onOpen?.());
   ws.addEventListener("message", (e) => options.onMessage(e.data as string));
   ws.addEventListener("error", () => options.onError?.(intentionalClose));
-  ws.addEventListener("close", () => options.onClose?.(intentionalClose));
+  ws.addEventListener("close", (event) => options.onClose?.(intentionalClose, event));
 
   const conn: WsConnection = {
     send(data: string): boolean {

--- a/packages/desktop/src/lib/ws-reconnect.test.ts
+++ b/packages/desktop/src/lib/ws-reconnect.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   RECONNECT_INTERVAL_MS,
   RECONNECT_MAX_MS,
+  RECONNECT_STABLE_MS,
   AUTO_RECONNECT_TIMEOUT_MS,
   scheduleReconnect,
   resetReconnectState,
@@ -140,7 +141,7 @@ describe("ws-reconnect", () => {
     expect(connect).toHaveBeenCalledOnce();
   });
 
-  it("resetReconnectState clears the failure count so the next retry uses the base delay", () => {
+  it("resets the failure count only after a stable connection interval", () => {
     const connect = vi.fn();
 
     scheduleReconnect("test", connect);
@@ -150,10 +151,27 @@ describe("ws-reconnect", () => {
     expect(connect).toHaveBeenCalledTimes(2);
 
     resetReconnectState("test");
+    vi.advanceTimersByTime(RECONNECT_STABLE_MS);
 
     scheduleReconnect("test", connect);
     vi.advanceTimersByTime(RECONNECT_INTERVAL_MS);
     expect(connect).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps exponential backoff when a connection flaps before stability", () => {
+    const connect = vi.fn();
+    scheduleReconnect("test", connect);
+    vi.advanceTimersByTime(RECONNECT_INTERVAL_MS);
+    expect(connect).toHaveBeenCalledOnce();
+
+    resetReconnectState("test");
+    vi.advanceTimersByTime(RECONNECT_STABLE_MS - 1);
+    scheduleReconnect("test", connect);
+
+    vi.advanceTimersByTime(RECONNECT_INTERVAL_MS);
+    expect(connect).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(RECONNECT_INTERVAL_MS);
+    expect(connect).toHaveBeenCalledTimes(2);
   });
 
   it("notifyRateLimited defers retries until the Retry-After window passes", () => {
@@ -163,6 +181,20 @@ describe("ws-reconnect", () => {
     // First failure would normally fire at 1s, but the rate-limit hold wins.
     scheduleReconnect("test", connect);
     vi.advanceTimersByTime(4999);
+    expect(connect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(connect).toHaveBeenCalledOnce();
+  });
+
+  it("defers a retry that was already scheduled when rate limiting arrives", () => {
+    const connect = vi.fn();
+    scheduleReconnect("test", connect);
+    vi.advanceTimersByTime(RECONNECT_INTERVAL_MS / 2);
+
+    notifyRateLimited(5000);
+    vi.advanceTimersByTime(RECONNECT_INTERVAL_MS / 2);
+    expect(connect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(4499);
     expect(connect).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
     expect(connect).toHaveBeenCalledOnce();

--- a/packages/desktop/src/lib/ws-reconnect.test.ts
+++ b/packages/desktop/src/lib/ws-reconnect.test.ts
@@ -186,6 +186,22 @@ describe("ws-reconnect", () => {
     expect(connect).toHaveBeenCalledOnce();
   });
 
+  it("honors a per-connection minimum delay without globally holding other sockets", () => {
+    const connect = vi.fn();
+    const other = vi.fn();
+
+    scheduleReconnect("test", connect, { minimumDelayMs: 5000 });
+    scheduleReconnect("other", other);
+
+    vi.advanceTimersByTime(RECONNECT_INTERVAL_MS);
+    expect(other).toHaveBeenCalledOnce();
+    expect(connect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(3999);
+    expect(connect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(connect).toHaveBeenCalledOnce();
+  });
+
   it("defers a retry that was already scheduled when rate limiting arrives", () => {
     const connect = vi.fn();
     scheduleReconnect("test", connect);

--- a/packages/desktop/src/lib/ws-reconnect.ts
+++ b/packages/desktop/src/lib/ws-reconnect.ts
@@ -17,6 +17,8 @@ export const RECONNECT_INTERVAL_MS = 1000;
 export const RECONNECT_MAX_MS = 30_000;
 export const AUTO_RECONNECT_TIMEOUT_MS = 240_000;
 export const AUTO_RECONNECT_TIMEOUT_SECONDS = AUTO_RECONNECT_TIMEOUT_MS / 1000;
+export const RECONNECT_STABLE_MS = 10_000;
+export const WS_RATE_LIMIT_RETRY_MS = 5_000;
 
 /** Backoff for the Nth (1-based) consecutive failure, with half-range jitter. */
 function backoffDelayMs(failures: number): number {
@@ -40,6 +42,10 @@ export function notifyRateLimited(retryAfterMs: number): void {
   if (until > rateLimitedUntil) rateLimitedUntil = until;
 }
 
+export function isRateLimited(): boolean {
+  return Date.now() < rateLimitedUntil;
+}
+
 /** Lift the rate-limit hold (the backend is reachable again). */
 export function clearRateLimit(): void {
   rateLimitedUntil = 0;
@@ -55,6 +61,7 @@ interface ForceReconnectOptions {
 
 interface ReconnectEntry {
   timer: ReturnType<typeof setTimeout> | null;
+  stableTimer: ReturnType<typeof setTimeout> | null;
   firstFailureAt: number | null;
   /** Consecutive failures since the last successful connect; drives backoff. */
   failures: number;
@@ -71,6 +78,7 @@ function getOrCreate(key: string): ReconnectEntry {
   if (!entry) {
     entry = {
       timer: null,
+      stableTimer: null,
       firstFailureAt: null,
       failures: 0,
       manualOnly: false,
@@ -100,6 +108,10 @@ export function scheduleReconnect(
   const entry = getOrCreate(key);
   entry.connect = connect;
   applyOptions(entry, options);
+  if (entry.stableTimer) {
+    clearTimeout(entry.stableTimer);
+    entry.stableTimer = null;
+  }
   if (entry.timer) return;
   if (entry.manualOnly) return;
 
@@ -114,20 +126,30 @@ export function scheduleReconnect(
   // Wait at least the backoff, and never retry before a 429's Retry-After.
   const delay = Math.max(backoffDelayMs(entry.failures), rateLimitedUntil - now);
 
-  entry.timer = setTimeout(() => {
+  const attemptConnect = (): void => {
+    const rateLimitDelay = rateLimitedUntil - Date.now();
+    if (rateLimitDelay > 0) {
+      entry.timer = setTimeout(attemptConnect, rateLimitDelay);
+      return;
+    }
     entry.timer = null;
     if (entry.manualOnly) return;
     if (isHiddenBrowserRemote()) return;
     connect();
-  }, delay);
+  };
+  entry.timer = setTimeout(attemptConnect, delay);
 }
 
 export function resetReconnectState(key: string): void {
   const entry = entries.get(key);
   if (!entry) return;
-  entry.firstFailureAt = null;
-  entry.failures = 0;
-  entry.manualOnly = false;
+  if (entry.stableTimer) clearTimeout(entry.stableTimer);
+  entry.stableTimer = setTimeout(() => {
+    entry.stableTimer = null;
+    entry.firstFailureAt = null;
+    entry.failures = 0;
+    entry.manualOnly = false;
+  }, RECONNECT_STABLE_MS);
 }
 
 export function clearReconnect(key: string): void {
@@ -136,6 +158,7 @@ export function clearReconnect(key: string): void {
     clearTimeout(entry.timer);
     entry.timer = null;
   }
+  if (entry?.stableTimer) clearTimeout(entry.stableTimer);
   entries.delete(key);
 }
 
@@ -170,6 +193,10 @@ export function forceReconnect(key: string, options?: ForceReconnectOptions): vo
   if (!entry?.connect) return;
   if (options?.bypassManualPause) {
     clearRateLimit();
+    if (entry.stableTimer) {
+      clearTimeout(entry.stableTimer);
+      entry.stableTimer = null;
+    }
     entry.firstFailureAt = null;
     entry.failures = 0;
     entry.manualOnly = false;

--- a/packages/desktop/src/lib/ws-reconnect.ts
+++ b/packages/desktop/src/lib/ws-reconnect.ts
@@ -55,6 +55,11 @@ interface ReconnectorOptions {
   onManualRequired?: (key: string) => void;
 }
 
+interface ScheduleReconnectOptions extends ReconnectorOptions {
+  /** Per-attempt floor used when a close signal implies reconnect pressure. */
+  minimumDelayMs?: number;
+}
+
 interface ForceReconnectOptions {
   bypassManualPause?: boolean;
 }
@@ -103,7 +108,7 @@ function pauseForManualReconnect(key: string, entry: ReconnectEntry): void {
 export function scheduleReconnect(
   key: string,
   connect: () => void,
-  options?: ReconnectorOptions,
+  options?: ScheduleReconnectOptions,
 ): void {
   const entry = getOrCreate(key);
   entry.connect = connect;
@@ -124,7 +129,11 @@ export function scheduleReconnect(
 
   entry.failures += 1;
   // Wait at least the backoff, and never retry before a 429's Retry-After.
-  const delay = Math.max(backoffDelayMs(entry.failures), rateLimitedUntil - now);
+  const delay = Math.max(
+    backoffDelayMs(entry.failures),
+    rateLimitedUntil - now,
+    options?.minimumDelayMs ?? 0,
+  );
 
   const attemptConnect = (): void => {
     const rateLimitDelay = rateLimitedUntil - Date.now();

--- a/packages/desktop/src/stores/session-status-connection.ts
+++ b/packages/desktop/src/stores/session-status-connection.ts
@@ -10,6 +10,7 @@ import {
   resetReconnectState,
   scheduleReconnect,
   unregisterReconnector,
+  WS_RATE_LIMIT_RETRY_MS,
 } from "@/lib/ws-reconnect";
 import { isBrowserRemote } from "@/lib/remote/device-token";
 import { hydratePrStatuses } from "@/stores/pr-status-hydration";
@@ -64,7 +65,7 @@ function handleAppWsOpen(connection: AppWsConnection): void {
   }
 }
 
-function handleAppWsClose(connection: AppWsConnection): void {
+function handleAppWsClose(connection: AppWsConnection, event: CloseEvent): void {
   const { ws, set, get, intentionalClose } = connection;
   connection.unsubscribeForgeVisibility();
   if (get().ws === ws) set({ isConnected: false, ws: null });
@@ -75,7 +76,9 @@ function handleAppWsClose(connection: AppWsConnection): void {
   useConnectionStatusStore
     .getState()
     .reportSource(APP_WS_SOURCE, "reconnecting", "App WebSocket dropped");
-  scheduleReconnect(APP_WS_SOURCE, () => get().connect());
+  scheduleReconnect(APP_WS_SOURCE, () => get().connect(), {
+    minimumDelayMs: event.code === 1006 || event.code === 1013 ? WS_RATE_LIMIT_RETRY_MS : undefined,
+  });
 }
 
 function handleAppWsError(connection: AppWsConnection): void {
@@ -108,7 +111,7 @@ function handleAppWsMessage(connection: AppWsConnection, event: MessageEvent): v
 
 function attachAppWsListeners(connection: AppWsConnection): void {
   connection.ws.addEventListener("open", () => handleAppWsOpen(connection));
-  connection.ws.addEventListener("close", () => handleAppWsClose(connection));
+  connection.ws.addEventListener("close", (event) => handleAppWsClose(connection, event));
   connection.ws.addEventListener("error", () => handleAppWsError(connection));
   connection.ws.addEventListener("message", (event) => handleAppWsMessage(connection, event));
 }

--- a/packages/desktop/src/stores/ws-envelope-error-handler.ts
+++ b/packages/desktop/src/stores/ws-envelope-error-handler.ts
@@ -11,6 +11,7 @@ import { type PermissionMode } from "@/types/permission-mode";
 import { makeErrorBlock } from "./ws-session-store-helpers";
 import { markPendingPromptsFailed, markPromptsReceived } from "./ws-pending-prompts";
 import type { StoreAccessors } from "./ws-envelope-types";
+import { notifyRateLimited, WS_RATE_LIMIT_RETRY_MS } from "@/lib/ws-reconnect";
 
 /**
  * Error codes whose user mistake originates outside the agent stream (e.g. a
@@ -27,6 +28,12 @@ const COMPACT_PRE_START_ERROR_CODES = new Set([
 
 export function handleError(ctx: StoreAccessors, sessionId: string, payload: unknown): void {
   const p = parseErrorPayload(payload);
+
+  if (p?.code === "RATE_LIMITED") {
+    notifyRateLimited(p.retryAfterMs ?? WS_RATE_LIMIT_RETRY_MS);
+    toast.error(p.message ?? "WebSocket message rate exceeded. Reconnecting shortly.");
+    return;
+  }
 
   if (p?.code && TOAST_ERROR_CODES.has(p.code) && p.message) {
     toast.error(p.message);

--- a/packages/desktop/src/stores/ws-envelope-handler.test.ts
+++ b/packages/desktop/src/stores/ws-envelope-handler.test.ts
@@ -6,6 +6,12 @@ import { handleEnvelope, type StoreAccessors } from "./ws-envelope-handler";
 import { createSessionEntry, type SessionEntry, type WsSessionStore } from "./ws-session-types";
 import { transitionTurn } from "./ws-turn-lifecycle";
 import { useGitStatusStore } from "./useGitStatusStore";
+import {
+  clearRateLimit,
+  forceReconnect,
+  registerReconnector,
+  unregisterReconnector,
+} from "@/lib/ws-reconnect";
 
 vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
@@ -101,6 +107,36 @@ describe("handleEnvelope turn_complete", () => {
       "The agent sent an invalid turn-complete update. The conversation was not changed.",
     );
     warnSpy.mockRestore();
+  });
+});
+
+describe("handleEnvelope RATE_LIMITED", () => {
+  it("holds reconnects without turning the agent turn into an error", () => {
+    vi.mocked(toast.error).mockClear();
+    const connect = vi.fn();
+    registerReconnector("rate-limited-test", connect);
+    const session = createSessionEntry();
+    session.lifecycle = transitionTurn(session.lifecycle, { type: "prompt_sent" });
+    const ctx = createTestContext(session);
+
+    handleEnvelope(ctx, "s1", {
+      domain: "session",
+      action: "error",
+      payload: {
+        code: "RATE_LIMITED",
+        message: "WebSocket message rate exceeded",
+        retry_after_ms: 5_000,
+      },
+    });
+    forceReconnect("rate-limited-test");
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(ctx.getSession("s1").lifecycle.phase).toBe("active");
+    expect(ctx.getSession("s1").blocks).toHaveLength(0);
+    expect(toast.error).toHaveBeenCalledWith("WebSocket message rate exceeded");
+
+    unregisterReconnector("rate-limited-test");
+    clearRateLimit();
   });
 });
 

--- a/packages/desktop/src/stores/ws-envelope-payload-session.ts
+++ b/packages/desktop/src/stores/ws-envelope-payload-session.ts
@@ -73,6 +73,7 @@ export function parseErrorPayload(payload: unknown): {
   code?: string;
   message?: string;
   mode?: string;
+  retryAfterMs?: number;
   receivedPromptMessageUuids: string[];
 } | null {
   const record = asRecord(payload);
@@ -83,6 +84,7 @@ export function parseErrorPayload(payload: unknown): {
     // Optional context attached to permission-mode rejections so the FE
     // can skip the rejected mode in the Shift+Tab cycle.
     mode: optionalString(record, "mode"),
+    retryAfterMs: optionalNumber(record, "retry_after_ms"),
     receivedPromptMessageUuids: (
       optionalArray(record, "received_prompt_message_uuids") ?? []
     ).filter((value): value is string => typeof value === "string"),

--- a/packages/desktop/src/stores/ws-session-connect.ts
+++ b/packages/desktop/src/stores/ws-session-connect.ts
@@ -1,16 +1,22 @@
 import { createWsConnection, type WsConnection } from "@/lib/ws-connection";
 import { getWsProtocols, getWsUrl } from "@/lib/ws-url";
-import { registerReconnector, resetReconnectState, scheduleReconnect } from "@/lib/ws-reconnect";
+import {
+  isRateLimited,
+  notifyRateLimited,
+  registerReconnector,
+  resetReconnectState,
+  scheduleReconnect,
+  WS_RATE_LIMIT_RETRY_MS,
+} from "@/lib/ws-reconnect";
 import {
   reportManualReconnectRequired,
   useConnectionStatusStore,
 } from "@/stores/connection-status-store";
 import { flushStreamDeltas } from "./ws-delta-coalescer";
 import type { StoreAccessors } from "./ws-envelope-handler";
-import { makeErrorBlock } from "./ws-session-store-helpers";
+import { appendErrorBlockPatch } from "./ws-session-store-helpers";
 import { createSessionEntry, type SessionEntry, updateSession } from "./ws-session-types";
 import { isTurnActive, transitionTurn } from "./ws-turn-lifecycle";
-import { blocksPatchWithDerived } from "./ws-message-processing";
 import { resyncMessagesOnReconnect } from "./ws-session-resync";
 import { handleSocketMessage, type SocketHandlerDeps } from "./ws-session-socket-handler";
 
@@ -51,7 +57,11 @@ function handleConnectionOpen(context: SessionConnectionContext): void {
   void resyncMessagesOnReconnect(ctx, context.sessionId);
 }
 
-function handleConnectionClose(context: SessionConnectionContext, intentional: boolean): void {
+function handleConnectionClose(
+  context: SessionConnectionContext,
+  intentional: boolean,
+  event: CloseEvent,
+): void {
   if (!isCurrentConnection(context) || intentional) return;
   const { ctx, rejectPendingRequests } = context.deps;
   const { get, set } = ctx;
@@ -60,14 +70,16 @@ function handleConnectionClose(context: SessionConnectionContext, intentional: b
   const session = get().sessions[context.sessionId];
   if (session) rejectPendingRequests(session);
   const wasRunning = session != null && isTurnActive(session.lifecycle);
-  const closedDerived = wasRunning
-    ? blocksPatchWithDerived(session.streamingState, [
-        ...session.blocks,
-        makeErrorBlock(session, "Connection lost while streaming. Reconnecting…", {
+  const alreadyReportedReconnect = session?.blocks.at(-1)?.errorCode === "WS_RECONNECTING";
+  const closedDerived =
+    wasRunning && !alreadyReportedReconnect
+      ? appendErrorBlockPatch(session, "Connection lost while streaming. Reconnecting…", {
+          code: "WS_RECONNECTING",
           idPrefix: "ws-err-close",
-        }),
-      ])
-    : { blocks: session?.blocks ?? [] };
+        })
+      : { blocks: session?.blocks ?? [] };
+  const retryAfterMs = event.code === 1013 ? WS_RATE_LIMIT_RETRY_MS : null;
+  if (retryAfterMs != null && !isRateLimited()) notifyRateLimited(retryAfterMs);
   set(
     updateSession(get(), context.sessionId, {
       conn: null,
@@ -81,7 +93,20 @@ function handleConnectionClose(context: SessionConnectionContext, intentional: b
   );
   useConnectionStatusStore
     .getState()
-    .reportSource(context.reconnectKey, "reconnecting", "Session WebSocket lost");
+    .reportSource(
+      context.reconnectKey,
+      "reconnecting",
+      retryAfterMs == null
+        ? `Session WebSocket closed (${event.code})`
+        : `Session WebSocket rate limited; retrying in ${Math.ceil(retryAfterMs / 1000)}s`,
+    );
+  if (event.code && event.code !== 1000) {
+    console.warn("Session WebSocket closed unexpectedly", {
+      code: event.code,
+      reason: event.reason || "no reason",
+      sessionId: context.sessionId,
+    });
+  }
   scheduleReconnect(context.reconnectKey, () => get().connect(context.sessionId));
 }
 
@@ -113,7 +138,7 @@ function createSessionConnection(context: SessionConnectionContext): WsConnectio
     url: getWsUrl(),
     protocols: getWsProtocols(),
     onOpen: () => handleConnectionOpen(context),
-    onClose: (intentional) => handleConnectionClose(context, intentional),
+    onClose: (intentional, event) => handleConnectionClose(context, intentional, event),
     onError: (intentional) => handleConnectionError(context, intentional),
     onMessage: (data) => {
       if (!isCurrentConnection(context)) return;

--- a/packages/desktop/src/stores/ws-session-connect.ts
+++ b/packages/desktop/src/stores/ws-session-connect.ts
@@ -107,7 +107,9 @@ function handleConnectionClose(
       sessionId: context.sessionId,
     });
   }
-  scheduleReconnect(context.reconnectKey, () => get().connect(context.sessionId));
+  scheduleReconnect(context.reconnectKey, () => get().connect(context.sessionId), {
+    minimumDelayMs: event.code === 1006 ? WS_RATE_LIMIT_RETRY_MS : (retryAfterMs ?? undefined),
+  });
 }
 
 function handleConnectionError(context: SessionConnectionContext, intentional: boolean): void {
@@ -130,7 +132,12 @@ function handleConnectionError(context: SessionConnectionContext, intentional: b
   useConnectionStatusStore
     .getState()
     .reportSource(context.reconnectKey, "reconnecting", "Session WebSocket error");
-  scheduleReconnect(context.reconnectKey, () => get().connect(context.sessionId));
+  // A blocked transport can prevent the backend's 1013 frame from reaching
+  // the browser, which then reports only an error/1006. Preserve the same
+  // bounded retry floor instead of immediately feeding another connection.
+  scheduleReconnect(context.reconnectKey, () => get().connect(context.sessionId), {
+    minimumDelayMs: WS_RATE_LIMIT_RETRY_MS,
+  });
 }
 
 function createSessionConnection(context: SessionConnectionContext): WsConnection {

--- a/packages/desktop/src/stores/ws-session-transport-actions.ts
+++ b/packages/desktop/src/stores/ws-session-transport-actions.ts
@@ -41,12 +41,12 @@ export function createWsSessionTransportActions(deps: TransportActionDeps): Tran
       // (it early-returns on `intentional`), so resolve in-flight requests now
       // rather than leaving permission/worktree calls hanging until the timeout.
       if (session) rejectPendingRequests(session);
-      if (!session?.conn) return;
-
-      if (session.serverSessionId) {
-        session.conn.sendJson(createDestroy(session.serverSessionId));
+      if (session?.conn) {
+        if (session.serverSessionId) {
+          session.conn.sendJson(createDestroy(session.serverSessionId));
+        }
+        session.conn.close();
       }
-      session.conn.close();
 
       const { [sessionId]: _, ...rest } = get().sessions;
       set({ sessions: rest });

--- a/packages/service/src/api/middleware/mod.rs
+++ b/packages/service/src/api/middleware/mod.rs
@@ -8,7 +8,7 @@ mod ws;
 
 pub use auth::{auth_middleware, AUTH_HEADER, MCP_CONTROL_HEADER};
 pub use cache_control::cache_control_middleware;
-pub use rate_limit::{rate_limit_middleware, RateLimiter};
+pub use rate_limit::{loopback_rate_limit_middleware, rate_limit_middleware, RateLimiter};
 pub use remote_auth::{remote_auth_middleware, DeviceId};
 pub use security_headers::remote_security_headers_middleware;
 pub use ws::authenticate_ws;

--- a/packages/service/src/api/middleware/rate_limit.rs
+++ b/packages/service/src/api/middleware/rate_limit.rs
@@ -1,10 +1,10 @@
-//! Per-IP fixed-window rate limiting for the remote (network) listener.
+//! Per-IP fixed-window rate limiting for loopback and remote listeners.
 //!
 //! The pairing endpoint is pre-auth and brute-forceable (a short pairing code
 //! is the only secret), so it gets a tight bucket; everything else gets a loose
 //! bucket that bounds general abuse. State is in-memory and lives for the life
-//! of one listener (a fresh limiter is created each time remote access is
-//! enabled), keyed by source IP from `ConnectInfo<SocketAddr>`.
+//! of one listener (each router receives its own limiter), keyed by source IP
+//! from `ConnectInfo<SocketAddr>`.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -23,13 +23,13 @@ const WINDOW: Duration = Duration::from_secs(60);
 /// Pairing-code attempts per IP per window. A code is single-use and expires in
 /// ~120s, so a legitimate device needs only one or two attempts.
 const PAIR_LIMIT: u32 = 5;
-/// All other remote requests per IP per window, counted *before* auth (this
-/// layer wraps `remote_auth_middleware`), so SPA assets and rejected tokens
-/// count too. A phone opening the app bursts well past a "reasonable" steady
-/// rate — hashed chunks and fonts, agent catalog, per-project settings, git
-/// stats, WS handshakes — and tripping this only produced 429s the client
-/// retried into. Sized as a runaway backstop rather than a traffic policy;
-/// pairing brute-force is bounded separately by `PAIR_LIMIT`.
+/// All other requests per IP per window, counted *before* listener-specific
+/// auth, so SPA assets and rejected tokens count too. A client opening the app
+/// bursts well past a "reasonable" steady rate — hashed chunks and fonts,
+/// agent catalog, per-project settings, git stats, WS handshakes — and tripping
+/// this only produced 429s the client retried into. Sized as a runaway backstop
+/// rather than a traffic policy; pairing brute-force is bounded separately by
+/// `PAIR_LIMIT`.
 const GENERAL_LIMIT: u32 = 6000;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]

--- a/packages/service/src/api/middleware/rate_limit.rs
+++ b/packages/service/src/api/middleware/rate_limit.rs
@@ -2,9 +2,11 @@
 //!
 //! The pairing endpoint is pre-auth and brute-forceable (a short pairing code
 //! is the only secret), so it gets a tight bucket; everything else gets a loose
-//! bucket that bounds general abuse. State is in-memory and lives for the life
-//! of one listener (each router receives its own limiter), keyed by source IP
-//! from `ConnectInfo<SocketAddr>`.
+//! bucket that bounds general abuse. Loopback requests carrying the per-launch
+//! credential use a separate bucket so anonymous local traffic cannot starve
+//! the authenticated renderer. State is in-memory and lives for the life of one
+//! listener (each router receives its own limiter), keyed by source IP from
+//! `ConnectInfo<SocketAddr>`.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -15,9 +17,13 @@ use axum::extract::{ConnectInfo, Request};
 use axum::http::Method;
 use axum::middleware::Next;
 use axum::response::Response;
-use axum::Extension;
+use axum::{extract::State, Extension};
 
-use super::response::too_many_requests;
+use super::auth::{is_websocket_upgrade, AUTH_HEADER, MCP_CONTROL_HEADER};
+use super::response::{connection_metadata_unavailable, too_many_requests};
+use super::ws::validate_ws_token;
+use crate::app_state::AppState;
+use crate::shared::security::constant_time_str_eq;
 
 const WINDOW: Duration = Duration::from_secs(60);
 /// Pairing-code attempts per IP per window. A code is single-use and expires in
@@ -36,6 +42,7 @@ const GENERAL_LIMIT: u32 = 6000;
 enum Bucket {
     Pair,
     General,
+    LoopbackAuthenticated,
 }
 
 struct Window {
@@ -55,7 +62,7 @@ impl RateLimiter {
     fn check(&self, ip: IpAddr, bucket: Bucket, now: Instant) -> Result<(), u64> {
         let limit = match bucket {
             Bucket::Pair => PAIR_LIMIT,
-            Bucket::General => GENERAL_LIMIT,
+            Bucket::General | Bucket::LoopbackAuthenticated => GENERAL_LIMIT,
         };
         let mut windows = self.windows.lock().expect("rate-limit mutex poisoned");
         // Bound map growth: drop windows that have fully elapsed.
@@ -93,22 +100,67 @@ pub async fn rate_limit_middleware(
     } else {
         Bucket::General
     };
-    let ip = client_ip(&request);
+    apply_limit(&limiter, bucket, request, next).await
+}
+
+/// Loopback middleware with credential-isolated buckets. The rate limit still
+/// runs before auth so rejected requests and tokenless upgrades are bounded,
+/// but they cannot consume the renderer's authenticated allowance.
+pub async fn loopback_rate_limit_middleware(
+    State(state): State<AppState>,
+    Extension(limiter): Extension<std::sync::Arc<RateLimiter>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let bucket = if has_valid_loopback_credential(&request, &state) {
+        Bucket::LoopbackAuthenticated
+    } else {
+        Bucket::General
+    };
+    apply_limit(&limiter, bucket, request, next).await
+}
+
+async fn apply_limit(
+    limiter: &RateLimiter,
+    bucket: Bucket,
+    request: Request,
+    next: Next,
+) -> Response {
+    let Some(ip) = client_ip(&request) else {
+        tracing::error!("rate limiter missing peer connection metadata");
+        return connection_metadata_unavailable();
+    };
     if let Err(retry_after) = limiter.check(ip, bucket, Instant::now()) {
         return too_many_requests(retry_after);
     }
     next.run(request).await
 }
 
+fn has_valid_loopback_credential(request: &Request, state: &AppState) -> bool {
+    if is_websocket_upgrade(request) {
+        return validate_ws_token(request.headers(), &state.auth_token).is_ok();
+    }
+
+    let (header, expected) = if request.uri().path().starts_with("/internal/mcp/") {
+        (MCP_CONTROL_HEADER, state.mcp_control_token.as_str())
+    } else {
+        (AUTH_HEADER, state.auth_token.as_str())
+    };
+    request
+        .headers()
+        .get(header)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|presented| constant_time_str_eq(presented, expected))
+}
+
 /// Source IP from the connection info axum injects via
-/// `into_make_service_with_connect_info`. Falls back to an unspecified address
-/// (all such requests then share one bucket) if it's somehow absent.
-fn client_ip(request: &Request) -> IpAddr {
+/// `into_make_service_with_connect_info`. Missing metadata is a server wiring
+/// error rather than a shared fallback bucket that one caller could exhaust.
+fn client_ip(request: &Request) -> Option<IpAddr> {
     request
         .extensions()
         .get::<ConnectInfo<SocketAddr>>()
         .map(|ConnectInfo(addr)| addr.ip())
-        .unwrap_or(IpAddr::from([0, 0, 0, 0]))
 }
 
 #[cfg(test)]
@@ -161,6 +213,9 @@ mod tests {
         // A different IP and a different bucket are unaffected.
         assert!(limiter.check(ip(2), Bucket::Pair, now).is_ok());
         assert!(limiter.check(ip(1), Bucket::General, now).is_ok());
+        assert!(limiter
+            .check(ip(1), Bucket::LoopbackAuthenticated, now)
+            .is_ok());
     }
 
     #[test]

--- a/packages/service/src/api/middleware/response.rs
+++ b/packages/service/src/api/middleware/response.rs
@@ -20,11 +20,19 @@ pub fn forbidden(reason: &'static str) -> Response {
     (StatusCode::FORBIDDEN, reason).into_response()
 }
 
-/// 429 with a `Retry-After` (seconds) hint. Used by the remote rate limiter.
+/// 429 with a `Retry-After` (seconds) hint. Used by listener rate limiters.
 pub fn too_many_requests(retry_after_secs: u64) -> Response {
     let mut resp = (StatusCode::TOO_MANY_REQUESTS, "rate limit exceeded").into_response();
     if let Ok(value) = HeaderValue::from_str(&retry_after_secs.to_string()) {
         resp.headers_mut().insert(header::RETRY_AFTER, value);
     }
     resp
+}
+
+pub fn connection_metadata_unavailable() -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "connection metadata unavailable",
+    )
+        .into_response()
 }

--- a/packages/service/src/api/mod.rs
+++ b/packages/service/src/api/mod.rs
@@ -136,7 +136,6 @@ fn compression_layer() -> tower_http::compression::CompressionLayer {
 /// remote-access control endpoints (enable/disable/status/pairing-code/revoke),
 /// which a remote device can therefore never reach.
 pub fn build_router(state: AppState) -> Router {
-    let limiter = std::sync::Arc::new(middleware::RateLimiter::default());
     build_api_routes()
         .route("/api/browser-bridge", put(register_browser_bridge))
         .merge(crate::domain::mcp::control::control_router())
@@ -145,8 +144,6 @@ pub fn build_router(state: AppState) -> Router {
             state.clone(),
             middleware::auth_middleware,
         ))
-        .layer(axum::middleware::from_fn(middleware::rate_limit_middleware))
-        .layer(axum::Extension(limiter))
         .layer(compression_layer())
         .with_state(state)
 }

--- a/packages/service/src/api/mod.rs
+++ b/packages/service/src/api/mod.rs
@@ -136,6 +136,9 @@ fn compression_layer() -> tower_http::compression::CompressionLayer {
 /// remote-access control endpoints (enable/disable/status/pairing-code/revoke),
 /// which a remote device can therefore never reach.
 pub fn build_router(state: AppState) -> Router {
+    // Keep a high-ceiling runaway backstop on loopback too: `/ws` is
+    // intentionally upgradeable without the HTTP launch-token middleware.
+    let limiter = std::sync::Arc::new(middleware::RateLimiter::default());
     build_api_routes()
         .route("/api/browser-bridge", put(register_browser_bridge))
         .merge(crate::domain::mcp::control::control_router())
@@ -144,6 +147,8 @@ pub fn build_router(state: AppState) -> Router {
             state.clone(),
             middleware::auth_middleware,
         ))
+        .layer(axum::middleware::from_fn(middleware::rate_limit_middleware))
+        .layer(axum::Extension(limiter))
         .layer(compression_layer())
         .with_state(state)
 }

--- a/packages/service/src/api/mod.rs
+++ b/packages/service/src/api/mod.rs
@@ -138,6 +138,8 @@ fn compression_layer() -> tower_http::compression::CompressionLayer {
 pub fn build_router(state: AppState) -> Router {
     // Keep a high-ceiling runaway backstop on loopback too: `/ws` is
     // intentionally upgradeable without the HTTP launch-token middleware.
+    // Credential-bearing requests have an independent allowance so anonymous
+    // local traffic cannot starve the renderer.
     let limiter = std::sync::Arc::new(middleware::RateLimiter::default());
     build_api_routes()
         .route("/api/browser-bridge", put(register_browser_bridge))
@@ -147,7 +149,10 @@ pub fn build_router(state: AppState) -> Router {
             state.clone(),
             middleware::auth_middleware,
         ))
-        .layer(axum::middleware::from_fn(middleware::rate_limit_middleware))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            middleware::loopback_rate_limit_middleware,
+        ))
         .layer(axum::Extension(limiter))
         .layer(compression_layer())
         .with_state(state)

--- a/packages/service/src/domain/ws_session/handler/connection.rs
+++ b/packages/service/src/domain/ws_session/handler/connection.rs
@@ -25,12 +25,14 @@ mod outbound;
 
 use outbound::{
     retryable_close, spawn_outbound_bridge, spawn_socket_sender, OutboundBridgeExit,
-    OUTBOUND_SOCKET_CAPACITY, OUTBOUND_SOCKET_SEND_TIMEOUT,
+    OUTBOUND_SOCKET_CAPACITY, OUTBOUND_SOCKET_SEND_TIMEOUT, RETRY_CLOSE_SEND_TIMEOUT,
 };
 
 const MAX_INBOUND_MESSAGES_PER_SECOND: u16 = 120;
 const INBOUND_RATE_RETRY_AFTER_MS: u64 = 5_000;
-const GRACEFUL_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
+const GRACEFUL_CLOSE_SEND_TIMEOUT: Duration =
+    Duration::from_secs(RETRY_CLOSE_SEND_TIMEOUT.as_secs() + 1);
+const GRACEFUL_CLOSE_ECHO_TIMEOUT: Duration = Duration::from_secs(1);
 
 struct InboundRateLimit {
     window_started: Instant,
@@ -60,13 +62,13 @@ async fn finish_graceful_close(
     ws_stream: &mut futures::stream::SplitStream<WebSocket>,
 ) {
     if !matches!(
-        tokio::time::timeout(GRACEFUL_CLOSE_TIMEOUT, send_task).await,
+        tokio::time::timeout(GRACEFUL_CLOSE_SEND_TIMEOUT, send_task).await,
         Ok(Ok(()))
     ) {
         return;
     }
     // Wait for the close echo; dropping immediately produces code 1006.
-    let _ = tokio::time::timeout(GRACEFUL_CLOSE_TIMEOUT, async {
+    let _ = tokio::time::timeout(GRACEFUL_CLOSE_ECHO_TIMEOUT, async {
         while let Some(message) = ws_stream.next().await {
             match message {
                 Ok(Message::Close(_)) | Err(_) => break,
@@ -145,7 +147,9 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
     let mut graceful_close_requested = false;
 
     // A separate priority channel lets overload shutdown bypass the full data
-    // queue and interrupt a stalled normal send with a retryable close.
+    // queue and cancel an in-progress normal `send`. The framed socket may
+    // still need to flush bytes it already accepted before it can enqueue the
+    // close, so graceful teardown gives that bounded flush time to recover.
     let (mut send_task, close_tx) = spawn_socket_sender(ws_sink, socket_rx);
 
     // Inbound loop: read messages from client. We `select!` against the

--- a/packages/service/src/domain/ws_session/handler/connection.rs
+++ b/packages/service/src/domain/ws_session/handler/connection.rs
@@ -24,8 +24,9 @@ use super::types::{QueryState, SdkSessions};
 mod outbound;
 
 use outbound::{
-    retryable_close, spawn_outbound_bridge, spawn_socket_sender, OutboundBridgeExit,
-    OUTBOUND_SOCKET_CAPACITY, OUTBOUND_SOCKET_SEND_TIMEOUT, RETRY_CLOSE_SEND_TIMEOUT,
+    retryable_error_shutdown, retryable_shutdown, spawn_outbound_bridge, spawn_socket_sender,
+    OutboundBridgeExit, OUTBOUND_SOCKET_CAPACITY, OUTBOUND_SOCKET_SEND_TIMEOUT,
+    RETRY_CLOSE_SEND_TIMEOUT,
 };
 
 const MAX_INBOUND_MESSAGES_PER_SECOND: u16 = 120;
@@ -174,7 +175,7 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
                             timeout_ms = OUTBOUND_SOCKET_SEND_TIMEOUT.as_millis(),
                             "WebSocket peer did not drain the outbound queue before timeout"
                         );
-                        if close_tx.send(retryable_close("overloaded")).await.is_err() {
+                        if close_tx.send(retryable_shutdown("overloaded")).await.is_err() {
                             debug!("WebSocket sender closed before overload close could be requested");
                         }
                         graceful_close_requested = true;
@@ -205,10 +206,13 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
                                 })
                                 .unwrap(),
                             );
-                            let _ = outbound_tx
-                                .send(Message::Text(String::from(err_env).into()));
-                            let _ = outbound_tx
-                                .send(Message::Close(Some(retryable_close("rate-limited"))));
+                            let shutdown = retryable_error_shutdown(
+                                Message::Text(String::from(err_env).into()),
+                                "rate-limited",
+                            );
+                            if close_tx.send(shutdown).await.is_err() {
+                                debug!("WebSocket sender closed before rate-limit shutdown could be requested");
+                            }
                             graceful_close_requested = true;
                             break;
                         }

--- a/packages/service/src/domain/ws_session/handler/connection.rs
+++ b/packages/service/src/domain/ws_session/handler/connection.rs
@@ -1,11 +1,9 @@
-//! WebSocket upgrade + per-connection inbound/outbound loop. Hands every
-//! parsed envelope to [`super::dispatch::dispatch_envelope`] and sweeps
-//! per-connection state on disconnect.
+//! WebSocket upgrade + per-connection loop, dispatch, and disconnect cleanup.
 
 use std::collections::HashMap;
 use std::time::Duration;
 
-use axum::extract::ws::{Message, WebSocket};
+use axum::extract::ws::{CloseFrame, Message, WebSocket};
 use axum::extract::{State, WebSocketUpgrade};
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
@@ -13,7 +11,7 @@ use axum::Extension;
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::api::middleware::authenticate_ws;
 use crate::app_state::AppState;
@@ -24,7 +22,16 @@ use super::dispatch::dispatch_envelope;
 use super::types::{QueryState, SdkSessions};
 
 const OUTBOUND_SOCKET_CAPACITY: usize = 256;
+const OUTBOUND_SOCKET_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_INBOUND_MESSAGES_PER_SECOND: u16 = 120;
+const INBOUND_RATE_RETRY_AFTER_MS: u64 = 5_000;
+const GRACEFUL_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutboundBridgeExit {
+    SendTimeout,
+    SocketClosed,
+}
 
 struct InboundRateLimit {
     window_started: Instant,
@@ -49,27 +56,71 @@ impl InboundRateLimit {
     }
 }
 
-/// Keep the widely-shared unbounded sender API behind a bounded socket queue.
-/// If a peer cannot drain that queue, close the connection so its next
-/// reconnect gets authoritative snapshots instead of letting host memory grow.
 fn spawn_outbound_bridge(
+    outbound_rx: mpsc::UnboundedReceiver<Message>,
+    socket_tx: mpsc::Sender<Message>,
+) -> (
+    tokio::task::JoinHandle<()>,
+    oneshot::Receiver<OutboundBridgeExit>,
+) {
+    spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, OUTBOUND_SOCKET_SEND_TIMEOUT)
+}
+
+fn spawn_outbound_bridge_with_timeout(
     mut outbound_rx: mpsc::UnboundedReceiver<Message>,
     socket_tx: mpsc::Sender<Message>,
-) -> (tokio::task::JoinHandle<()>, oneshot::Receiver<()>) {
-    let (overflow_tx, overflow_rx) = oneshot::channel();
+    send_timeout: Duration,
+) -> (
+    tokio::task::JoinHandle<()>,
+    oneshot::Receiver<OutboundBridgeExit>,
+) {
+    let (exit_tx, exit_rx) = oneshot::channel();
     let task = tokio::spawn(async move {
         while let Some(message) = outbound_rx.recv().await {
-            match socket_tx.try_send(message) {
-                Ok(()) => {}
-                Err(mpsc::error::TrySendError::Full(_)) => {
-                    let _ = overflow_tx.send(());
+            let message = match socket_tx.try_send(message) {
+                Ok(()) => continue,
+                Err(mpsc::error::TrySendError::Full(message)) => message,
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    let _ = exit_tx.send(OutboundBridgeExit::SocketClosed);
                     return;
                 }
-                Err(mpsc::error::TrySendError::Closed(_)) => return,
+            };
+            match tokio::time::timeout(send_timeout, socket_tx.send(message)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    let _ = exit_tx.send(OutboundBridgeExit::SocketClosed);
+                    return;
+                }
+                Err(_) => {
+                    let _ = exit_tx.send(OutboundBridgeExit::SendTimeout);
+                    return;
+                }
             }
         }
     });
-    (task, overflow_rx)
+    (task, exit_rx)
+}
+
+async fn finish_graceful_close(
+    send_task: &mut tokio::task::JoinHandle<()>,
+    ws_stream: &mut futures::stream::SplitStream<WebSocket>,
+) {
+    if !matches!(
+        tokio::time::timeout(GRACEFUL_CLOSE_TIMEOUT, send_task).await,
+        Ok(Ok(()))
+    ) {
+        return;
+    }
+    // Wait for the close echo; dropping immediately produces code 1006.
+    let _ = tokio::time::timeout(GRACEFUL_CLOSE_TIMEOUT, async {
+        while let Some(message) = ws_stream.next().await {
+            match message {
+                Ok(Message::Close(_)) | Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+    })
+    .await;
 }
 
 pub async fn ws_handler(
@@ -134,16 +185,21 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
     let (mut ws_sink, mut ws_stream) = socket.split();
     let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<Message>();
     let (socket_tx, mut socket_rx) = mpsc::channel::<Message>(OUTBOUND_SOCKET_CAPACITY);
-    let (bridge_task, mut overflow_rx) = spawn_outbound_bridge(outbound_rx, socket_tx);
+    let (bridge_task, mut bridge_exit_rx) = spawn_outbound_bridge(outbound_rx, socket_tx);
     let sdk_sessions: SdkSessions = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let mut inbound_rate = InboundRateLimit::new();
+    let mut graceful_close_requested = false;
 
     // Spawn outbound forwarder: reads from the bounded queue, writes to the sink.
     // Exits when either the channel is dropped or the sink fails (peer gone).
     let mut send_task = tokio::spawn(async move {
         use futures::SinkExt;
         while let Some(msg) = socket_rx.recv().await {
+            let close_after_send = matches!(msg, Message::Close(_));
             if ws_sink.send(msg).await.is_err() {
+                break;
+            }
+            if close_after_send {
                 break;
             }
         }
@@ -163,26 +219,46 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
                 debug!("ws_sink closed; ending inbound loop");
                 break;
             }
-            _ = &mut overflow_rx => {
-                debug!("WebSocket outbound queue overflowed; closing for snapshot resync");
+            bridge_exit = &mut bridge_exit_rx => {
+                match bridge_exit {
+                    Ok(OutboundBridgeExit::SendTimeout) => warn!(
+                        capacity = OUTBOUND_SOCKET_CAPACITY,
+                        timeout_ms = OUTBOUND_SOCKET_SEND_TIMEOUT.as_millis(),
+                        "WebSocket peer did not drain the outbound queue before timeout"
+                    ),
+                    Ok(OutboundBridgeExit::SocketClosed) | Err(_) => {
+                        debug!("WebSocket outbound bridge closed");
+                    }
+                }
                 break;
             }
             msg = ws_stream.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         if !inbound_rate.allow(Instant::now()) {
+                            warn!(
+                                max_messages_per_second = MAX_INBOUND_MESSAGES_PER_SECOND,
+                                retry_after_ms = INBOUND_RATE_RETRY_AFTER_MS,
+                                "WebSocket inbound message rate exceeded"
+                            );
                             let err_env = WsEnvelope::new(
                                 "session",
                                 "error",
                                 serde_json::to_value(SessionErrorPayload {
                                     code: "RATE_LIMITED".into(),
                                     message: "WebSocket message rate exceeded".into(),
+                                    retry_after_ms: Some(INBOUND_RATE_RETRY_AFTER_MS),
                                     ..Default::default()
                                 })
                                 .unwrap(),
                             );
                             let _ = outbound_tx
                                 .send(Message::Text(String::from(err_env).into()));
+                            let _ = outbound_tx.send(Message::Close(Some(CloseFrame {
+                                code: 1013,
+                                reason: "rate-limited".into(),
+                            })));
+                            graceful_close_requested = true;
                             break;
                         }
                         let text_str: &str = &text;
@@ -220,6 +296,10 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
         }
     }
 
+    if graceful_close_requested {
+        finish_graceful_close(&mut send_task, &mut ws_stream).await;
+    }
+
     // Cleanup: this connection is going away, but a turn it started must keep
     // running on the host. Drop only `Pending` handles — viewers with no live
     // process. Every `Active` handle is left in place: its stream reader holds
@@ -241,12 +321,8 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
     sessions.retain(|_, handle| matches!(handle.state, QueryState::Active { .. }));
     drop(sessions);
 
-    // Only sweep this connection's active-turn ownership when no live turn
-    // survives. A surviving turn must keep its registry entry so other devices
-    // can resolve the owner map to answer permissions/questions and render the
-    // synchronized timer while it runs to completion. The registry holds only
-    // `Weak` pointers, so the entry self-clears once the turn's reader drops the
-    // map.
+    // A surviving turn keeps its weak registry ownership so other devices can
+    // answer gates and render its timer. The reader clears it at completion.
     if live_turns == 0 {
         state.active_turns.remove_owned_by(&sdk_sessions).await;
     }
@@ -270,22 +346,43 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn outbound_bridge_signals_when_bounded_queue_is_full() {
+    async fn outbound_bridge_waits_before_signalling_a_slow_socket() {
         let (socket_tx, _socket_rx) = mpsc::channel(1);
         socket_tx
             .try_send(Message::Text("already full".into()))
             .expect("prefill bounded queue");
         let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
-        let (task, overflow) = spawn_outbound_bridge(outbound_rx, socket_tx);
+        let (task, exit) =
+            spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, Duration::from_millis(20));
 
         outbound_tx
             .send(Message::Text("overflow".into()))
             .expect("enqueue outbound message");
 
-        tokio::time::timeout(Duration::from_secs(1), overflow)
+        let reason = tokio::time::timeout(Duration::from_secs(1), exit)
             .await
-            .expect("overflow should be signalled")
-            .expect("overflow sender should not drop");
+            .expect("slow socket should be signalled")
+            .expect("exit sender should not drop");
+        assert_eq!(reason, OutboundBridgeExit::SendTimeout);
+        task.await.expect("bridge should exit cleanly");
+    }
+
+    #[tokio::test]
+    async fn outbound_bridge_drains_after_temporary_backpressure() {
+        let (socket_tx, mut socket_rx) = mpsc::channel(1);
+        socket_tx
+            .try_send(Message::Text("already full".into()))
+            .expect("prefill bounded queue");
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+        let (task, _exit) =
+            spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, Duration::from_secs(1));
+        outbound_tx
+            .send(Message::Text("event".into()))
+            .expect("enqueue outbound message");
+
+        let _ = socket_rx.recv().await;
+        assert!(matches!(socket_rx.recv().await, Some(Message::Text(_))));
+        drop(outbound_tx);
         task.await.expect("bridge should exit cleanly");
     }
 

--- a/packages/service/src/domain/ws_session/handler/connection.rs
+++ b/packages/service/src/domain/ws_session/handler/connection.rs
@@ -3,13 +3,13 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use axum::extract::ws::{CloseFrame, Message, WebSocket};
+use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{State, WebSocketUpgrade};
 use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 use axum::Extension;
 use futures::StreamExt;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tracing::{debug, warn};
 
@@ -21,17 +21,16 @@ use crate::remote::RemoteContext;
 use super::dispatch::dispatch_envelope;
 use super::types::{QueryState, SdkSessions};
 
-const OUTBOUND_SOCKET_CAPACITY: usize = 256;
-const OUTBOUND_SOCKET_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+mod outbound;
+
+use outbound::{
+    retryable_close, spawn_outbound_bridge, spawn_socket_sender, OutboundBridgeExit,
+    OUTBOUND_SOCKET_CAPACITY, OUTBOUND_SOCKET_SEND_TIMEOUT,
+};
+
 const MAX_INBOUND_MESSAGES_PER_SECOND: u16 = 120;
 const INBOUND_RATE_RETRY_AFTER_MS: u64 = 5_000;
 const GRACEFUL_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OutboundBridgeExit {
-    SendTimeout,
-    SocketClosed,
-}
 
 struct InboundRateLimit {
     window_started: Instant,
@@ -54,51 +53,6 @@ impl InboundRateLimit {
         self.count = self.count.saturating_add(1);
         self.count <= MAX_INBOUND_MESSAGES_PER_SECOND
     }
-}
-
-fn spawn_outbound_bridge(
-    outbound_rx: mpsc::UnboundedReceiver<Message>,
-    socket_tx: mpsc::Sender<Message>,
-) -> (
-    tokio::task::JoinHandle<()>,
-    oneshot::Receiver<OutboundBridgeExit>,
-) {
-    spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, OUTBOUND_SOCKET_SEND_TIMEOUT)
-}
-
-fn spawn_outbound_bridge_with_timeout(
-    mut outbound_rx: mpsc::UnboundedReceiver<Message>,
-    socket_tx: mpsc::Sender<Message>,
-    send_timeout: Duration,
-) -> (
-    tokio::task::JoinHandle<()>,
-    oneshot::Receiver<OutboundBridgeExit>,
-) {
-    let (exit_tx, exit_rx) = oneshot::channel();
-    let task = tokio::spawn(async move {
-        while let Some(message) = outbound_rx.recv().await {
-            let message = match socket_tx.try_send(message) {
-                Ok(()) => continue,
-                Err(mpsc::error::TrySendError::Full(message)) => message,
-                Err(mpsc::error::TrySendError::Closed(_)) => {
-                    let _ = exit_tx.send(OutboundBridgeExit::SocketClosed);
-                    return;
-                }
-            };
-            match tokio::time::timeout(send_timeout, socket_tx.send(message)).await {
-                Ok(Ok(())) => {}
-                Ok(Err(_)) => {
-                    let _ = exit_tx.send(OutboundBridgeExit::SocketClosed);
-                    return;
-                }
-                Err(_) => {
-                    let _ = exit_tx.send(OutboundBridgeExit::SendTimeout);
-                    return;
-                }
-            }
-        }
-    });
-    (task, exit_rx)
 }
 
 async fn finish_graceful_close(
@@ -182,28 +136,17 @@ fn record_remote_connect(state: &AppState, device_id: i64) {
 
 /// Runs the WebSocket connection loop after upgrade.
 async fn handle_connection(socket: WebSocket, state: AppState) {
-    let (mut ws_sink, mut ws_stream) = socket.split();
+    let (ws_sink, mut ws_stream) = socket.split();
     let (outbound_tx, outbound_rx) = mpsc::unbounded_channel::<Message>();
-    let (socket_tx, mut socket_rx) = mpsc::channel::<Message>(OUTBOUND_SOCKET_CAPACITY);
+    let (socket_tx, socket_rx) = mpsc::channel::<Message>(OUTBOUND_SOCKET_CAPACITY);
     let (bridge_task, mut bridge_exit_rx) = spawn_outbound_bridge(outbound_rx, socket_tx);
     let sdk_sessions: SdkSessions = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let mut inbound_rate = InboundRateLimit::new();
     let mut graceful_close_requested = false;
 
-    // Spawn outbound forwarder: reads from the bounded queue, writes to the sink.
-    // Exits when either the channel is dropped or the sink fails (peer gone).
-    let mut send_task = tokio::spawn(async move {
-        use futures::SinkExt;
-        while let Some(msg) = socket_rx.recv().await {
-            let close_after_send = matches!(msg, Message::Close(_));
-            if ws_sink.send(msg).await.is_err() {
-                break;
-            }
-            if close_after_send {
-                break;
-            }
-        }
-    });
+    // A separate priority channel lets overload shutdown bypass the full data
+    // queue and interrupt a stalled normal send with a retryable close.
+    let (mut send_task, close_tx) = spawn_socket_sender(ws_sink, socket_rx);
 
     // Inbound loop: read messages from client. We `select!` against the
     // outbound task so a half-open TCP socket (e.g. laptop sleep, Wi-Fi
@@ -221,11 +164,17 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
             }
             bridge_exit = &mut bridge_exit_rx => {
                 match bridge_exit {
-                    Ok(OutboundBridgeExit::SendTimeout) => warn!(
-                        capacity = OUTBOUND_SOCKET_CAPACITY,
-                        timeout_ms = OUTBOUND_SOCKET_SEND_TIMEOUT.as_millis(),
-                        "WebSocket peer did not drain the outbound queue before timeout"
-                    ),
+                    Ok(OutboundBridgeExit::SendTimeout) => {
+                        warn!(
+                            capacity = OUTBOUND_SOCKET_CAPACITY,
+                            timeout_ms = OUTBOUND_SOCKET_SEND_TIMEOUT.as_millis(),
+                            "WebSocket peer did not drain the outbound queue before timeout"
+                        );
+                        if close_tx.send(retryable_close("overloaded")).await.is_err() {
+                            debug!("WebSocket sender closed before overload close could be requested");
+                        }
+                        graceful_close_requested = true;
+                    }
                     Ok(OutboundBridgeExit::SocketClosed) | Err(_) => {
                         debug!("WebSocket outbound bridge closed");
                     }
@@ -254,10 +203,8 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
                             );
                             let _ = outbound_tx
                                 .send(Message::Text(String::from(err_env).into()));
-                            let _ = outbound_tx.send(Message::Close(Some(CloseFrame {
-                                code: 1013,
-                                reason: "rate-limited".into(),
-                            })));
+                            let _ = outbound_tx
+                                .send(Message::Close(Some(retryable_close("rate-limited"))));
                             graceful_close_requested = true;
                             break;
                         }
@@ -344,47 +291,6 @@ async fn handle_connection(socket: WebSocket, state: AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[tokio::test]
-    async fn outbound_bridge_waits_before_signalling_a_slow_socket() {
-        let (socket_tx, _socket_rx) = mpsc::channel(1);
-        socket_tx
-            .try_send(Message::Text("already full".into()))
-            .expect("prefill bounded queue");
-        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
-        let (task, exit) =
-            spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, Duration::from_millis(20));
-
-        outbound_tx
-            .send(Message::Text("overflow".into()))
-            .expect("enqueue outbound message");
-
-        let reason = tokio::time::timeout(Duration::from_secs(1), exit)
-            .await
-            .expect("slow socket should be signalled")
-            .expect("exit sender should not drop");
-        assert_eq!(reason, OutboundBridgeExit::SendTimeout);
-        task.await.expect("bridge should exit cleanly");
-    }
-
-    #[tokio::test]
-    async fn outbound_bridge_drains_after_temporary_backpressure() {
-        let (socket_tx, mut socket_rx) = mpsc::channel(1);
-        socket_tx
-            .try_send(Message::Text("already full".into()))
-            .expect("prefill bounded queue");
-        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
-        let (task, _exit) =
-            spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, Duration::from_secs(1));
-        outbound_tx
-            .send(Message::Text("event".into()))
-            .expect("enqueue outbound message");
-
-        let _ = socket_rx.recv().await;
-        assert!(matches!(socket_rx.recv().await, Some(Message::Text(_))));
-        drop(outbound_tx);
-        task.await.expect("bridge should exit cleanly");
-    }
 
     #[test]
     fn inbound_rate_limit_resets_after_one_second() {

--- a/packages/service/src/domain/ws_session/handler/connection/outbound.rs
+++ b/packages/service/src/domain/ws_session/handler/connection/outbound.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 
 pub(super) const OUTBOUND_SOCKET_CAPACITY: usize = 256;
 pub(super) const OUTBOUND_SOCKET_SEND_TIMEOUT: Duration = Duration::from_secs(5);
-const RETRY_CLOSE_SEND_TIMEOUT: Duration = Duration::from_millis(500);
+pub(super) const RETRY_CLOSE_SEND_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum OutboundBridgeExit {
@@ -221,6 +221,107 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert!(matches!(
             messages.first(),
+            Some(Message::Close(Some(frame))) if frame.code == 1013 && frame.reason == "overloaded"
+        ));
+    }
+
+    struct RecoveringBlockedSink {
+        blocked: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        waker: std::sync::Arc<std::sync::Mutex<Option<std::task::Waker>>>,
+        recorded: std::sync::Arc<std::sync::Mutex<Vec<Message>>>,
+        normal_started: Option<oneshot::Sender<()>>,
+    }
+
+    impl Sink<Message> for RecoveringBlockedSink {
+        type Error = std::convert::Infallible;
+
+        fn poll_ready(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            if self.blocked.load(std::sync::atomic::Ordering::SeqCst) {
+                *self.waker.lock().expect("blocked sink waker poisoned") = Some(cx.waker().clone());
+                std::task::Poll::Pending
+            } else {
+                std::task::Poll::Ready(Ok(()))
+            }
+        }
+
+        fn start_send(
+            mut self: std::pin::Pin<&mut Self>,
+            message: Message,
+        ) -> Result<(), Self::Error> {
+            if matches!(message, Message::Text(_)) {
+                self.blocked
+                    .store(true, std::sync::atomic::Ordering::SeqCst);
+                if let Some(started) = self.normal_started.take() {
+                    let _ = started.send(());
+                }
+            }
+            self.recorded
+                .lock()
+                .expect("recording sink poisoned")
+                .push(message);
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            self.poll_ready(cx)
+        }
+
+        fn poll_close(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            self.poll_ready(cx)
+        }
+    }
+
+    #[tokio::test]
+    async fn priority_close_waits_for_a_blocked_sink_to_recover() {
+        let blocked = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let waker = std::sync::Arc::new(std::sync::Mutex::new(None::<std::task::Waker>));
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let (normal_started_tx, normal_started_rx) = oneshot::channel();
+        let sink = RecoveringBlockedSink {
+            blocked: blocked.clone(),
+            waker: waker.clone(),
+            recorded: recorded.clone(),
+            normal_started: Some(normal_started_tx),
+        };
+        let (socket_tx, socket_rx) = mpsc::channel(1);
+        let (close_tx, close_rx) = mpsc::channel(1);
+        let sender = tokio::spawn(run_socket_sender(sink, socket_rx, close_rx));
+
+        socket_tx
+            .send(Message::Text("blocked event".into()))
+            .await
+            .expect("queue normal message");
+        normal_started_rx.await.expect("normal send starts");
+        close_tx
+            .send(retryable_close("overloaded"))
+            .await
+            .expect("request priority close");
+
+        // This exceeds the old 500 ms close-send timeout. A temporarily
+        // blocked peer still gets the 1013 frame when it resumes draining
+        // within the new bounded grace period.
+        tokio::time::sleep(Duration::from_millis(750)).await;
+        blocked.store(false, std::sync::atomic::Ordering::SeqCst);
+        if let Some(waker) = waker.lock().expect("blocked sink waker poisoned").take() {
+            waker.wake();
+        }
+
+        tokio::time::timeout(Duration::from_secs(1), sender)
+            .await
+            .expect("sender finishes after sink recovery")
+            .expect("sender task succeeds");
+        let messages = recorded.lock().expect("recording sink poisoned");
+        assert!(matches!(
+            messages.last(),
             Some(Message::Close(Some(frame))) if frame.code == 1013 && frame.reason == "overloaded"
         ));
     }

--- a/packages/service/src/domain/ws_session/handler/connection/outbound.rs
+++ b/packages/service/src/domain/ws_session/handler/connection/outbound.rs
@@ -1,0 +1,227 @@
+//! Bounded WebSocket outbound queue and priority close delivery.
+
+use std::fmt::Display;
+use std::time::Duration;
+
+use axum::extract::ws::{CloseFrame, Message};
+use futures::{Sink, SinkExt};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, warn};
+
+pub(super) const OUTBOUND_SOCKET_CAPACITY: usize = 256;
+pub(super) const OUTBOUND_SOCKET_SEND_TIMEOUT: Duration = Duration::from_secs(5);
+const RETRY_CLOSE_SEND_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OutboundBridgeExit {
+    SendTimeout,
+    SocketClosed,
+}
+
+pub(super) fn retryable_close(reason: &'static str) -> CloseFrame {
+    CloseFrame {
+        code: 1013,
+        reason: reason.into(),
+    }
+}
+
+pub(super) fn spawn_outbound_bridge(
+    outbound_rx: mpsc::UnboundedReceiver<Message>,
+    socket_tx: mpsc::Sender<Message>,
+) -> (
+    tokio::task::JoinHandle<()>,
+    oneshot::Receiver<OutboundBridgeExit>,
+) {
+    spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, OUTBOUND_SOCKET_SEND_TIMEOUT)
+}
+
+fn spawn_outbound_bridge_with_timeout(
+    mut outbound_rx: mpsc::UnboundedReceiver<Message>,
+    socket_tx: mpsc::Sender<Message>,
+    send_timeout: Duration,
+) -> (
+    tokio::task::JoinHandle<()>,
+    oneshot::Receiver<OutboundBridgeExit>,
+) {
+    let (exit_tx, exit_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        while let Some(message) = outbound_rx.recv().await {
+            let message = match socket_tx.try_send(message) {
+                Ok(()) => continue,
+                Err(mpsc::error::TrySendError::Full(message)) => message,
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    let _ = exit_tx.send(OutboundBridgeExit::SocketClosed);
+                    return;
+                }
+            };
+            match tokio::time::timeout(send_timeout, socket_tx.send(message)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    let _ = exit_tx.send(OutboundBridgeExit::SocketClosed);
+                    return;
+                }
+                Err(_) => {
+                    let _ = exit_tx.send(OutboundBridgeExit::SendTimeout);
+                    return;
+                }
+            }
+        }
+    });
+    (task, exit_rx)
+}
+
+pub(super) fn spawn_socket_sender<S>(
+    sink: S,
+    socket_rx: mpsc::Receiver<Message>,
+) -> (tokio::task::JoinHandle<()>, mpsc::Sender<CloseFrame>)
+where
+    S: Sink<Message> + Unpin + Send + 'static,
+    S::Error: Display + Send + 'static,
+{
+    let (close_tx, close_rx) = mpsc::channel(1);
+    let task = tokio::spawn(run_socket_sender(sink, socket_rx, close_rx));
+    (task, close_tx)
+}
+
+async fn run_socket_sender<S>(
+    mut sink: S,
+    mut socket_rx: mpsc::Receiver<Message>,
+    mut close_rx: mpsc::Receiver<CloseFrame>,
+) where
+    S: Sink<Message> + Unpin,
+    S::Error: Display,
+{
+    loop {
+        let message = tokio::select! {
+            biased;
+            close = close_rx.recv() => {
+                if let Some(frame) = close {
+                    send_retry_close(&mut sink, frame).await;
+                }
+                break;
+            }
+            message = socket_rx.recv() => {
+                let Some(message) = message else { break };
+                message
+            }
+        };
+        let close_after_send = matches!(message, Message::Close(_));
+        tokio::select! {
+            biased;
+            close = close_rx.recv() => {
+                if let Some(frame) = close {
+                    send_retry_close(&mut sink, frame).await;
+                }
+                break;
+            }
+            result = sink.send(message) => {
+                if let Err(error) = result {
+                    debug!(%error, "WebSocket sink send failed");
+                    break;
+                }
+                if close_after_send {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn send_retry_close<S>(sink: &mut S, frame: CloseFrame)
+where
+    S: Sink<Message> + Unpin,
+    S::Error: Display,
+{
+    match tokio::time::timeout(
+        RETRY_CLOSE_SEND_TIMEOUT,
+        sink.send(Message::Close(Some(frame))),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => debug!(%error, "WebSocket retry close send failed"),
+        Err(_) => warn!("WebSocket retry close send timed out"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn outbound_bridge_waits_before_signalling_a_slow_socket() {
+        let (socket_tx, _socket_rx) = mpsc::channel(1);
+        socket_tx
+            .try_send(Message::Text("already full".into()))
+            .expect("prefill bounded queue");
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+        let (task, exit) =
+            spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, Duration::from_millis(20));
+
+        outbound_tx
+            .send(Message::Text("overflow".into()))
+            .expect("enqueue outbound message");
+
+        let reason = tokio::time::timeout(Duration::from_secs(1), exit)
+            .await
+            .expect("slow socket should be signalled")
+            .expect("exit sender should not drop");
+        assert_eq!(reason, OutboundBridgeExit::SendTimeout);
+        task.await.expect("bridge should exit cleanly");
+    }
+
+    #[tokio::test]
+    async fn outbound_bridge_drains_after_temporary_backpressure() {
+        let (socket_tx, mut socket_rx) = mpsc::channel(1);
+        socket_tx
+            .try_send(Message::Text("already full".into()))
+            .expect("prefill bounded queue");
+        let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+        let (task, _exit) =
+            spawn_outbound_bridge_with_timeout(outbound_rx, socket_tx, Duration::from_secs(1));
+        outbound_tx
+            .send(Message::Text("event".into()))
+            .expect("enqueue outbound message");
+
+        let _ = socket_rx.recv().await;
+        assert!(matches!(socket_rx.recv().await, Some(Message::Text(_))));
+        drop(outbound_tx);
+        task.await.expect("bridge should exit cleanly");
+    }
+
+    #[tokio::test]
+    async fn retry_close_bypasses_queued_socket_messages() {
+        let (socket_tx, socket_rx) = mpsc::channel(2);
+        socket_tx
+            .send(Message::Text("stale event".into()))
+            .await
+            .expect("queue normal message");
+        let (close_tx, close_rx) = mpsc::channel(1);
+        close_tx
+            .send(retryable_close("overloaded"))
+            .await
+            .expect("queue priority close");
+
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded_for_sink = recorded.clone();
+        let sink = Box::pin(futures::sink::unfold((), move |(), message| {
+            let recorded = recorded_for_sink.clone();
+            async move {
+                recorded
+                    .lock()
+                    .expect("recording sink poisoned")
+                    .push(message);
+                Ok::<_, std::convert::Infallible>(())
+            }
+        }));
+
+        run_socket_sender(sink, socket_rx, close_rx).await;
+
+        let messages = recorded.lock().expect("recording sink poisoned");
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(
+            messages.first(),
+            Some(Message::Close(Some(frame))) if frame.code == 1013 && frame.reason == "overloaded"
+        ));
+    }
+}

--- a/packages/service/src/domain/ws_session/handler/connection/outbound.rs
+++ b/packages/service/src/domain/ws_session/handler/connection/outbound.rs
@@ -25,6 +25,25 @@ pub(super) fn retryable_close(reason: &'static str) -> CloseFrame {
     }
 }
 
+pub(super) struct PriorityShutdown {
+    before_close: Option<Message>,
+    close: CloseFrame,
+}
+
+pub(super) fn retryable_shutdown(reason: &'static str) -> PriorityShutdown {
+    PriorityShutdown {
+        before_close: None,
+        close: retryable_close(reason),
+    }
+}
+
+pub(super) fn retryable_error_shutdown(error: Message, reason: &'static str) -> PriorityShutdown {
+    PriorityShutdown {
+        before_close: Some(error),
+        close: retryable_close(reason),
+    }
+}
+
 pub(super) fn spawn_outbound_bridge(
     outbound_rx: mpsc::UnboundedReceiver<Message>,
     socket_tx: mpsc::Sender<Message>,
@@ -73,7 +92,7 @@ fn spawn_outbound_bridge_with_timeout(
 pub(super) fn spawn_socket_sender<S>(
     sink: S,
     socket_rx: mpsc::Receiver<Message>,
-) -> (tokio::task::JoinHandle<()>, mpsc::Sender<CloseFrame>)
+) -> (tokio::task::JoinHandle<()>, mpsc::Sender<PriorityShutdown>)
 where
     S: Sink<Message> + Unpin + Send + 'static,
     S::Error: Display + Send + 'static,
@@ -86,7 +105,7 @@ where
 async fn run_socket_sender<S>(
     mut sink: S,
     mut socket_rx: mpsc::Receiver<Message>,
-    mut close_rx: mpsc::Receiver<CloseFrame>,
+    mut close_rx: mpsc::Receiver<PriorityShutdown>,
 ) where
     S: Sink<Message> + Unpin,
     S::Error: Display,
@@ -94,9 +113,9 @@ async fn run_socket_sender<S>(
     loop {
         let message = tokio::select! {
             biased;
-            close = close_rx.recv() => {
-                if let Some(frame) = close {
-                    send_retry_close(&mut sink, frame).await;
+            shutdown = close_rx.recv() => {
+                if let Some(shutdown) = shutdown {
+                    send_priority_shutdown(&mut sink, shutdown).await;
                 }
                 break;
             }
@@ -108,9 +127,9 @@ async fn run_socket_sender<S>(
         let close_after_send = matches!(message, Message::Close(_));
         tokio::select! {
             biased;
-            close = close_rx.recv() => {
-                if let Some(frame) = close {
-                    send_retry_close(&mut sink, frame).await;
+            shutdown = close_rx.recv() => {
+                if let Some(shutdown) = shutdown {
+                    send_priority_shutdown(&mut sink, shutdown).await;
                 }
                 break;
             }
@@ -127,20 +146,21 @@ async fn run_socket_sender<S>(
     }
 }
 
-async fn send_retry_close<S>(sink: &mut S, frame: CloseFrame)
+async fn send_priority_shutdown<S>(sink: &mut S, shutdown: PriorityShutdown)
 where
     S: Sink<Message> + Unpin,
     S::Error: Display,
 {
-    match tokio::time::timeout(
-        RETRY_CLOSE_SEND_TIMEOUT,
-        sink.send(Message::Close(Some(frame))),
-    )
-    .await
-    {
+    let send = async {
+        if let Some(message) = shutdown.before_close {
+            sink.send(message).await?;
+        }
+        sink.send(Message::Close(Some(shutdown.close))).await
+    };
+    match tokio::time::timeout(RETRY_CLOSE_SEND_TIMEOUT, send).await {
         Ok(Ok(())) => {}
-        Ok(Err(error)) => debug!(%error, "WebSocket retry close send failed"),
-        Err(_) => warn!("WebSocket retry close send timed out"),
+        Ok(Err(error)) => debug!(%error, "WebSocket priority shutdown send failed"),
+        Err(_) => warn!("WebSocket priority shutdown send timed out"),
     }
 }
 
@@ -198,7 +218,7 @@ mod tests {
             .expect("queue normal message");
         let (close_tx, close_rx) = mpsc::channel(1);
         close_tx
-            .send(retryable_close("overloaded"))
+            .send(retryable_shutdown("overloaded"))
             .await
             .expect("queue priority close");
 
@@ -302,7 +322,7 @@ mod tests {
             .expect("queue normal message");
         normal_started_rx.await.expect("normal send starts");
         close_tx
-            .send(retryable_close("overloaded"))
+            .send(retryable_shutdown("overloaded"))
             .await
             .expect("request priority close");
 
@@ -323,6 +343,43 @@ mod tests {
         assert!(matches!(
             messages.last(),
             Some(Message::Close(Some(frame))) if frame.code == 1013 && frame.reason == "overloaded"
+        ));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_error_precedes_priority_close() {
+        let (_socket_tx, socket_rx) = mpsc::channel(1);
+        let (close_tx, close_rx) = mpsc::channel(1);
+        close_tx
+            .send(retryable_error_shutdown(
+                Message::Text("rate limited".into()),
+                "rate-limited",
+            ))
+            .await
+            .expect("queue priority shutdown");
+
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded_for_sink = recorded.clone();
+        let sink = Box::pin(futures::sink::unfold((), move |(), message| {
+            let recorded = recorded_for_sink.clone();
+            async move {
+                recorded
+                    .lock()
+                    .expect("recording sink poisoned")
+                    .push(message);
+                Ok::<_, std::convert::Infallible>(())
+            }
+        }));
+
+        run_socket_sender(sink, socket_rx, close_rx).await;
+
+        let messages = recorded.lock().expect("recording sink poisoned");
+        assert!(
+            matches!(messages.first(), Some(Message::Text(text)) if text.as_str() == "rate limited")
+        );
+        assert!(matches!(
+            messages.get(1),
+            Some(Message::Close(Some(frame))) if frame.code == 1013 && frame.reason == "rate-limited"
         ));
     }
 }

--- a/packages/service/src/domain/ws_session/protocol/server.rs
+++ b/packages/service/src/domain/ws_session/protocol/server.rs
@@ -141,6 +141,10 @@ pub struct SessionErrorPayload {
     /// mode in the cycle without re-querying state.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
+    /// Delay requested after a transient rate-limit response. Clients use this
+    /// instead of immediately feeding a reconnect storm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]

--- a/packages/service/src/main.rs
+++ b/packages/service/src/main.rs
@@ -9,6 +9,7 @@ mod shared;
 
 use axum::http::header::{HeaderName, CONTENT_TYPE};
 use axum::http::Method;
+use axum::serve::ListenerExt;
 use clap::Parser;
 use std::path::PathBuf;
 use tower_http::cors::CorsLayer;
@@ -227,57 +228,24 @@ async fn main() -> anyhow::Result<()> {
             info!("Cadencr service listening on {addr}");
 
             let listener = tokio::net::TcpListener::bind(&addr).await?;
-            // Wrap in a `Listener` that disables Nagle's algorithm on every
-            // accepted connection. Nagle is the default on `tokio::net::TcpStream`
-            // and silently coalesces small frames for ~200 ms — which turns
-            // a real-time WebSocket stream (commit output, agent output) into
-            // a "dump everything at the end" feed. We never want that here.
-            axum::serve(NoDelayListener(listener), app)
-                .with_graceful_shutdown(shutdown_signal(pty_manager, remote_for_shutdown))
-                .await?;
+            // Disable Nagle's algorithm on every accepted connection. Nagle is
+            // the default on `tokio::net::TcpStream` and silently coalesces
+            // small frames for ~200 ms, which destroys real-time WS streaming.
+            let listener = listener.tap_io(|stream| {
+                if let Err(err) = stream.set_nodelay(true) {
+                    tracing::warn!("set_nodelay failed: {err}");
+                }
+            });
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .with_graceful_shutdown(shutdown_signal(pty_manager, remote_for_shutdown))
+            .await?;
         }
     }
 
     Ok(())
-}
-
-/// `tokio::net::TcpListener` wrapper that disables Nagle's algorithm on every
-/// accepted connection. Without this, small WebSocket frames (single
-/// command-output chunks, agent stream lines) sit in the OS TCP buffer for
-/// up to ~200 ms before being flushed, which destroys the live-streaming UX
-/// the commit dialog and agent panes depend on.
-struct NoDelayListener(tokio::net::TcpListener);
-
-impl axum::serve::Listener for NoDelayListener {
-    type Io = tokio::net::TcpStream;
-    type Addr = std::net::SocketAddr;
-
-    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
-        loop {
-            match self.0.accept().await {
-                Ok((stream, addr)) => {
-                    // Best-effort: a `set_nodelay` failure on a localhost
-                    // TCP stream is exotic and not worth aborting the
-                    // connection over — log it and continue.
-                    if let Err(err) = stream.set_nodelay(true) {
-                        tracing::warn!("set_nodelay failed: {err}");
-                    }
-                    return (stream, addr);
-                }
-                Err(err) => {
-                    // Mirror axum's own retry-with-backoff behavior on
-                    // transient accept errors; without this an EMFILE / per-
-                    // process FD exhaustion would tight-loop.
-                    tracing::warn!("accept failed: {err}");
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-            }
-        }
-    }
-
-    fn local_addr(&self) -> std::io::Result<Self::Addr> {
-        self.0.local_addr()
-    }
 }
 
 fn build_cors_layer(frontend_port: u16) -> CorsLayer {

--- a/packages/service/tests/api_test.rs
+++ b/packages/service/tests/api_test.rs
@@ -16,6 +16,40 @@ async fn test_health_check() {
     assert_eq!(body["status"], "ok");
 }
 
+/// The loopback limiter must remain outside authentication so an untrusted
+/// local page or process cannot create unbounded auth or WebSocket-upgrade work.
+#[tokio::test]
+async fn loopback_rate_limit_sheds_requests_before_auth() {
+    const GENERAL_LIMIT: usize = 6000;
+
+    let server = start_test_server().await;
+    let unauthenticated_client = reqwest::Client::new();
+    let url = format!("{}/api/health", server.base_url);
+
+    for request_number in 1..=GENERAL_LIMIT {
+        let status = unauthenticated_client
+            .get(&url)
+            .send()
+            .await
+            .expect("loopback request")
+            .status();
+        assert_eq!(
+            status, 401,
+            "request {request_number} should reach authentication"
+        );
+    }
+
+    let response = unauthenticated_client
+        .get(url)
+        .send()
+        .await
+        .expect("rate-limited loopback request");
+    assert_eq!(response.status(), 429);
+    assert!(response
+        .headers()
+        .contains_key(reqwest::header::RETRY_AFTER));
+}
+
 /// The OpenAPI count assertion is brittle: every new endpoint forces an
 /// update. Switch to explicit lookups for the workflow-overhaul paths so a
 /// new endpoint never breaks this test, and a removed one is loud.

--- a/packages/service/tests/api_test.rs
+++ b/packages/service/tests/api_test.rs
@@ -17,9 +17,10 @@ async fn test_health_check() {
 }
 
 /// The loopback limiter must remain outside authentication so an untrusted
-/// local page or process cannot create unbounded auth or WebSocket-upgrade work.
+/// local page or process cannot create unbounded auth or WebSocket-upgrade
+/// work. Its anonymous allowance must be isolated from valid renderer traffic.
 #[tokio::test]
-async fn loopback_rate_limit_sheds_requests_before_auth() {
+async fn loopback_anonymous_flood_does_not_starve_authenticated_requests() {
     const GENERAL_LIMIT: usize = 6000;
 
     let server = start_test_server().await;
@@ -48,6 +49,48 @@ async fn loopback_rate_limit_sheds_requests_before_auth() {
     assert!(response
         .headers()
         .contains_key(reqwest::header::RETRY_AFTER));
+
+    let authenticated_response = server
+        .client
+        .get(format!("{}/api/health", server.base_url))
+        .send()
+        .await
+        .expect("authenticated loopback request");
+    assert_eq!(
+        authenticated_response.status(),
+        200,
+        "anonymous quota exhaustion must not block the renderer"
+    );
+
+    let tokenless_upgrade = apply_ws_upgrade_headers(
+        unauthenticated_client.get(format!("{}/ws", server.base_url)),
+        "http://localhost:1420",
+    )
+    .send()
+    .await
+    .expect("tokenless WebSocket upgrade");
+    assert_eq!(
+        tokenless_upgrade.status(),
+        429,
+        "tokenless upgrades remain bounded by the anonymous quota"
+    );
+
+    let authenticated_upgrade = apply_ws_upgrade_headers(
+        server.client.get(format!("{}/ws", server.base_url)),
+        "http://localhost:1420",
+    )
+    .header(
+        reqwest::header::SEC_WEBSOCKET_PROTOCOL,
+        "cadencr-token.test-token",
+    )
+    .send()
+    .await
+    .expect("authenticated WebSocket upgrade");
+    assert_eq!(
+        authenticated_upgrade.status(),
+        101,
+        "anonymous quota exhaustion must not block the renderer WebSocket"
+    );
 }
 
 /// The OpenAPI count assertion is brittle: every new endpoint forces an

--- a/packages/service/tests/common/mod.rs
+++ b/packages/service/tests/common/mod.rs
@@ -254,7 +254,12 @@ pub async fn start_test_server() -> TestServer {
     let app = api::build_router(state).layer(tower_http::cors::CorsLayer::permissive());
 
     tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
 
     let mut default_headers = HeaderMap::new();


### PR DESCRIPTION
## Summary

- prevent oversized or distant inline diffs from eagerly mounting the heavy Pierre renderer
- keep reconnect backoff across flapping sockets, honor rate-limit windows, deduplicate transcript errors, and evict unreferenced idle sessions
- bound slow-peer WebSocket forwarding and return a clean retryable `1013` close instead of feeding reconnect churn
- add low-overhead renderer lifecycle diagnostics for future crash reports

## Root cause

Large inline diffs could remain mounted and continue asynchronous highlighting beyond their useful viewport lifetime. At the same time, brief WebSocket opens reset retry state, already-scheduled retries ignored later rate-limit signals, and hidden session transports could remain retained indefinitely. Slow outbound peers also turned transient queue pressure into immediate disconnect/reconnect cycles.

## User impact

Large transcripts now perform substantially less renderer work, oversized diffs require explicit expansion and use plain text, reconnect storms back off instead of growing the transcript, and abandoned idle transports are released after a grace period.

## Validation

- `pnpm test` — all 6 workspace tasks passed; desktop: 500 files / 3,832 tests
- `pnpm lint`
- `pnpm --filter @cadencr/desktop ts-check`
- `pnpm --filter @cadencr/desktop knip`
- `pnpm format:check`
- `git diff --check`
- live QA: 300/300 loopback health requests returned `200`; WebSocket overload returned a clean `1013` close with `retry_after_ms: 5000`

Fixes #161