### PR TITLE
fix(desktop): stop streaming markdown throttle tripping React's nested-update limit

### DIFF
--- a/packages/desktop/src/hooks/useStreamingMarkdownThrottle.test.ts
+++ b/packages/desktop/src/hooks/useStreamingMarkdownThrottle.test.ts
@@ -19,7 +19,7 @@ describe("useStreamingMarkdownThrottle", () => {
     const { result, rerender } = renderHook(({ c, a }) => useStreamingMarkdownThrottle(c, a), {
       initialProps: { c: "a", a: true },
     });
-    // Leading edge emits immediately.
+    // The initial content shows immediately.
     expect(result.current).toBe("a");
 
     // Bursts within the 100ms window do not advance the parsed content.
@@ -45,5 +45,35 @@ describe("useStreamingMarkdownThrottle", () => {
     // Turn stops: the final content must appear without waiting for the timer.
     rerender({ c: "abcdef", a: false });
     expect(result.current).toBe("abcdef");
+  });
+
+  it("never publishes synchronously from the effect, even when the window is overdue", () => {
+    const { result, rerender } = renderHook(({ c, a }) => useStreamingMarkdownThrottle(c, a), {
+      initialProps: { c: "a", a: true },
+    });
+    // Drain the initial emit and let the 100ms window fully elapse.
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    // An overdue update is deferred to a 0ms timer task, not published from
+    // the passive effect (a pending default-lane update at the tail of a sync
+    // commit is what trips React's nested-update counter — error #185).
+    rerender({ c: "ab", a: true });
+    expect(result.current).toBe("a");
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(result.current).toBe("ab");
+  });
+
+  it("leaves no pending publish once streaming stops", () => {
+    const { result, rerender } = renderHook(({ c, a }) => useStreamingMarkdownThrottle(c, a), {
+      initialProps: { c: "a", a: true },
+    });
+    rerender({ c: "ab", a: true }); // trailing timer armed
+    rerender({ c: "abc", a: false });
+    expect(result.current).toBe("abc");
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/desktop/src/hooks/useStreamingMarkdownThrottle.test.ts
+++ b/packages/desktop/src/hooks/useStreamingMarkdownThrottle.test.ts
@@ -67,6 +67,16 @@ describe("useStreamingMarkdownThrottle", () => {
     expect(result.current).toBe("ab");
   });
 
+  it("shows fresh content when a stream restarts after inactive changes", () => {
+    const { result, rerender } = renderHook(({ c, a }) => useStreamingMarkdownThrottle(c, a), {
+      initialProps: { c: "a", a: true },
+    });
+    rerender({ c: "ab", a: false }); // stream stops
+    rerender({ c: "edited", a: false }); // content changes while inactive
+    rerender({ c: "edited", a: true }); // stream restarts
+    expect(result.current).toBe("edited"); // no stale "a" flash
+  });
+
   it("leaves no pending publish once streaming stops", () => {
     const { result, rerender } = renderHook(({ c, a }) => useStreamingMarkdownThrottle(c, a), {
       initialProps: { c: "a", a: true },

--- a/packages/desktop/src/hooks/useStreamingMarkdownThrottle.ts
+++ b/packages/desktop/src/hooks/useStreamingMarkdownThrottle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { startTransition, useEffect, useRef, useState } from "react";
 
 /** Max re-parse cadence for the actively streaming markdown block. */
 const STREAMING_REPARSE_MS = 100;
@@ -11,10 +11,16 @@ const STREAMING_REPARSE_MS = 100;
  * across a long stream. (Streamdown memoizes the *settled* blocks above it, so
  * this is bounded by the current block rather than the whole message, but the
  * quadratic is still there.) While `active`, this returns text that advances at
- * most every ~100ms (leading + trailing edge), so the parse cost is bounded by a
- * time cadence rather than the token rate. When not
- * streaming (or once it stops) the latest content passes through immediately so
- * the final message is never left truncated.
+ * most every ~100ms, so the parse cost is bounded by a time cadence rather than
+ * the token rate. When not streaming (or once it stops) the latest content
+ * passes through immediately so the final message is never left truncated.
+ *
+ * Publishing is timer-only and transition-wrapped, never synchronous from the
+ * effect: a setState scheduled from the effect of a sync (WebSocket-driven)
+ * commit leaves a default-lane update pending at the tail of that commit, and
+ * React's module-global nested-update counter throws error #185 once ~50
+ * consecutive sync commits end that way (see issue #211 and 2bf1b003 for the
+ * previous instance). Transition-lane updates are not counted at all.
  */
 export function useStreamingMarkdownThrottle(content: string, active: boolean): string {
   const [throttled, setThrottled] = useState(content);
@@ -25,27 +31,24 @@ export function useStreamingMarkdownThrottle(content: string, active: boolean): 
 
   useEffect(() => {
     if (!active) {
-      // Not (or no longer) streaming: show the latest content immediately.
+      // Not (or no longer) streaming: the hook returns `content` directly, so
+      // there is nothing to publish — just disarm the trailing timer.
       if (timerRef.current) {
         clearTimeout(timerRef.current);
         timerRef.current = null;
       }
-      setThrottled(content);
-      return;
-    }
-    const wait = STREAMING_REPARSE_MS - (Date.now() - lastEmitRef.current);
-    if (wait <= 0) {
-      lastEmitRef.current = Date.now();
-      setThrottled(content);
       return;
     }
     // Within the window: let the already-scheduled trailing update pick up the
     // latest content instead of scheduling a second timer.
     if (timerRef.current) return;
+    const wait = Math.max(0, STREAMING_REPARSE_MS - (Date.now() - lastEmitRef.current));
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
       lastEmitRef.current = Date.now();
-      setThrottled(latestRef.current);
+      startTransition(() => {
+        setThrottled((prev) => (prev === latestRef.current ? prev : latestRef.current));
+      });
     }, wait);
   }, [content, active]);
 

--- a/packages/desktop/src/hooks/useStreamingMarkdownThrottle.ts
+++ b/packages/desktop/src/hooks/useStreamingMarkdownThrottle.ts
@@ -24,10 +24,20 @@ const STREAMING_REPARSE_MS = 100;
  */
 export function useStreamingMarkdownThrottle(content: string, active: boolean): string {
   const [throttled, setThrottled] = useState(content);
+  const [prevActive, setPrevActive] = useState(active);
   const latestRef = useRef(content);
   const lastEmitRef = useRef(0);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   latestRef.current = content;
+
+  // Seed the throttled value when a stream (re)starts, so reactivation after
+  // the content changed while inactive never flashes stale text. A
+  // render-phase update re-renders before commit and leaves nothing pending,
+  // unlike publishing from the effect.
+  if (active !== prevActive) {
+    setPrevActive(active);
+    if (active) setThrottled(content);
+  }
 
   useEffect(() => {
     if (!active) {


### PR DESCRIPTION
Fixes #211.

## What happened

Long streaming sessions flood the transcript with repeated `Internal error: Minified React error #185` cards (observed on 0.11.4, macOS). React #185 is "Maximum update depth exceeded".

<img width="2000" alt="Transcript flooded with repeated React error 185 cards" src="https://raw.githubusercontent.com/baptou12/CadencR/pr-assets/assets/pr218-react-185-transcript.png" />

## Mechanism

Same failure mode as 2bf1b003 (the v0.10.0 fix for the mobile layout): React's nested-update counter is **module-global** — at the end of each commit it increments whenever a sync commit ends with a default-lane update still pending, and throws #185 past 50. The throw therefore lands on an unrelated `setState`: the `ctx.set` inside `handleEnvelope`, which `ws-session-socket-handler.ts` catches and renders as an inline error block — one card per envelope, and the WS layer looks guilty when it isn't.

`useStreamingMarkdownThrottle` kept that counter fed: on every coalesced delta batch its passive effect either published `setThrottled` synchronously (overdue window) or armed a 0–100 ms timer that would — so during a stream there was essentially *always* a default-lane update pending. The hook is mounted 1–2× per streaming block (`AgentBlock`, `ThinkingBlock`, two per `SubagentActionRow`), multiplying the per-commit odds.

## Fix

- Publish **only from the timer task** — overdue updates go through a 0 ms timer (`Math.max(0, wait)`) instead of a synchronous `setState` in the effect.
- Wrap the emission in `startTransition`: transition lanes are excluded from the counted mask entirely, so the mechanism is gone rather than merely less likely (a timer-scheduled default-lane update could still be caught pending by a sync flood).
- The inactive branch no longer mirrors `content` into state — the hook already returns `content` directly when not streaming.
- Skip duplicate publishes via the functional updater (per 2bf1b003, returning the same value from an updater does **not** prevent scheduling when the fiber already has queued work, but it avoids redundant re-renders in the common case).

## Verification

- New regression tests: an overdue update is never published synchronously from the effect; no timer survives the end of a stream. Existing throttle/trailing-edge tests unchanged and green.
- Full desktop suite (4271 tests), `ts-check`, `lint`, `knip`, and the Rust workspace checks pass.
- Like 2bf1b003, reaching the 50-commit threshold needs sync WS commits to outpace the default-lane flush, which does not reproduce reliably on a dev machine — verified by the mechanism being gone, not by watching the error stop. The instrumentation described in 2bf1b003 (log per-commit pending default lanes + scheduling fibers) is the way to double-check on a real streaming session if wanted.