### PR TITLE
fix(desktop): open clicked file:// links in their default app

### DIFF
--- a/packages/desktop/electron/main/ipc.test.ts
+++ b/packages/desktop/electron/main/ipc.test.ts
@@ -166,6 +166,11 @@ describe("ipc validators", () => {
       openExternalLink(pathToFileURL(path.join(dir, "missing.html")).href),
     ).rejects.toThrow();
     await expect(openExternalLink("javascript:alert(1)")).rejects.toThrow(/Only http/);
+    // Guard must fire before any path conversion or filesystem access: a file
+    // URL host maps to a UNC host on Windows and stat-ing it dials out.
+    await expect(openExternalLink("file://intranet-host/share/spec.html")).rejects.toThrow(
+      /remote host/,
+    );
     expect(electronState.openPath).toHaveBeenCalledTimes(1);
     expect(electronState.openExternal).not.toHaveBeenCalled();
   });

--- a/packages/desktop/electron/main/ipc.test.ts
+++ b/packages/desktop/electron/main/ipc.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clipboard,
@@ -15,6 +16,7 @@ const electronState = vi.hoisted(() => ({
   logsPath: "",
   readClipboardText: vi.fn(() => "terminal paste"),
   openExternal: vi.fn<(_url: string) => Promise<void>>(() => Promise.resolve()),
+  openPath: vi.fn<(_path: string) => Promise<string>>(() => Promise.resolve("")),
 }));
 
 vi.mock("electron", () => ({
@@ -29,7 +31,11 @@ vi.mock("electron", () => ({
   clipboard: { readText: electronState.readClipboardText },
   ipcMain: { handle: vi.fn(), on: vi.fn() },
   nativeTheme: { shouldUseDarkColors: false, on: vi.fn() },
-  shell: { openExternal: electronState.openExternal, showItemInFolder: vi.fn() },
+  shell: {
+    openExternal: electronState.openExternal,
+    openPath: electronState.openPath,
+    showItemInFolder: vi.fn(),
+  },
 }));
 
 import {
@@ -37,6 +43,7 @@ import {
   canonicalFilePath,
   clearRegisteredFilePaths,
   openExternal,
+  openExternalLink,
   parseNotifyOptions,
   parseZoomFactor,
   readFileBase64,
@@ -70,6 +77,7 @@ describe("ipc validators", () => {
     electronState.logsPath = "";
     electronState.readClipboardText.mockClear();
     electronState.openExternal.mockClear();
+    electronState.openPath.mockClear();
     vi.mocked(ipcMain.handle).mockClear();
     vi.mocked(ipcMain.on).mockClear();
     clearRegisteredFilePaths();
@@ -143,6 +151,32 @@ describe("ipc validators", () => {
     await expect(openExternal("https://user@example.com")).rejects.toThrow(/credentials/);
     await expect(openExternal("https://127.0.0.1:5004")).rejects.toThrow(/Loopback/);
     expect(electronState.openExternal).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens clicked file:// links with the default app, rejecting non-files", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cadencr-link-"));
+    const file = path.join(dir, "spec.html");
+    await fs.writeFile(file, "<html></html>", "utf8");
+
+    await openExternalLink(pathToFileURL(file).href);
+    expect(electronState.openPath).toHaveBeenCalledWith(await fs.realpath(file));
+
+    await expect(openExternalLink(pathToFileURL(dir).href)).rejects.toThrow(/not a file/);
+    await expect(
+      openExternalLink(pathToFileURL(path.join(dir, "missing.html")).href),
+    ).rejects.toThrow();
+    await expect(openExternalLink("javascript:alert(1)")).rejects.toThrow(/Only http/);
+    expect(electronState.openPath).toHaveBeenCalledTimes(1);
+    expect(electronState.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("surfaces shell.openPath failures for file:// links", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cadencr-link-"));
+    const file = path.join(dir, "spec.html");
+    await fs.writeFile(file, "<html></html>", "utf8");
+    electronState.openPath.mockResolvedValueOnce("No app is associated with this file.");
+
+    await expect(openExternalLink(pathToFileURL(file).href)).rejects.toThrow(/No app/);
   });
 
   it("accepts null senderFrame only after the sender webContents matched", () => {

--- a/packages/desktop/electron/main/ipc.ts
+++ b/packages/desktop/electron/main/ipc.ts
@@ -252,6 +252,11 @@ export async function openExternalLink(rawUrl: unknown): Promise<void> {
   if (typeof rawUrl !== "string") throw new Error("Expected a URL.");
   const parsed = new URL(rawUrl);
   if (parsed.protocol === "file:") {
+    // A file URL host becomes a UNC host on Windows (`\\server\share`), and
+    // merely stat-ing that path dials out over SMB — local files only.
+    if (parsed.hostname) {
+      throw new Error("file:// links with a remote host cannot be opened.");
+    }
     const canonical = await canonicalFilePath(fileURLToPath(parsed));
     const failure = await shell.openPath(canonical);
     if (failure) throw new Error(failure);

--- a/packages/desktop/electron/main/ipc.ts
+++ b/packages/desktop/electron/main/ipc.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   app,
   dialog,
@@ -243,13 +244,21 @@ export async function openExternal(rawUrl: unknown): Promise<void> {
  * User-initiated "open in default browser" for a clicked link. Looser than
  * `openExternal` (which also backs auto navigation-interception): permits
  * `http:` and loopback so a dev-server URL can be opened in the system
- * browser on demand. Still rejects credentials and any non-http(s) scheme.
+ * browser on demand, and `file:` so agent-emitted links to local documents
+ * open in their default app. Still rejects credentials and any other scheme
+ * (`javascript:`, `data:`, ...).
  */
 export async function openExternalLink(rawUrl: unknown): Promise<void> {
   if (typeof rawUrl !== "string") throw new Error("Expected a URL.");
   const parsed = new URL(rawUrl);
+  if (parsed.protocol === "file:") {
+    const canonical = await canonicalFilePath(fileURLToPath(parsed));
+    const failure = await shell.openPath(canonical);
+    if (failure) throw new Error(failure);
+    return;
+  }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error("Only http:// and https:// links can be opened externally.");
+    throw new Error("Only http://, https:// and file:// links can be opened externally.");
   }
   if (parsed.username || parsed.password) {
     throw new Error("URLs with embedded credentials cannot be opened externally.");

--- a/packages/desktop/src/lib/desktop-bridge.ts
+++ b/packages/desktop/src/lib/desktop-bridge.ts
@@ -107,8 +107,9 @@ export interface CadencrDesktopBridge {
   /**
    * User-initiated "open in default browser" for a clicked link. Looser than
    * {@link openExternal}: permits `http:` and loopback hosts so a dev-server
-   * URL can be opened in the system browser on demand. Still rejects
-   * credentials and non-http(s) schemes.
+   * URL can be opened in the system browser on demand, and (desktop shell
+   * only) `file:` links to local documents, opened in their default app.
+   * Still rejects credentials and other schemes (`javascript:`, `data:`).
    */
   openExternalLink: (url: string) => Promise<void>;
   /**

--- a/packages/desktop/src/lib/safe-url.ts
+++ b/packages/desktop/src/lib/safe-url.ts
@@ -24,7 +24,9 @@ export function isSafeExternalUrl(rawUrl: string): boolean {
  * also permits `http:` and loopback hosts, because explicitly choosing "open
  * in default browser" on a `localhost` dev URL is a legitimate action. Still
  * rejects credentials and any non-http(s) scheme (`file:`, `javascript:`,
- * `data:`), which the `new URL` protocol check below enforces.
+ * `data:`), which the `new URL` protocol check below enforces. Unlike the
+ * desktop shell, `file:` stays rejected here: a remote browser tab cannot
+ * reach files on the host machine.
  */
 export function isUserOpenableUrl(rawUrl: string): boolean {
   let parsed: URL;


### PR DESCRIPTION
## Problem

Clicking an agent-emitted markdown link that points to a local document (`file://…`) fails with a toast:

> Error invoking remote method 'shell:open-external-link': Error: Only http:// and https:// links can be opened externally.

Agents routinely emit such links (e.g. "open the saved spec" pointing at an `.html` file in the worktree), so the click should just work.

## Fix

`openExternalLink` (the user-initiated click handler in `electron/main/ipc.ts`) now accepts `file:` URLs:

- the URL is converted with `fileURLToPath` and validated through the existing `canonicalFilePath` guard — `realpath`, no `..` segments, regular files only (directories and missing files are rejected);
- the canonical path is handed to `shell.openPath`, so the document opens in its default app (an `.html` spec opens in the browser); a non-empty failure string from `openPath` is surfaced as the toast error.

`javascript:`, `data:` and every other scheme stay rejected. The remote-browser fallback (`desktop-bridge` / `isUserOpenableUrl`) still rejects `file:` — a remote tab cannot reach files on the host machine.

## Tests

- opens a real temp file through a `file://` URL and asserts `shell.openPath` receives the canonical path
- rejects a directory URL, a missing file, and `javascript:`
- surfaces a `shell.openPath` failure string as an error

`tsc --noEmit`, oxlint, the full desktop vitest suite (4233 tests) and knip all pass. Note: the service suite passes standalone; the pre-commit turbo run trips the known-flaky `spawn_runs_handshake_initial_config_and_prompt` ACP timeout under parallel load (unrelated — no Rust files touched).