### PR TITLE
fix(mcp): spawn defaults to the caller's project and surfaces branch-setup git errors

### DIFF
--- a/packages/service/src/domain/mcp/control/spawn_resolve.rs
+++ b/packages/service/src/domain/mcp/control/spawn_resolve.rs
@@ -72,12 +72,16 @@ pub(super) fn branch_worktree_settings(
     ))
 }
 
-/// Resolve the project a spawned session should land in. A target is required:
-/// the caller must pass `target_project_id` or `target_project_path` (pass the
-/// caller's own project id to spawn locally). Errors are phrased to point the
-/// agent at `workspace_list_projects` for valid targets.
+/// Resolve the project a spawned session should land in. Explicit selectors
+/// win: `target_project_id` / `target_project_path` (both must agree when
+/// supplied). When neither is given, the spawn lands in the caller's own
+/// project: agents running in managed worktrees cannot reliably derive their
+/// project from the filesystem (issue #210), so the source session is the
+/// authoritative fallback. Errors are phrased to point the agent at
+/// `workspace_list_projects` for valid targets.
 pub(super) async fn resolve_target_project(
     pool: &sqlx::SqlitePool,
+    source_project_id: i64,
     target_project_id: Option<i64>,
     target_project_path: Option<&str>,
 ) -> Result<TargetProject, AppError> {
@@ -96,12 +100,13 @@ pub(super) async fn resolve_target_project(
                 "No CadencR project is registered at path '{path}'. The path must exactly match a project root; call workspace_list_projects to see registered project paths."
             ))
         })?,
-        (None, None) => {
-            return Err(AppError::BadRequest(
-                "A target project is required: pass project_id or project_path (call workspace_list_projects to see available projects, then pass the caller's own project id to spawn in the current project)."
-                    .to_string(),
-            ))
-        }
+        (None, None) => fetch_project_by_id(pool, source_project_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::Internal(format!(
+                    "source session's project {source_project_id} no longer exists"
+                ))
+            })?,
     };
 
     // When both selectors are supplied the path acts as a confirmation guard so
@@ -288,18 +293,23 @@ mod tests {
         pool
     }
 
+    // Regression for issue #210: agents in managed worktrees guessed their
+    // project by lexical path ancestry and hit non-git projects. Omitting the
+    // target must fall back to the caller's own project instead.
     #[tokio::test]
-    async fn resolve_target_project_requires_a_target() {
+    async fn resolve_target_project_defaults_to_caller_project() {
         let pool = seed_projects_pool().await;
-        let error = resolve_target_project(&pool, None, None).await.unwrap_err();
-        assert!(matches!(error, AppError::BadRequest(_)));
-        assert!(error.to_string().contains("project_id or project_path"));
+        let target = resolve_target_project(&pool, 7, None, None).await.unwrap();
+        assert_eq!(target.id, 7);
+        assert_eq!(target.name, "Caller");
     }
 
     #[tokio::test]
     async fn resolve_target_project_by_id_selects_project() {
         let pool = seed_projects_pool().await;
-        let target = resolve_target_project(&pool, Some(9), None).await.unwrap();
+        let target = resolve_target_project(&pool, 7, Some(9), None)
+            .await
+            .unwrap();
         assert_eq!(target.id, 9);
         assert_eq!(target.name, "Target");
     }
@@ -307,7 +317,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_target_project_by_path_selects_project() {
         let pool = seed_projects_pool().await;
-        let target = resolve_target_project(&pool, None, Some("  /repos/target  "))
+        let target = resolve_target_project(&pool, 7, None, Some("  /repos/target  "))
             .await
             .unwrap();
         assert_eq!(target.id, 9);
@@ -316,7 +326,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_target_project_unknown_id_points_at_workspace_list() {
         let pool = seed_projects_pool().await;
-        let error = resolve_target_project(&pool, Some(404), None)
+        let error = resolve_target_project(&pool, 7, Some(404), None)
             .await
             .unwrap_err();
         assert!(matches!(error, AppError::BadRequest(_)));
@@ -326,7 +336,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_target_project_unknown_path_points_at_workspace_list() {
         let pool = seed_projects_pool().await;
-        let error = resolve_target_project(&pool, None, Some("/nope"))
+        let error = resolve_target_project(&pool, 7, None, Some("/nope"))
             .await
             .unwrap_err();
         assert!(matches!(error, AppError::BadRequest(_)));
@@ -336,7 +346,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_target_project_rejects_inconsistent_id_and_path() {
         let pool = seed_projects_pool().await;
-        let error = resolve_target_project(&pool, Some(9), Some("/repos/caller"))
+        let error = resolve_target_project(&pool, 7, Some(9), Some("/repos/caller"))
             .await
             .unwrap_err();
         assert!(matches!(error, AppError::BadRequest(_)));

--- a/packages/service/src/domain/mcp/control/spawn_session.rs
+++ b/packages/service/src/domain/mcp/control/spawn_session.rs
@@ -74,6 +74,7 @@ pub(super) async fn spawn_session_handler(
 
     let target_project = match resolve_target_project(
         &state.write_pool,
+        source.project_id,
         body.target_project_id,
         body.target_project_path.as_deref(),
     )

--- a/packages/service/src/domain/mcp/servers/project_schema.rs
+++ b/packages/service/src/domain/mcp/servers/project_schema.rs
@@ -231,8 +231,8 @@ mod tests {
         assert_eq!(schema["properties"]["project_id"]["type"], "number");
         assert_eq!(schema["properties"]["project_path"]["type"], "string");
         // Keep the advertised schema flat so MCP clients generate concrete
-        // arguments instead of an opaque union. The control endpoint still
-        // enforces that one target selector is present.
+        // arguments instead of an opaque union. The control endpoint falls
+        // back to the caller's own project when no selector is present.
         assert!(schema.get("anyOf").is_none());
         assert_eq!(schema["required"][0], "title");
         assert!(schema["description"]

--- a/packages/service/src/domain/mcp/servers/project_schema_descriptions.rs
+++ b/packages/service/src/domain/mcp/servers/project_schema_descriptions.rs
@@ -11,7 +11,7 @@ pub(super) fn tool_description(name: &str) -> &'static str {
         "project_compare_sessions" => "Compare two current-project sessions and their worktree status.",
         "project_link_sessions" => "Record an explicit relationship between current-project sessions.",
         "project_list_agent_providers" => "List canonical CadencR provider ids, models, and each model's available thinking levels for project_spawn_session.",
-        "project_spawn_session" => "Create another CadencR session in a target project. Use follow to receive gates and completion reactively: these events steer the current parent turn, so do not poll status, tails, or pending gates. You MUST specify project_id or project_path (call workspace_list_projects first). Use canonical provider ids and advertised thinking levels; call project_list_agent_providers when unsure.",
+        "project_spawn_session" => "Create another CadencR session in a target project. Use follow to receive gates and completion reactively: these events steer the current parent turn, so do not poll status, tails, or pending gates. Spawns into the caller's own project unless project_id or project_path selects another one (call workspace_list_projects first). Use canonical provider ids and advertised thinking levels; call project_list_agent_providers when unsure.",
         "project_send_session_message" => "Send a provenance-tracked message to another current-project session. Delivery steers the active target turn by default; request next_turn explicitly only when delayed handling is intentional.",
         "project_list_pending_gates" => "Recovery only: reconcile a linked child's pending gate after a missed/stale notification. A live <cadencr-gate> already contains the complete request id, kind, options, and payload; never poll this tool.",
         "project_respond_gate" => "Answer a linked child's pending gate using the exact session id, request id, kind, and payload from the automatically delivered <cadencr-gate>.",
@@ -25,7 +25,7 @@ pub(super) fn property_description(tool_name: &str, property: &str) -> String {
             "Canonical provider id: {}. Common aliases are normalized, but canonical ids are preferred.",
             valid_provider_ids().join(", ")
         ),
-        ("project_spawn_session", "project_id") => "Target project id for the new session (required unless project_path is given). Pass the caller's own project id for the current project, or another registered id from workspace_list_projects.".into(),
+        ("project_spawn_session", "project_id") => "Target project id for the new session. Omit to spawn in the caller's own project; pass a registered id from workspace_list_projects to target another project.".into(),
         ("project_spawn_session", "project_path") => "Target project root path (alternative to project_id). It must exactly match a registered path from workspace_list_projects; if both selectors are given they must agree.".into(),
         ("project_spawn_session", "model") => model_description(),
         ("project_spawn_session", "thinking_level") => "Provider/model-specific thinking or reasoning level. Use one of the target provider/model pair's thinking_levels from project_list_agent_providers. When omitted, CadencR uses the last selection for that target provider/model, then the CLI-advertised default_thinking_level.".into(),

--- a/packages/service/src/domain/ws_session/handler/session_prompt/prompt_pending.rs
+++ b/packages/service/src/domain/ws_session/handler/session_prompt/prompt_pending.rs
@@ -101,8 +101,11 @@ pub(super) async fn handle_pending_prompt(mut context: PendingPromptContext) -> 
             )
             .await;
             let internal_replay = context.internal_replay;
+            // Keep the underlying git error in the internal-caller reply so
+            // MCP spawns don't surface an opaque "branch setup failed" (#210).
+            let failure = format!("branch setup failed: {error}");
             report_branch_setup_error(context, error).await;
-            return reported_failure(internal_replay, "branch setup failed");
+            return reported_failure(internal_replay, &failure);
         }
     };
     if let Err(error) = reresolve_worktree_and_resume(&mut context).await {

--- a/packages/service/tests/mcp_control_test.rs
+++ b/packages/service/tests/mcp_control_test.rs
@@ -108,6 +108,40 @@ async fn project_spawn_session_creates_feature_session_provenance_and_link() {
     );
 }
 
+// Regression for issue #210: agents in managed worktrees cannot reliably
+// derive their own project from the filesystem, so omitting the target must
+// spawn into the caller's project instead of erroring.
+#[tokio::test]
+async fn project_spawn_session_defaults_to_caller_project_without_target() {
+    let pool = seeded_control_pool().await;
+
+    let app = control_router().with_state(AppState::with_pool(pool.clone()));
+    let body = serde_json::json!({
+        "source_feature_id": 42,
+        "source_session_id": 777,
+        "title": "Follow-up in caller project",
+        "branch": { "mode": "skip" }
+    });
+    let response = app.oneshot(spawn_request_from_body(body)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(response_body["project"]["id"].as_i64(), Some(7));
+    assert_eq!(
+        response_body["crossProject"],
+        serde_json::Value::Bool(false)
+    );
+    let feature_project: i64 = sqlx::query_scalar("SELECT project_id FROM features WHERE id = ?")
+        .bind(response_body["featureId"].as_i64().unwrap())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(feature_project, 7);
+}
+
 #[tokio::test]
 async fn project_spawn_session_can_skip_session_link() {
     let pool = seeded_control_pool().await;

--- a/packages/service/tests/support/mcp_control.rs
+++ b/packages/service/tests/support/mcp_control.rs
@@ -232,8 +232,8 @@ pub fn spawn_request_with_optional_provider_optional_model(
     let body = json!({
         "source_feature_id": 42,
         "source_session_id": 777,
-        // Target the caller's own seeded project (id 7) — a spawn now requires an
-        // explicit target, and "spawn locally" means passing the caller's project id.
+        // Explicitly target the caller's own seeded project (id 7); omitting the
+        // target would also spawn locally, but these tests pin the explicit path.
         "target_project_id": 7,
         "title": "Investigate flaky login test",
         "initial_message": "Please investigate and report findings.",


### PR DESCRIPTION
## Problem

Agents running in Cadencr-managed worktrees (`~/.cadencr/worktrees/...`) cannot reliably derive their own project from the filesystem: the worktree lives outside the project root, so matching the cwd against registered project paths falls back to lexical ancestry. On a machine with a project registered at `/Users/<user>`, that ancestor wins, `project_spawn_session` targets a non-Git project, and branch setup dies on `git rev-parse --show-toplevel` — reported to the caller only as an opaque `Internal error: branch setup failed` (#210).

Confirmed against live data: the `mcp_tool_audit_log` rows behind #210 all target a registered non-Git home-directory project, and the underlying git error never reaches the tool response.

## Fix

Both suggestions from the issue:

- **Prefer the parent session's project.** `resolve_target_project` now falls back to the source session's project when neither `project_id` nor `project_path` is supplied, instead of erroring. Explicit selectors keep working exactly as before (including the id/path consistency guard). Tool schema descriptions updated so agents stop guessing their own project.
- **Surface the underlying Git error.** The internal-caller failure reply now carries the root cause (`branch setup failed: failed to resolve git root: ...`) instead of the bare `branch setup failed`, so it lands in the spawn response and the audit log.

## Tests

- Unit: omitting the target resolves the caller's project (regression test for the ancestry guess); existing explicit-target tests updated for the new signature.
- Integration (`mcp_control_test.rs`): `POST /internal/mcp/project/spawn-session` without a target returns the caller's project with `crossProject: false` and creates the feature in it.

Fixes #210
