### PR TITLE
fix(mcp): pin protocol negotiation below 2026-07-28

### DIFF
--- a/packages/service/src/domain/mcp/servers/browser.rs
+++ b/packages/service/src/domain/mcp/servers/browser.rs
@@ -276,6 +276,12 @@ impl ServerHandler for BrowserServer {
         server_info("cadencr-browser")
     }
 
+    fn supported_protocol_versions(
+        &self,
+    ) -> std::borrow::Cow<'static, [rmcp::model::ProtocolVersion]> {
+        super::supported_protocol_versions()
+    }
+
     fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,

--- a/packages/service/src/domain/mcp/servers/mod.rs
+++ b/packages/service/src/domain/mcp/servers/mod.rs
@@ -5,9 +5,10 @@ mod project_schema;
 mod send_message_schema;
 pub mod workspace;
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
-use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
+use rmcp::model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo};
 
 use self::{browser::BrowserServer, project::ProjectServer, workspace::WorkspaceServer};
 use super::context::McpContext;
@@ -101,9 +102,30 @@ pub fn mcp_server_name(agent_type: AgentType) -> String {
     format!("cadencr-{}", agent_type.short_name())
 }
 
+/// Highest MCP protocol version the Cadencr servers negotiate.
+///
+/// `2026-07-28` is deliberately excluded from negotiation: rmcp 3.1.1 tags
+/// results for that version with `resultType` but omits the `ttlMs` and
+/// `cacheScope` fields that SEP-2549 makes mandatory on `tools/list`, so
+/// spec-conformant clients (Claude Code >= 2.1.232) reject the response and
+/// the session ends up with zero tools (issue #208). Re-allow it only once
+/// rmcp emits conformant cacheable results.
+const PINNED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2025_11_25;
+
+fn supported_protocol_versions() -> Cow<'static, [ProtocolVersion]> {
+    const SUPPORTED: &[ProtocolVersion] = &[
+        ProtocolVersion::V_2024_11_05,
+        ProtocolVersion::V_2025_03_26,
+        ProtocolVersion::V_2025_06_18,
+        ProtocolVersion::V_2025_11_25,
+    ];
+    Cow::Borrowed(SUPPORTED)
+}
+
 fn server_info(name: &str) -> ServerInfo {
     let caps = ServerCapabilities::builder().enable_tools().build();
-    let info = ServerInfo::new(caps).with_server_info(Implementation::new(name, "1.0.0"));
+    let mut info = ServerInfo::new(caps).with_server_info(Implementation::new(name, "1.0.0"));
+    info.protocol_version = PINNED_PROTOCOL_VERSION;
     if name == "cadencr-project" {
         return info.with_instructions(
             "CadencR project orchestration is reactive. Inter-agent messages, gates, and awaited replies steer active turns by default. After spawning with follow or requesting a reply, wait for automatically delivered <cadencr-gate> and <cadencr-reply> events; do not poll session tails, status, or pending gates. Queueing is opt-in through delivery=next_turn only.",
@@ -142,6 +164,17 @@ mod tests {
     #[test]
     fn required_tools_rejects_legacy_prefix() {
         assert!(cadencr_mcp_required_tools("legacy-session").is_empty());
+    }
+
+    #[test]
+    fn negotiation_never_offers_2026_07_28() {
+        let versions = super::supported_protocol_versions();
+        assert!(!versions.contains(&rmcp::model::ProtocolVersion::V_2026_07_28));
+        assert!(versions.contains(&super::PINNED_PROTOCOL_VERSION));
+        assert!(
+            server_info("cadencr-project").protocol_version
+                < rmcp::model::ProtocolVersion::V_2026_07_28
+        );
     }
 
     #[test]

--- a/packages/service/src/domain/mcp/servers/project.rs
+++ b/packages/service/src/domain/mcp/servers/project.rs
@@ -31,6 +31,12 @@ impl ServerHandler for ProjectServer {
         server_info("cadencr-project")
     }
 
+    fn supported_protocol_versions(
+        &self,
+    ) -> std::borrow::Cow<'static, [rmcp::model::ProtocolVersion]> {
+        super::supported_protocol_versions()
+    }
+
     fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,

--- a/packages/service/src/domain/mcp/servers/workspace.rs
+++ b/packages/service/src/domain/mcp/servers/workspace.rs
@@ -175,6 +175,12 @@ impl ServerHandler for WorkspaceServer {
         server_info("cadencr-workspace")
     }
 
+    fn supported_protocol_versions(
+        &self,
+    ) -> std::borrow::Cow<'static, [rmcp::model::ProtocolVersion]> {
+        super::supported_protocol_versions()
+    }
+
     fn list_tools(
         &self,
         _request: Option<PaginatedRequestParams>,

--- a/packages/service/tests/mcp_spawn_test.rs
+++ b/packages/service/tests/mcp_spawn_test.rs
@@ -1,10 +1,14 @@
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::time::Duration;
 
 use cadencr_service::domain::mcp::servers::{mcp_server_name, AgentType};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+
+/// Upper bound for MCP child-process I/O: response reads and shutdown wait.
+const IO_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct McpTestProcess {
     child: Child,
@@ -57,7 +61,10 @@ async fn test_mcp_negotiates_below_2026_07_28_and_keeps_legacy_result_shape() {
     let init_req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
     write_json_line(&mut process.stdin, init_req).await;
     let mut line = String::new();
-    process.reader.read_line(&mut line).await.unwrap();
+    tokio::time::timeout(IO_TIMEOUT, process.reader.read_line(&mut line))
+        .await
+        .expect("timed out waiting for initialize response")
+        .unwrap();
     let init_resp: serde_json::Value = serde_json::from_str(&line).unwrap();
     assert_eq!(init_resp["result"]["protocolVersion"], "2025-11-25");
 
@@ -67,7 +74,10 @@ async fn test_mcp_negotiates_below_2026_07_28_and_keeps_legacy_result_shape() {
     let tools_req = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
     write_json_line(&mut process.stdin, tools_req).await;
     let mut tools_line = String::new();
-    process.reader.read_line(&mut tools_line).await.unwrap();
+    tokio::time::timeout(IO_TIMEOUT, process.reader.read_line(&mut tools_line))
+        .await
+        .expect("timed out waiting for tools/list response")
+        .unwrap();
     let tools_resp: serde_json::Value = serde_json::from_str(&tools_line).unwrap();
     assert!(
         tools_resp["result"].get("resultType").is_none(),
@@ -363,7 +373,7 @@ fn assert_browser_open_url_schema_is_pinned(tools: &[serde_json::Value]) {
 
 async fn shutdown_mcp_process(mut process: McpTestProcess) {
     drop(process.stdin);
-    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), process.child.wait()).await;
+    let _ = tokio::time::timeout(IO_TIMEOUT, process.child.wait()).await;
 }
 
 async fn assert_stdio_tools_list_for_agent_type(

--- a/packages/service/tests/mcp_spawn_test.rs
+++ b/packages/service/tests/mcp_spawn_test.rs
@@ -41,6 +41,43 @@ async fn test_mcp_stdio_server_responds_to_tools_list() {
     shutdown_mcp_process(process).await;
 }
 
+/// Regression test for issue #208: a client requesting protocol `2026-07-28`
+/// must be negotiated down to the pinned version, and `tools/list` must keep
+/// the legacy wire shape (no top-level `resultType`). rmcp 3.1.1 tags
+/// `2026-07-28` results with `resultType` but omits the SEP-2549-mandatory
+/// `ttlMs`/`cacheScope`, which spec-conformant clients such as Claude Code
+/// reject — leaving the session with zero tools.
+#[tokio::test]
+async fn test_mcp_negotiates_below_2026_07_28_and_keeps_legacy_result_shape() {
+    let (_tmp, db_path) = setup_browser_test_db().await;
+    let Some(mut process) = spawn_mcp_process(&db_path, "browser") else {
+        return;
+    };
+
+    let init_req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2026-07-28","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#;
+    write_json_line(&mut process.stdin, init_req).await;
+    let mut line = String::new();
+    process.reader.read_line(&mut line).await.unwrap();
+    let init_resp: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(init_resp["result"]["protocolVersion"], "2025-11-25");
+
+    let initialized = r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#;
+    write_json_line(&mut process.stdin, initialized).await;
+
+    let tools_req = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+    write_json_line(&mut process.stdin, tools_req).await;
+    let mut tools_line = String::new();
+    process.reader.read_line(&mut tools_line).await.unwrap();
+    let tools_resp: serde_json::Value = serde_json::from_str(&tools_line).unwrap();
+    assert!(
+        tools_resp["result"].get("resultType").is_none(),
+        "tools/list must keep the legacy wire shape, got: {tools_resp}"
+    );
+    assert!(!tools_resp["result"]["tools"].as_array().unwrap().is_empty());
+
+    shutdown_mcp_process(process).await;
+}
+
 async fn setup_browser_test_db() -> (tempfile::TempDir, PathBuf) {
     let tmp = tempfile::TempDir::new().unwrap();
     let db_path = tmp.path().join("test.db");


### PR DESCRIPTION
## Problem

Since Claude Code >= 2.1.232, sessions connected to the Cadencr MCP servers come up with **zero tools** (#208).

Root cause: rmcp 3.1.1 negotiates protocol `2026-07-28` and tags `tools/list` results with `resultType`, but omits the `ttlMs` and `cacheScope` fields that SEP-2549 makes mandatory on cacheable results. Spec-conformant clients reject the malformed response.

## Fix

- Pin the advertised protocol version to `2025-11-25` and exclude `2026-07-28` from negotiation via `supported_protocol_versions()` on all three servers (browser, project, workspace).
- `supported_protocol_versions()` + `PINNED_PROTOCOL_VERSION` live in `packages/service/src/domain/mcp/servers/mod.rs` with a comment explaining when the pin can be lifted (once rmcp emits conformant cacheable results).

## Tests

- Unit test: negotiation never offers `2026-07-28` and the pinned version is offered.
- Stdio regression test (`mcp_spawn_test.rs`): a client requesting `2026-07-28` is negotiated down to `2025-11-25`, and `tools/list` keeps the legacy wire shape (no top-level `resultType`) with a non-empty tool list.

Fixes #208