### PR TITLE
fix(worktree): bound persisted setup log replay

### DIFF
--- a/packages/desktop/src/stores/ws-session-store.test.ts
+++ b/packages/desktop/src/stores/ws-session-store.test.ts
@@ -2986,6 +2986,26 @@ describe("ws-session-store", () => {
       expect(session.worktreeSetupOutput).toEqual(["Installing deps...", "Done."]);
     });
 
+    it("replaces setup output with one persisted replay snapshot", async () => {
+      useWsSessionStore.getState().connect("s1");
+      await tick();
+      const ws = getWs();
+      ws.simulateMessage({
+        domain: "workflow",
+        action: "worktree.setup_output",
+        payload: { line: "stale line" },
+      });
+
+      ws.simulateMessage({
+        domain: "workflow",
+        action: "worktree.setup_output",
+        payload: { line: "restored one\nrestored two", replace: true },
+      });
+
+      const output = useWsSessionStore.getState().sessions["s1"].worktreeSetupOutput;
+      expect(output).toEqual(["restored one\nrestored two"]);
+    });
+
     it("handles worktree.ready event", async () => {
       useWsSessionStore.getState().connect("s1");
       await tick();

--- a/packages/desktop/src/stores/ws-worktree-handler.ts
+++ b/packages/desktop/src/stores/ws-worktree-handler.ts
@@ -52,9 +52,10 @@ export function handleWorktreeEvent(
       const session = ctx.getSession(sessionId);
       const line = payloadString("line");
       if (!line) break;
+      const output = value.replace === true ? [line] : [...session.worktreeSetupOutput, line];
       ctx.set(
         updateSession(ctx.get(), sessionId, {
-          worktreeSetupOutput: [...session.worktreeSetupOutput, line],
+          worktreeSetupOutput: output,
         }),
       );
       break;
@@ -72,7 +73,7 @@ export function handleWorktreeEvent(
         updateSession(ctx.get(), sessionId, {
           worktreeStatus: "setup_error",
           worktreeError: payloadString("error") ?? payloadString("message"),
-          ...(shouldHydrateOutput ? { worktreeSetupOutput: output.split("\n") } : {}),
+          ...(shouldHydrateOutput ? { worktreeSetupOutput: [output] } : {}),
         }),
       );
       break;

--- a/packages/service/src/domain/features/repository/settings_repository.rs
+++ b/packages/service/src/domain/features/repository/settings_repository.rs
@@ -3,6 +3,7 @@ use sqlx::{AssertSqlSafe, Executor, Sqlite, SqlitePool};
 use super::super::models::{FeatureModelSettings, FeatureProviderSettings, FeatureSetting};
 use crate::domain::agents::runtime::{runtime_setting_key, validate_agent_type};
 use crate::error::AppError;
+use crate::shared::setup_log::setup_log_for_transport;
 
 pub async fn get_feature_settings(
     pool: &SqlitePool,
@@ -50,7 +51,10 @@ pub async fn get_feature_settings(
             .bind(feature_id)
             .fetch_all(pool)
             .await?;
-    for (key, value) in settings {
+    for (key, mut value) in settings {
+        if key == "worktree_setup_log" {
+            value = setup_log_for_transport(value);
+        }
         result.push(FeatureSetting { key, value });
     }
 

--- a/packages/service/src/domain/workflow/worktree/replay.rs
+++ b/packages/service/src/domain/workflow/worktree/replay.rs
@@ -21,6 +21,7 @@ use super::{
     get_project_directory, get_project_id_for_feature, get_setting, resolve_live_worktree,
 };
 use crate::domain::workflow::ws_sender::WsSender;
+use crate::shared::setup_log::setup_log_for_transport;
 
 /// Re-emit the feature's persisted worktree state to `sender`, reusing the exact
 /// envelopes the frontend's worktree state machine already handles. Returns the
@@ -74,11 +75,16 @@ async fn replay_setup_error(read_pool: &SqlitePool, feature_id: i64, sender: &Ws
     let output = get_setting(read_pool, feature_id, "worktree_setup_log")
         .await
         .unwrap_or_default();
+    let display_output = setup_log_for_transport(output);
     send_envelope(
         sender,
         "workflow",
         "worktree.setup_error",
-        serde_json::json!({ "feature_id": feature_id, "error": error, "output": output }),
+        serde_json::json!({
+            "feature_id": feature_id,
+            "error": error,
+            "output": display_output,
+        }),
     );
 }
 
@@ -97,14 +103,22 @@ async fn replay_setup_running(read_pool: &SqlitePool, feature_id: i64, sender: &
 
 async fn replay_setup_output(read_pool: &SqlitePool, feature_id: i64, sender: &WsSender) {
     if let Some(log) = get_setting(read_pool, feature_id, "worktree_setup_log").await {
-        for line in log.lines() {
-            send_envelope(
-                sender,
-                "workflow",
-                "worktree.setup_output",
-                serde_json::json!({ "feature_id": feature_id, "line": line }),
-            );
+        if log.is_empty() {
+            return;
         }
+        let display_log = setup_log_for_transport(log);
+        // A message per persisted line can overflow the WS queue and reconnect.
+        // Restore one replaceable snapshot; live setup remains line-streamed.
+        send_envelope(
+            sender,
+            "workflow",
+            "worktree.setup_output",
+            serde_json::json!({
+                "feature_id": feature_id,
+                "line": display_log,
+                "replace": true,
+            }),
+        );
     }
 }
 
@@ -153,13 +167,19 @@ mod tests {
         dir
     }
 
-    fn actions(rx: &mut mpsc::UnboundedReceiver<Message>) -> Vec<String> {
+    fn envelopes(rx: &mut mpsc::UnboundedReceiver<Message>) -> Vec<serde_json::Value> {
         let mut out = Vec::new();
         while let Ok(Message::Text(text)) = rx.try_recv() {
-            let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-            out.push(v["action"].as_str().unwrap().to_string());
+            out.push(serde_json::from_str(&text).unwrap());
         }
         out
+    }
+
+    fn actions(envelopes: &[serde_json::Value]) -> Vec<String> {
+        envelopes
+            .iter()
+            .map(|value| value["action"].as_str().unwrap().to_string())
+            .collect()
     }
 
     #[tokio::test]
@@ -195,15 +215,18 @@ mod tests {
             .unwrap()
             .is_some());
 
+        let envelopes = envelopes(&mut rx);
         assert_eq!(
-            actions(&mut rx),
+            actions(&envelopes),
             vec![
                 "worktree.created",
-                "worktree.setup_output",
                 "worktree.setup_output",
                 "worktree.ready"
             ]
         );
+        let snapshot = &envelopes[1]["payload"];
+        assert_eq!(snapshot["line"], "$ pnpm install\nDone");
+        assert_eq!(snapshot["replace"], true);
     }
 
     #[tokio::test]
@@ -262,7 +285,7 @@ mod tests {
             .is_some());
 
         assert_eq!(
-            actions(&mut rx),
+            actions(&envelopes(&mut rx)),
             vec!["worktree.created", "worktree.setup_running"],
             "with no persisted log, only created + setup_running are replayed"
         );
@@ -288,7 +311,7 @@ mod tests {
             .is_some());
 
         assert_eq!(
-            actions(&mut rx),
+            actions(&envelopes(&mut rx)),
             vec!["worktree.created", "worktree.setup_error"]
         );
     }

--- a/packages/service/src/domain/workflow/worktree/setup.rs
+++ b/packages/service/src/domain/workflow/worktree/setup.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use sqlx::SqlitePool;
 
 use crate::domain::workflow::ws_sender::WsSender;
+use crate::shared::setup_log::setup_log_for_transport;
 
 use super::db::set_setting;
 use super::envelope::send_envelope;
@@ -23,6 +24,7 @@ async fn report_setup_error(
     let _ = set_setting(write_pool, feature_id, "worktree_setup_error", error).await;
     let log = log_lines.lock().await.join("\n");
     let _ = set_setting(write_pool, feature_id, "worktree_setup_log", &log).await;
+    let display_log = setup_log_for_transport(log);
     send_envelope(
         ws_sender,
         "workflow",
@@ -30,7 +32,7 @@ async fn report_setup_error(
         serde_json::json!({
             "feature_id": feature_id,
             "error": error,
-            "output": log,
+            "output": display_log,
         }),
     );
 }

--- a/packages/service/src/shared/mod.rs
+++ b/packages/service/src/shared/mod.rs
@@ -11,6 +11,7 @@ pub mod image_file;
 pub mod login_env;
 pub mod migrate;
 pub mod security;
+pub mod setup_log;
 pub mod slug;
 pub mod ssh_env;
 pub mod startup_progress;

--- a/packages/service/src/shared/setup_log.rs
+++ b/packages/service/src/shared/setup_log.rs
@@ -1,0 +1,33 @@
+const MAX_SETUP_LOG_TRANSPORT_BYTES: usize = 128 * 1024;
+const TRUNCATED_PREFIX: &str = "[... earlier setup output truncated ...]\n";
+
+/// Keep persisted setup diagnostics intact while bounding copies sent to UI clients.
+pub(crate) fn setup_log_for_transport(log: String) -> String {
+    if log.len() <= MAX_SETUP_LOG_TRANSPORT_BYTES {
+        return log;
+    }
+
+    let tail_bytes = MAX_SETUP_LOG_TRANSPORT_BYTES - TRUNCATED_PREFIX.len();
+    let mut start = log.len() - tail_bytes;
+    while !log.is_char_boundary(start) {
+        start += 1;
+    }
+
+    format!("{TRUNCATED_PREFIX}{}", &log[start..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_setup_logs_without_splitting_utf8() {
+        let log = format!("old\n{}retained", "é".repeat(MAX_SETUP_LOG_TRANSPORT_BYTES));
+
+        let bounded = setup_log_for_transport(log);
+
+        assert!(bounded.len() <= MAX_SETUP_LOG_TRANSPORT_BYTES);
+        assert!(bounded.starts_with(TRUNCATED_PREFIX));
+        assert!(bounded.ends_with("retained"));
+    }
+}


### PR DESCRIPTION
## Summary

- replay persisted worktree setup output as one idempotent WebSocket snapshot
- cap setup logs sent to the renderer at 128 KiB while preserving the full database value
- keep live setup-output streaming unchanged

## Root cause

A multi-megabyte persisted setup log was replayed as one WebSocket envelope per line. Each frontend append copied the growing output array; queue overflow then triggered reconnects, which restarted the same replay.

## Scope

- no migration or generated API change
- one backward-compatible optional `replace` payload field
- no profiling, debug instrumentation, or unrelated React workaround

## Validation

- pre-commit suite passed: format, lint, TypeScript, tests, and knip
- persisted-log replay tests pass in Rust and Vitest
- live setup-log payloads stayed at or below 128 KiB
- 12 Editor/Git cycles retained 64.8 MB renderer heap after GC, with no multi-megabyte setup-log strings
