### PR TITLE
fix(desktop): let the main panel reclaim the space of a collapsed sidebar

### DIFF
--- a/packages/desktop/src/routes/__root.sidebar-collapse.test.tsx
+++ b/packages/desktop/src/routes/__root.sidebar-collapse.test.tsx
@@ -1,0 +1,87 @@
+import { type ComponentType, type ReactNode, useCallback, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@/test-utils";
+import { useSidebarCollapsed } from "@/components/SidebarContext";
+
+/**
+ * Guards the 0.11.3 regression where `Cmd+B` faded the sidebar out but left its
+ * panel reserving the width. Mounts the real `ui/resizable` — the mock in
+ * `__root.test.tsx` cannot show it — and toggles through `SidebarContext`.
+ */
+const mocks = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+
+vi.mock("@tanstack/react-router", () => ({
+  createRootRoute: (opts: { component: unknown }) => ({ options: opts }),
+  Outlet: () => {
+    const { collapsed, setCollapsed } = useSidebarCollapsed();
+    return (
+      <button type="button" data-testid="toggle" onClick={() => setCollapsed(!collapsed)}>
+        toggle
+      </button>
+    );
+  },
+  useNavigate: () => mocks.mockNavigate,
+  useRouterState: () => ({ location: { pathname: "/" } }),
+  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock("@tanstack/react-hotkeys", () => ({ useHotkeys: vi.fn() }));
+
+vi.mock("@/hooks/useDebouncedSetting", () => ({
+  useDebouncedSetting: (key: string) => {
+    const [value, setStored] = useState<string | null>(key === "sidebar_left_width" ? "256" : null);
+    const setValue = useCallback((next: string) => setStored(next), []);
+    return { value, setValue, isLoading: false, isSaving: false };
+  },
+  useDebouncedSettingFromMap: () => ({ value: "256", setValue: vi.fn(), isLoading: false }),
+}));
+
+vi.mock("@/api/settings", () => ({
+  useGetWorkspaceSettings: vi.fn(() => ({ data: [], isLoading: false })),
+  settingsArrayToMap: vi.fn(() => ({})),
+  getWorkspaceSettingsQueryKey: () => ["workspace", "settings"] as const,
+}));
+
+vi.mock("@/components/Sidebar", () => ({
+  Sidebar: () => <div data-testid="sidebar">Sidebar</div>,
+}));
+
+vi.mock("@/components/CommandPalette", () => ({ CommandPalette: () => null }));
+
+import { Route } from "./__root";
+
+const GROUP_WIDTH = 800;
+const GROUP_HEIGHT = 600;
+
+function RootLayout() {
+  const Component = (Route as unknown as { options: { component: ComponentType } }).options
+    .component;
+  return <Component />;
+}
+
+function sidebarPanel(): HTMLElement {
+  const panel = document.querySelector<HTMLElement>("#sidebar");
+  if (!panel) throw new Error("sidebar panel not rendered");
+  return panel;
+}
+
+describe("global sidebar collapse", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("hands the sidebar's width back to the main panel and takes it back", () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () => new DOMRect(0, 0, GROUP_WIDTH, GROUP_HEIGHT),
+    );
+    render(<RootLayout />);
+    const expandedGrow = sidebarPanel().style.flexGrow;
+    expect(Number(expandedGrow)).toBeGreaterThan(0);
+
+    act(() => screen.getByTestId("toggle").click());
+    expect(sidebarPanel().style.flexGrow).toBe("0");
+
+    act(() => screen.getByTestId("toggle").click());
+    expect(sidebarPanel().style.flexGrow).toBe(expandedGrow);
+  });
+});

--- a/packages/desktop/src/routes/useRootLayoutController.tsx
+++ b/packages/desktop/src/routes/useRootLayoutController.tsx
@@ -96,13 +96,21 @@ function useSidebarController(isMobile: boolean) {
   useEffect(() => {
     document.documentElement.dataset.sidebarCollapsed = collapsed ? "true" : "false";
   }, [collapsed]);
+  // A changed `collapsible` reaches the Panel one render later, so the
+  // `collapse()` riding the same commit no-ops and the sidebar keeps its width.
+  // Retry once it lands; re-setting the same flag bails out instead of looping.
+  const [retryCollapse, setRetryCollapse] = useState(false);
   useEffect(() => {
     if (isMobile || collapsedSetting.isLoading) return;
     const panel = sidebarPanelRef.current;
-    if (!panel || panel.isCollapsed() === collapsed) return;
+    if (!panel || panel.isCollapsed() === collapsed) {
+      setRetryCollapse(false);
+      return;
+    }
     if (collapsed) panel.collapse();
     else panel.expand();
-  }, [collapsed, collapsedSetting.isLoading, isMobile]);
+    setRetryCollapse(collapsed && !panel.isCollapsed());
+  }, [collapsed, collapsedSetting.isLoading, isMobile, retryCollapse]);
   useEffect(() => {
     leftSidebarRef.current?.focus();
   }, []);


### PR DESCRIPTION
Closes #199

## Problem

Since 0.11.3, `Cmd+B` faded the sidebar out but its panel kept reserving its width, so the main content stayed anchored at its old left offset and a blank band was left on the left of the window.

## Cause

`setCollapsed` writes the `sidebar_collapsed` setting, and the effect in `useSidebarController` calls `panel.collapse()` imperatively. `AppShell` flips the Panel's `collapsible` prop in that very same commit — but react-resizable-panels only re-registers a panel's constraints on the render *after* the prop changes. The first `collapse()` therefore ran against a still-non-collapsible panel and silently did nothing, while the sidebar's own styling (driven off `collapsed`) faded out immediately.

Expanding was unaffected: `setCollapsed` already calls `expand()` while the panel is still collapsible.

## Fix

Retry the collapse once the re-registration has landed. A `retryCollapse` state flag re-runs the effect one render later; it settles after that extra render, because a collapse that can never succeed re-sets the same value and React bails out instead of looping.

## Test

New `packages/desktop/src/routes/__root.sidebar-collapse.test.tsx` mounts the real `ui/resizable` (the mocked one in `__root.test.tsx` cannot reproduce the bug) and asserts the sidebar panel's `flex-grow` drops to `0` on collapse and returns to its previous value on expand. It fails on `main` and passes here.

## Checks

`pnpm turbo run format:check lint ts-check test knip` — 22/22 tasks green.