### PR TITLE
fix(terminal): resolve alacritty.toml general.import chains

### DIFF
--- a/packages/landing/src/pages/docs/terminal.mdx
+++ b/packages/landing/src/pages/docs/terminal.mdx
@@ -80,7 +80,7 @@ Each terminal pane is launched in the feature's worktree. If something inside th
 
 ### Matching your own terminal
 
-CadencR's terminal reads your `~/.config/alacritty/alacritty.toml` if you have one, so the font, colors, cursor, and scrollback depth already match the terminal you use outside the app. No file? CadencR falls back to its own defaults — nothing to configure.
+CadencR's terminal reads your `~/.config/alacritty/alacritty.toml` if you have one, so the font, colors, cursor, and scrollback depth already match the terminal you use outside the app, including files pulled in via `general.import` if you split your config across several files. No file? CadencR falls back to its own defaults — nothing to configure.
 
 ## When not to use it
 

--- a/packages/service/src/domain/agents/providers/installed/managed/trust.rs
+++ b/packages/service/src/domain/agents/providers/installed/managed/trust.rs
@@ -280,7 +280,6 @@ fn invalid_signature(message: impl Into<String>) -> ManagedTrustError {
 
 #[cfg(test)]
 mod tests {
-    use base64::Engine as _;
     use ed25519_dalek::{Signer as _, SigningKey};
 
     use super::*;

--- a/packages/service/src/domain/terminal/alacritty_config.rs
+++ b/packages/service/src/domain/terminal/alacritty_config.rs
@@ -18,6 +18,8 @@ use tokio::sync::broadcast;
 use tracing::{debug, warn};
 use utoipa::ToSchema;
 
+mod resolve;
+
 /// Alacritty's own documented default: `font.size`.
 const DEFAULT_FONT_SIZE: f64 = 11.25;
 /// Alacritty's own documented default: `scrolling.history`.
@@ -170,22 +172,6 @@ pub fn default_config_path() -> Option<PathBuf> {
     })
 }
 
-/// Parse `path`. Returns `Ok(None)` when the file does not exist — that's
-/// the common case (most users don't have this file) and is not an error.
-/// Returns `Err` only when the file exists but fails to parse, since that
-/// means the user's real settings are silently not being honored.
-///
-pub fn parse_alacritty_config(path: &std::path::Path) -> Result<Option<AlacrittyConfig>, String> {
-    let raw = match std::fs::read_to_string(path) {
-        Ok(raw) => raw,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(format!("failed to read {}: {e}", path.display())),
-    };
-    toml::from_str(&raw)
-        .map(Some)
-        .map_err(|e| format!("failed to parse {}: {e}", path.display()))
-}
-
 /// `GET /api/terminal/alacritty-config` response.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct AlacrittyConfigResponse {
@@ -219,8 +205,8 @@ pub fn read_alacritty_config_response(fallback_palette: AnsiPalette) -> Alacritt
             parse_error: None,
         };
     };
-    match parse_alacritty_config(&path) {
-        Ok(Some(config)) => AlacrittyConfigResponse {
+    match resolve::resolve_alacritty_config(&path) {
+        Ok(Some((config, _touched))) => AlacrittyConfigResponse {
             // Preserve omitted colors so the renderer can inherit its current
             // Cadencr theme rather than treating our dark fallback as explicit.
             config,
@@ -353,47 +339,6 @@ fn is_watched_config_file(path: &std::path::Path, target_file_name: &OsStr) -> b
 mod tests {
     use super::*;
 
-    fn write_temp_toml(contents: &str) -> tempfile::TempPath {
-        let mut file = tempfile::NamedTempFile::new().unwrap();
-        std::io::Write::write_all(&mut file, contents.as_bytes()).unwrap();
-        file.into_temp_path()
-    }
-
-    #[test]
-    fn missing_file_is_not_an_error() {
-        let path = std::env::temp_dir().join("definitely-does-not-exist-alacritty.toml");
-        assert_eq!(parse_alacritty_config(&path), Ok(None));
-    }
-
-    #[test]
-    fn malformed_file_is_an_error_not_a_panic() {
-        let path = write_temp_toml("this is not [ valid");
-        let result = parse_alacritty_config(&path);
-        assert!(result.is_err(), "expected an error, got {result:?}");
-    }
-
-    #[test]
-    fn empty_file_gets_alacrittys_real_documented_defaults() {
-        let path = write_temp_toml("");
-        let config = parse_alacritty_config(&path).unwrap().unwrap();
-        assert_eq!(config.scrolling.history, 10_000);
-        assert_eq!(config.cursor.style.shape, "Block");
-        assert_eq!(config.cursor.style.blinking, "Off");
-        assert_eq!(config.font.size, 11.25);
-        assert_eq!(config.font.normal.family, None);
-        assert_eq!(config.colors.normal, None);
-    }
-
-    #[test]
-    fn partial_file_only_overrides_what_it_sets() {
-        let path = write_temp_toml("[cursor.style]\nshape = \"Beam\"\n");
-        let config = parse_alacritty_config(&path).unwrap().unwrap();
-        assert_eq!(config.cursor.style.shape, "Beam");
-        // Untouched by the file — still Alacritty's documented default.
-        assert_eq!(config.cursor.style.blinking, "Off");
-        assert_eq!(config.scrolling.history, 10_000);
-    }
-
     #[test]
     fn response_reports_found_true_only_on_successful_parse() {
         let fallback = AnsiPalette {
@@ -411,67 +356,6 @@ mod tests {
             !(response.found && response.parse_error.is_some()),
             "a successfully parsed file must not also report a parse error"
         );
-    }
-
-    #[test]
-    fn full_file_is_parsed_field_for_field() {
-        // `r##"..."##`, not `r#"..."#`: the content contains `"#` sequences
-        // (every `"#hexcolor"` value), which would otherwise close a
-        // single-hash raw string early -- caught by actually compiling this
-        // test while writing the plan, not by inspection.
-        let path = write_temp_toml(
-            r##"
-[font]
-size = 15
-
-[font.normal]
-family = "Iosevka Nerd Font Mono"
-style = "Light"
-
-[colors.primary]
-foreground = "#cdd6f4"
-background = "#1e1e2e"
-
-[colors.cursor]
-text = "#1e1e2e"
-cursor = "#f5e0dc"
-
-[colors.normal]
-black = "#45475a"
-red = "#f38ba8"
-green = "#a6e3a1"
-yellow = "#f9e2af"
-blue = "#89b4fa"
-magenta = "#f5c2e7"
-cyan = "#94e2d5"
-white = "#bac2de"
-
-[colors.bright]
-black = "#585b70"
-red = "#f38ba8"
-green = "#a6e3a1"
-yellow = "#f9e2af"
-blue = "#89b4fa"
-magenta = "#f5c2e7"
-cyan = "#94e2d5"
-white = "#a6adc8"
-
-[scrolling]
-history = 5000
-"##,
-        );
-        let config = parse_alacritty_config(&path).unwrap().unwrap();
-        assert_eq!(config.font.size, 15.0);
-        assert_eq!(
-            config.font.normal.family.as_deref(),
-            Some("Iosevka Nerd Font Mono")
-        );
-        assert_eq!(config.colors.primary.background.as_deref(), Some("#1e1e2e"));
-        assert_eq!(config.colors.cursor.cursor.as_deref(), Some("#f5e0dc"));
-        assert_eq!(config.colors.normal.unwrap().red, "#f38ba8");
-        assert_eq!(config.scrolling.history, 5000);
-        // Not set in the file -- still the real default, not zeroed.
-        assert_eq!(config.cursor.style.shape, "Block");
     }
 
     #[test]

--- a/packages/service/src/domain/terminal/alacritty_config.rs
+++ b/packages/service/src/domain/terminal/alacritty_config.rs
@@ -6,7 +6,7 @@
 //! be able to surface, since it means the user's real settings are silently
 //! not being honored.
 
-use std::ffi::OsStr;
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -279,13 +279,29 @@ pub fn start_watcher(tx: broadcast::Sender<AlacrittyConfigChangedEvent>) {
     let Some(config_path) = default_config_path() else {
         return;
     };
-    let Some(watch_dir) = config_path.parent().map(std::path::Path::to_path_buf) else {
-        return;
+
+    // Resolve once at startup to learn every file this config chain actually
+    // touches (the root plus every `general.import`, transitively) — an
+    // import living in a different directory (e.g. `themes/font.toml`) needs
+    // its own directory watched, or edits to it would never trigger a
+    // refetch. Best-effort: a resolution failure here still starts a watcher
+    // on the root's own directory, so an existing valid config keeps live
+    // reload even if a newly-broken import can't be resolved yet. Fixed for
+    // the process lifetime: a brand-new import path added later needs a
+    // service restart to be picked up.
+    let touched = match resolve::resolve_alacritty_config(&config_path) {
+        Ok(Some((_, touched))) => touched,
+        _ => vec![config_path.clone()],
     };
-    let target_file_name = config_path
-        .file_name()
-        .map(|n| n.to_owned())
-        .unwrap_or_default();
+
+    let watched_names: HashSet<std::ffi::OsString> = touched
+        .iter()
+        .filter_map(|p| p.file_name().map(|n| n.to_owned()))
+        .collect();
+    let watch_dirs: HashSet<PathBuf> = touched
+        .iter()
+        .filter_map(|p| p.parent().map(std::path::Path::to_path_buf))
+        .collect();
 
     let mut debouncer = match new_debouncer(
         Duration::from_millis(500),
@@ -299,7 +315,7 @@ pub fn start_watcher(tx: broadcast::Sender<AlacrittyConfigChangedEvent>) {
             };
             let changed = events
                 .iter()
-                .any(|e| is_watched_config_file(&e.path, &target_file_name));
+                .any(|e| is_watched_config_file(&e.path, &watched_names));
             if changed {
                 debug!("alacritty.toml change detected");
                 let _ = tx.send(AlacrittyConfigChangedEvent {});
@@ -313,26 +329,28 @@ pub fn start_watcher(tx: broadcast::Sender<AlacrittyConfigChangedEvent>) {
         }
     };
 
-    // Watching the parent directory (not the file itself) survives editors
+    // Watching each directory (not the files themselves) survives editors
     // that save by replacing the file (write-to-temp-then-rename) rather
-    // than writing in place — a watch on the file's own inode would go
-    // stale the moment such an editor "saves."
-    if let Err(e) = debouncer
-        .watcher()
-        .watch(&watch_dir, RecursiveMode::NonRecursive)
-    {
-        warn!(dir = %watch_dir.display(), "failed to watch alacritty config dir: {e}");
-        return;
+    // than writing in place — a watch on a file's own inode would go stale
+    // the moment such an editor "saves."
+    for dir in &watch_dirs {
+        if let Err(e) = debouncer.watcher().watch(dir, RecursiveMode::NonRecursive) {
+            warn!(dir = %dir.display(), "failed to watch alacritty config dir: {e}");
+        }
     }
     let _ = WATCHER.set(debouncer);
-    debug!(dir = %watch_dir.display(), "alacritty config watcher started");
+    debug!(dirs = ?watch_dirs, "alacritty config watcher started");
 }
 
-/// Whether `path`'s file name matches `target_file_name` — the config file
-/// itself, not some unrelated file in the same directory (e.g. a
-/// `.alacritty.toml.swp` an editor drops next to it).
-fn is_watched_config_file(path: &std::path::Path, target_file_name: &OsStr) -> bool {
-    path.file_name() == Some(target_file_name)
+/// Whether `path`'s file name matches one of the config chain's own files —
+/// the root or one of its imports, not some unrelated file dropped in the
+/// same directory (e.g. a `.alacritty.toml.swp` an editor leaves behind).
+fn is_watched_config_file(
+    path: &std::path::Path,
+    watched_names: &HashSet<std::ffi::OsString>,
+) -> bool {
+    path.file_name()
+        .is_some_and(|name| watched_names.contains(name))
 }
 
 #[cfg(test)]
@@ -359,19 +377,28 @@ mod tests {
     }
 
     #[test]
-    fn matches_only_the_exact_config_file_name() {
-        let target = OsStr::new("alacritty.toml");
+    fn matches_only_files_in_the_watched_set() {
+        let watched: HashSet<std::ffi::OsString> = [
+            std::ffi::OsString::from("alacritty.toml"),
+            std::ffi::OsString::from("font.toml"),
+        ]
+        .into_iter()
+        .collect();
         assert!(is_watched_config_file(
             std::path::Path::new("/home/user/.config/alacritty/alacritty.toml"),
-            target
+            &watched
+        ));
+        assert!(is_watched_config_file(
+            std::path::Path::new("/home/user/.config/alacritty/themes/font.toml"),
+            &watched
         ));
         assert!(!is_watched_config_file(
             std::path::Path::new("/home/user/.config/alacritty/alacritty.toml.swp"),
-            target
+            &watched
         ));
         assert!(!is_watched_config_file(
-            std::path::Path::new("/home/user/.config/alacritty/other.toml"),
-            target
+            std::path::Path::new("/home/user/.config/alacritty/themes/other.toml"),
+            &watched
         ));
     }
 }

--- a/packages/service/src/domain/terminal/alacritty_config/resolve.rs
+++ b/packages/service/src/domain/terminal/alacritty_config/resolve.rs
@@ -1,0 +1,504 @@
+//! Resolves `general.import` chains for `alacritty.toml`-family files: reads
+//! the root file, recursively pulls in every imported file (Alacritty's own
+//! layering behavior), and merges them with the precedence Alacritty itself
+//! uses — later imports override earlier ones, and the importing file's own
+//! fields override every import. Returns the final `AlacrittyConfig` plus
+//! every file path touched, so the caller's file watcher can follow the whole
+//! chain instead of only the root.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use super::{
+    AlacrittyConfig, ColorsConfig, CursorColors, CursorConfig, CursorStyle, FontConfig, FontFace,
+    PrimaryColors, ScrollingConfig, DEFAULT_CURSOR_BLINKING, DEFAULT_CURSOR_SHAPE,
+    DEFAULT_FONT_SIZE, DEFAULT_SCROLLBACK_HISTORY,
+};
+
+/// Mirrors `AlacrittyConfig`'s shape but leaves every leaf unset (`None`)
+/// when the file doesn't mention it, instead of filling in Alacritty's
+/// documented default immediately. Filling defaults per-layer would make an
+/// import's explicit value get silently overwritten by a later, unrelated
+/// layer that simply never mentions that field — the same bug `colors.normal`
+/// already avoids by staying `Option<AnsiPalette>` in the public struct.
+/// Defaults are only filled once, in `finalize`, after every layer merges.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct PartialConfig {
+    general: PartialGeneral,
+    font: PartialFontConfig,
+    colors: ColorsConfig,
+    cursor: PartialCursorConfig,
+    scrolling: PartialScrollingConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct PartialGeneral {
+    import: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct PartialFontConfig {
+    normal: FontFace,
+    size: Option<f64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct PartialCursorStyle {
+    shape: Option<String>,
+    blinking: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct PartialCursorConfig {
+    style: PartialCursorStyle,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct PartialScrollingConfig {
+    history: Option<u32>,
+}
+
+/// Read and resolve `path` and every file it (transitively) imports via
+/// `general.import`. `Ok(None)` only when `path` itself does not exist — the
+/// common case, not an error. An import that is missing or fails to parse
+/// *is* an error: unlike the root file, the user explicitly named it.
+///
+/// Returns the fully merged `AlacrittyConfig` and every file path that was
+/// actually read, in resolution order (root first), for the caller's file
+/// watcher.
+pub fn resolve_alacritty_config(
+    path: &Path,
+) -> Result<Option<(AlacrittyConfig, Vec<PathBuf>)>, String> {
+    let Some(raw) = read_to_string_or_none(path)? else {
+        return Ok(None);
+    };
+    let mut visited = HashSet::new();
+    let (partial, touched) = resolve_layer(path, &raw, &mut visited)?;
+    Ok(Some((finalize(partial), touched)))
+}
+
+/// Resolve one file's own layer plus every file it imports, most-recently
+/// merged last so this file's own fields win. `visited` guards against import
+/// cycles (a file that imports itself, directly or through others): a path
+/// already in `visited` is skipped rather than re-read, so a cycle degrades
+/// to "that layer contributes nothing the second time" instead of looping.
+fn resolve_layer(
+    path: &Path,
+    raw: &str,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<(PartialConfig, Vec<PathBuf>), String> {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canonical) {
+        return Ok((PartialConfig::default(), Vec::new()));
+    }
+
+    let own: PartialConfig =
+        toml::from_str(raw).map_err(|e| format!("failed to parse {}: {e}", path.display()))?;
+    let mut touched = vec![path.to_path_buf()];
+    let mut merged = PartialConfig::default();
+
+    let import_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    for import in &own.general.import {
+        let import_path = resolve_import_path(import, import_dir)?;
+        let Some(import_raw) = read_to_string_or_none(&import_path)? else {
+            return Err(format!(
+                "imported file not found: {}",
+                import_path.display()
+            ));
+        };
+        let (import_partial, import_touched) = resolve_layer(&import_path, &import_raw, visited)?;
+        merged = merge_partial(merged, import_partial);
+        touched.extend(import_touched);
+    }
+
+    merged = merge_partial(merged, own);
+    Ok((merged, touched))
+}
+
+/// Expand a leading `~` and resolve a relative path against the importing
+/// file's own directory — matching Alacritty's own `general.import`
+/// resolution, not the service process's working directory.
+fn resolve_import_path(raw: &str, importer_dir: &Path) -> Result<PathBuf, String> {
+    let expanded = if let Some(rest) = raw.strip_prefix("~/") {
+        let home = dirs::home_dir()
+            .ok_or_else(|| "cannot expand '~' in import path: no home directory".to_string())?;
+        home.join(rest)
+    } else {
+        PathBuf::from(raw)
+    };
+    Ok(if expanded.is_absolute() {
+        expanded
+    } else {
+        importer_dir.join(expanded)
+    })
+}
+
+/// `None` only for a missing file — the caller decides whether that's normal
+/// (root) or an error (an explicit import).
+fn read_to_string_or_none(path: &Path) -> Result<Option<String>, String> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("failed to read {}: {e}", path.display())),
+    }
+}
+
+/// `overlay`'s fields win wherever it sets them; `base` fills the rest.
+/// Called with imports merged in list order (each subsequent import is
+/// `overlay` over the ones before it), then once more with the importing
+/// file's own fields as the final `overlay`.
+fn merge_partial(base: PartialConfig, overlay: PartialConfig) -> PartialConfig {
+    PartialConfig {
+        general: PartialGeneral::default(), // never read past this layer
+        font: PartialFontConfig {
+            normal: FontFace {
+                family: overlay.font.normal.family.or(base.font.normal.family),
+                style: overlay.font.normal.style.or(base.font.normal.style),
+            },
+            size: overlay.font.size.or(base.font.size),
+        },
+        colors: ColorsConfig {
+            primary: PrimaryColors {
+                foreground: overlay
+                    .colors
+                    .primary
+                    .foreground
+                    .or(base.colors.primary.foreground),
+                background: overlay
+                    .colors
+                    .primary
+                    .background
+                    .or(base.colors.primary.background),
+            },
+            cursor: CursorColors {
+                text: overlay.colors.cursor.text.or(base.colors.cursor.text),
+                cursor: overlay.colors.cursor.cursor.or(base.colors.cursor.cursor),
+            },
+            normal: overlay.colors.normal.or(base.colors.normal),
+            bright: overlay.colors.bright.or(base.colors.bright),
+        },
+        cursor: PartialCursorConfig {
+            style: PartialCursorStyle {
+                shape: overlay.cursor.style.shape.or(base.cursor.style.shape),
+                blinking: overlay.cursor.style.blinking.or(base.cursor.style.blinking),
+            },
+        },
+        scrolling: PartialScrollingConfig {
+            history: overlay.scrolling.history.or(base.scrolling.history),
+        },
+    }
+}
+
+/// Fill whatever no layer set with Alacritty's own documented defaults — the
+/// same constants the single-file path already used.
+fn finalize(partial: PartialConfig) -> AlacrittyConfig {
+    AlacrittyConfig {
+        font: FontConfig {
+            normal: partial.font.normal,
+            size: partial.font.size.unwrap_or(DEFAULT_FONT_SIZE),
+        },
+        colors: partial.colors,
+        cursor: CursorConfig {
+            style: CursorStyle {
+                shape: partial
+                    .cursor
+                    .style
+                    .shape
+                    .unwrap_or_else(|| DEFAULT_CURSOR_SHAPE.to_string()),
+                blinking: partial
+                    .cursor
+                    .style
+                    .blinking
+                    .unwrap_or_else(|| DEFAULT_CURSOR_BLINKING.to_string()),
+            },
+        },
+        scrolling: ScrollingConfig {
+            history: partial
+                .scrolling
+                .history
+                .unwrap_or(DEFAULT_SCROLLBACK_HISTORY),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp_toml(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn missing_root_file_is_not_an_error() {
+        let path = std::env::temp_dir().join("definitely-does-not-exist-alacritty.toml");
+        assert_eq!(resolve_alacritty_config(&path), Ok(None));
+    }
+
+    #[test]
+    fn malformed_root_file_is_an_error_not_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp_toml(dir.path(), "alacritty.toml", "this is not [ valid");
+        let result = resolve_alacritty_config(&path);
+        assert!(result.is_err(), "expected an error, got {result:?}");
+    }
+
+    #[test]
+    fn empty_file_gets_alacrittys_real_documented_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp_toml(dir.path(), "alacritty.toml", "");
+        let (config, touched) = resolve_alacritty_config(&path).unwrap().unwrap();
+        assert_eq!(config.scrolling.history, 10_000);
+        assert_eq!(config.cursor.style.shape, "Block");
+        assert_eq!(config.cursor.style.blinking, "Off");
+        assert_eq!(config.font.size, 11.25);
+        assert_eq!(config.font.normal.family, None);
+        assert_eq!(config.colors.normal, None);
+        assert_eq!(touched, vec![path]);
+    }
+
+    #[test]
+    fn partial_file_only_overrides_what_it_sets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "[cursor.style]\nshape = \"Beam\"\n",
+        );
+        let (config, _touched) = resolve_alacritty_config(&path).unwrap().unwrap();
+        assert_eq!(config.cursor.style.shape, "Beam");
+        assert_eq!(config.cursor.style.blinking, "Off");
+        assert_eq!(config.scrolling.history, 10_000);
+    }
+
+    #[test]
+    fn full_file_is_parsed_field_for_field() {
+        let dir = tempfile::tempdir().unwrap();
+        // `r##"..."##`, not `r#"..."#`: the content contains `"#` sequences
+        // (every `"#hexcolor"` value), which would otherwise close a
+        // single-hash raw string early.
+        let path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            r##"
+[font]
+size = 15
+
+[font.normal]
+family = "Iosevka Nerd Font Mono"
+style = "Light"
+
+[colors.primary]
+foreground = "#cdd6f4"
+background = "#1e1e2e"
+
+[colors.cursor]
+text = "#1e1e2e"
+cursor = "#f5e0dc"
+
+[colors.normal]
+black = "#45475a"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#bac2de"
+
+[colors.bright]
+black = "#585b70"
+red = "#f38ba8"
+green = "#a6e3a1"
+yellow = "#f9e2af"
+blue = "#89b4fa"
+magenta = "#f5c2e7"
+cyan = "#94e2d5"
+white = "#a6adc8"
+
+[scrolling]
+history = 5000
+"##,
+        );
+        let (config, touched) = resolve_alacritty_config(&path).unwrap().unwrap();
+        assert_eq!(config.font.size, 15.0);
+        assert_eq!(
+            config.font.normal.family.as_deref(),
+            Some("Iosevka Nerd Font Mono")
+        );
+        assert_eq!(config.colors.primary.background.as_deref(), Some("#1e1e2e"));
+        assert_eq!(config.colors.cursor.cursor.as_deref(), Some("#f5e0dc"));
+        assert_eq!(config.colors.normal.unwrap().red, "#f38ba8");
+        assert_eq!(config.scrolling.history, 5000);
+        // Not set in the file -- still the real default, not zeroed.
+        assert_eq!(config.cursor.style.shape, "Block");
+        assert_eq!(touched, vec![path]);
+    }
+
+    #[test]
+    fn one_level_import_is_merged_under_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let font_path = write_temp_toml(
+            dir.path(),
+            "font.toml",
+            "[font.normal]\nfamily = \"Iosevka Nerd Font Mono\"\n",
+        );
+        let root_path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "general.import = [\"font.toml\"]\n[scrolling]\nhistory = 5000\n",
+        );
+        let (config, touched) = resolve_alacritty_config(&root_path).unwrap().unwrap();
+        assert_eq!(
+            config.font.normal.family.as_deref(),
+            Some("Iosevka Nerd Font Mono"),
+            "font.family should come from the imported file"
+        );
+        assert_eq!(
+            config.scrolling.history, 5000,
+            "root's own field should still apply"
+        );
+        assert_eq!(touched, vec![root_path, font_path]);
+    }
+
+    #[test]
+    fn root_field_wins_over_an_imported_value_for_the_same_field() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_toml(dir.path(), "font.toml", "[font]\nsize = 12\n");
+        let root_path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "general.import = [\"font.toml\"]\n[font]\nsize = 20\n",
+        );
+        let (config, _touched) = resolve_alacritty_config(&root_path).unwrap().unwrap();
+        assert_eq!(
+            config.font.size, 20.0,
+            "the importing file's own value must win over its import"
+        );
+    }
+
+    #[test]
+    fn later_import_wins_over_an_earlier_one_for_the_same_field() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_toml(dir.path(), "a.toml", "[font]\nsize = 10\n");
+        write_temp_toml(dir.path(), "b.toml", "[font]\nsize = 20\n");
+        let root_path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "general.import = [\"a.toml\", \"b.toml\"]\n",
+        );
+        let (config, _touched) = resolve_alacritty_config(&root_path).unwrap().unwrap();
+        assert_eq!(
+            config.font.size, 20.0,
+            "later entries in general.import must override earlier ones"
+        );
+    }
+
+    #[test]
+    fn nested_import_two_levels_deep_is_resolved() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_toml(
+            dir.path(),
+            "palette.toml",
+            "[colors.primary]\nbackground = \"#1e1e2e\"\n",
+        );
+        write_temp_toml(
+            dir.path(),
+            "theme.toml",
+            "general.import = [\"palette.toml\"]\n[colors.primary]\nforeground = \"#cdd6f4\"\n",
+        );
+        let root_path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "general.import = [\"theme.toml\"]\n",
+        );
+        let (config, touched) = resolve_alacritty_config(&root_path).unwrap().unwrap();
+        assert_eq!(config.colors.primary.background.as_deref(), Some("#1e1e2e"));
+        assert_eq!(config.colors.primary.foreground.as_deref(), Some("#cdd6f4"));
+        assert_eq!(
+            touched.len(),
+            3,
+            "root + theme.toml + palette.toml should all be touched"
+        );
+    }
+
+    #[test]
+    fn import_cycle_does_not_loop_forever() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_toml(
+            dir.path(),
+            "b.toml",
+            "general.import = [\"a.toml\"]\n[font]\nsize = 12\n",
+        );
+        let root_path = write_temp_toml(
+            dir.path(),
+            "a.toml",
+            "general.import = [\"b.toml\"]\n[scrolling]\nhistory = 3000\n",
+        );
+        let (config, _touched) = resolve_alacritty_config(&root_path).unwrap().unwrap();
+        // a.toml (root) is visited first, so b.toml's re-import of a.toml is
+        // the one that gets skipped -- a.toml's own fields still apply.
+        assert_eq!(config.scrolling.history, 3000);
+    }
+
+    #[test]
+    fn missing_import_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "general.import = [\"does-not-exist.toml\"]\n",
+        );
+        let result = resolve_alacritty_config(&root_path);
+        assert!(result.is_err(), "expected an error, got {result:?}");
+    }
+
+    #[test]
+    fn malformed_import_is_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        write_temp_toml(dir.path(), "broken.toml", "this is not [ valid");
+        let root_path = write_temp_toml(
+            dir.path(),
+            "alacritty.toml",
+            "general.import = [\"broken.toml\"]\n",
+        );
+        let result = resolve_alacritty_config(&root_path);
+        assert!(result.is_err(), "expected an error, got {result:?}");
+    }
+
+    #[test]
+    fn resolve_import_path_keeps_an_absolute_path_as_is() {
+        let importer_dir = Path::new("/does/not/matter");
+        let resolved = resolve_import_path("/abs/theme.toml", importer_dir).unwrap();
+        assert_eq!(resolved, PathBuf::from("/abs/theme.toml"));
+    }
+
+    #[test]
+    fn resolve_import_path_is_relative_to_the_importing_files_directory() {
+        let importer_dir = Path::new("/home/user/.config/alacritty");
+        let resolved = resolve_import_path("themes/font.toml", importer_dir).unwrap();
+        assert_eq!(
+            resolved,
+            PathBuf::from("/home/user/.config/alacritty/themes/font.toml")
+        );
+    }
+
+    #[test]
+    fn resolve_import_path_expands_a_leading_tilde_to_home() {
+        let home = dirs::home_dir().expect("test environment must have a resolvable home dir");
+        let importer_dir = Path::new("/does/not/matter");
+        let resolved =
+            resolve_import_path("~/.config/alacritty/themes/font.toml", importer_dir).unwrap();
+        assert_eq!(resolved, home.join(".config/alacritty/themes/font.toml"));
+    }
+}


### PR DESCRIPTION
## Summary

The terminal config reader only ever parsed the root `alacritty.toml` and silently ignored `general.import` — a split config (font/colors defined in imported files) was invisible to Cadencr, which fell back to hardcoded defaults instead of the user's real font and theme.

## Motivation

Reported while debugging why celeritty wasn't showing a user-selected Nerd Font: the user's `alacritty.toml` splits font and color config into `themes/*.toml` via `general.import`. Cadencr's parser read only the root file, so `font.normal.family` and the theme's palette were never picked up — no error surfaced, just a silent fallback to defaults.

## Linked issues

- Closes # — no tracking issue existed; found and fixed during a live debugging session with the user.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Maintenance / tooling

## Areas touched

- [ ] Desktop frontend
- [x] Backend service
- [ ] Claude provider
- [ ] Codex provider
- [ ] OpenCode provider
- [ ] Database / migration
- [ ] API surface
- [ ] Docs
- [ ] CI / release

## Changes

- Add a recursive `general.import` resolver (`alacritty_config/resolve.rs`) that merges imported files with Alacritty's own precedence: later imports override earlier ones, and the importing file's own fields override every import.
- Merge on an `Option`-based partial representation instead of already-defaulted structs, so an import that leaves a field unset can no longer silently overwrite a value set by an earlier layer.
- Guard against import cycles (a file importing itself, directly or transitively) — a revisited path contributes nothing instead of looping.
- Treat a missing or malformed import as an error (`parse_error`), unlike a missing root file (normal, most users don't have one) — an explicit `general.import` entry is the user's stated intent.
- Extend the live-reload file watcher to cover every directory the resolved import chain touches, not just the root file's own directory, so editing an imported file (e.g. `themes/font.toml`) now triggers a refresh too.

## Screenshots / recordings

N/A — backend-only fix, no UI change.

## API / database changes

- [x] No API or database changes
- [ ] API changed and generated client was updated
- [ ] Database migration added
- [ ] Migration tested locally

## UX checklist

- [ ] Loading/error states are visible for async operations
- [ ] Keyboard shortcut impact considered
- [x] No optimistic frontend updates added

## Test plan

Commands run:

```bash
pnpm rust -- test -p cadencr-service --lib alacritty_config
pnpm rust -- check -p cadencr-service
pnpm rust -- fmt -p cadencr-service -- --check
```

17 new/adapted unit tests cover: single file (no imports) unchanged behavior, one-level and two-level nested imports, precedence (root > import > nested import), import cycles, missing/malformed import errors, and `~`/relative path resolution.

Manual flows verified:

- [x] A real split config (`general.import` pointing at `themes/font.toml` + a theme file) now shows the configured font and palette in the terminal
- [x] Editing an imported file live-reloads the terminal without restarting the service

## Checklist

- [x] Commits follow the [Conventional Commits](https://www.conventionalcommits.org/) style.
- [x] Rebased onto the latest `main`.
- [ ] Docs (README, CONTRIBUTING, etc.) updated for any user-visible change.